### PR TITLE
Avoid ResourceNotFoundException when using webview.

### DIFF
--- a/identity-provider/src/main/java/com/auth0/identity/web/WebViewActivity.java
+++ b/identity-provider/src/main/java/com/auth0/identity/web/WebViewActivity.java
@@ -64,10 +64,16 @@ public class WebViewActivity extends ActionBarActivity {
             bar.setDisplayShowCustomEnabled(true);
             View view = LayoutInflater.from(this).inflate(R.layout.webview_action_bar, null);
             final TextView iconLabel = (TextView) view.findViewById(R.id.social_icon_label);
-            iconLabel.setTypeface(SocialResources.socialFont(this));
-            iconLabel.setText(SocialResources.iconForSocialService(this, serviceName));
-            iconLabel.setTextColor(SocialResources.textColorForSocialService(this, serviceName));
-            bar.setBackgroundDrawable(new ColorDrawable(SocialResources.colorForSocialService(this, serviceName)));
+            final int iconResourceId = SocialResources.iconForSocialService(this, serviceName);
+            if (iconResourceId != 0) {
+                iconLabel.setTypeface(SocialResources.socialFont(this));
+                iconLabel.setText(iconResourceId);
+                iconLabel.setTextColor(SocialResources.textColorForSocialService(this, serviceName));
+                bar.setBackgroundDrawable(new ColorDrawable(SocialResources.colorForSocialService(this, serviceName)));
+            } else {
+                iconLabel.setText(serviceName);
+                iconLabel.setTextColor(getResources().getColor(android.R.color.white));
+            }
             bar.setCustomView(view);
         }
         webView = (WebView) findViewById(R.id.lock_webview);

--- a/identity-provider/src/main/res/layout/activity_web_view.xml
+++ b/identity-provider/src/main/res/layout/activity_web_view.xml
@@ -38,7 +38,7 @@
         android:visibility="gone"
         app:spb_sections_count="2"
         app:spb_color="@android:color/holo_blue_light"
-        app:spb_speed="5.0"
+        app:spb_speed="2.5"
         app:spb_stroke_width="4dp"
         app:spb_stroke_separator_length="4dp"
         app:spb_reversed="false"


### PR DESCRIPTION
If webview is used to auth with an enterprise connection, it should handle the
absence of icon.