### PR TITLE
Lock configuration for EU

### DIFF
--- a/android-core/src/main/java/com/auth0/api/APIClient.java
+++ b/android-core/src/main/java/com/auth0/api/APIClient.java
@@ -37,7 +37,6 @@ public class APIClient extends BaseAPIClient {
     private static final String DEFAULT_DB_CONNECTION = "Username-Password-Authentication";
     private static final String ID_TOKEN_KEY = "id_token";
     private static final String EMAIL_KEY = "email";
-    private static final String TENANT_KEY = "tenant";
     private static final String TOKEN_TYPE_KEY = "token_type";
     private static final String EXPIRES_IN_KEY = "expires_in";
     private static final String REFRESH_TOKEN_KEY = "refresh_token";
@@ -69,6 +68,7 @@ public class APIClient extends BaseAPIClient {
      * Creates a new API client using clientID and tenant name.
      * @param clientID Your application clientID.
      * @param tenantName Name of the tenant.
+     * @deprecated since 1.7.0, instead build using clientID and baseURL
      */
     public APIClient(String clientID, String tenantName) {
         super(clientID, tenantName);

--- a/android-core/src/main/java/com/auth0/api/APIClient.java
+++ b/android-core/src/main/java/com/auth0/api/APIClient.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.auth0.api.BaseAPIClient.APP_INFO_CDN_URL_FORMAT;
 import static com.auth0.api.ParameterBuilder.GRANT_TYPE_PASSWORD;
 
 /**

--- a/android-core/src/main/java/com/auth0/api/BaseAPIClient.java
+++ b/android-core/src/main/java/com/auth0/api/BaseAPIClient.java
@@ -24,6 +24,7 @@
 
 package com.auth0.api;
 
+import android.net.Uri;
 import android.os.Build;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,7 +33,7 @@ import com.loopj.android.http.AsyncHttpClient;
 public abstract class BaseAPIClient {
 
     public static final String BASE_URL_FORMAT = "https://%s.auth0.com";
-    public static final String APP_INFO_CDN_URL_FORMAT = "https://cdn.auth0.com/client/%s.js";
+    public static final String APP_INFO_CDN_URL_FORMAT = "https://cdn.auth0.com";
     static final String APPLICATION_JSON = "application/json";
 
     private final String clientID;
@@ -43,7 +44,10 @@ public abstract class BaseAPIClient {
 
     public BaseAPIClient(String clientID, String baseURL, String configurationURL, String tenantName) {
         this.clientID = clientID;
-        this.configurationURL = configurationURL;
+        this.configurationURL = Uri.parse(configurationURL).buildUpon()
+                .appendPath("client")
+                .appendPath(this.clientID + ".js")
+                .build().toString();
         this.baseURL = baseURL;
         this.client = new AsyncHttpClient();
         this.client.setUserAgent(String.format("%s (%s Android %s)", tenantName, Build.MODEL, Build.VERSION.RELEASE));
@@ -56,7 +60,7 @@ public abstract class BaseAPIClient {
 
     @Deprecated
     public BaseAPIClient(String clientID, String tenantName) {
-        this(clientID, String.format(BASE_URL_FORMAT, tenantName), String.format(APP_INFO_CDN_URL_FORMAT, clientID), tenantName);
+        this(clientID, String.format(BASE_URL_FORMAT, tenantName), APP_INFO_CDN_URL_FORMAT, tenantName);
     }
 
     public String getClientID() {

--- a/android-core/src/main/java/com/auth0/api/BaseAPIClient.java
+++ b/android-core/src/main/java/com/auth0/api/BaseAPIClient.java
@@ -33,7 +33,8 @@ import com.loopj.android.http.AsyncHttpClient;
 public abstract class BaseAPIClient {
 
     public static final String BASE_URL_FORMAT = "https://%s.auth0.com";
-    public static final String APP_INFO_CDN_URL_FORMAT = "https://cdn.auth0.com";
+    public static final String AUTH0_US_CDN_URL = "https://cdn.auth0.com";
+    public static final String AUTH0_EU_CDN_URL = "https://cdn.eu.auth0.com";
     static final String APPLICATION_JSON = "application/json";
 
     private final String clientID;
@@ -60,7 +61,7 @@ public abstract class BaseAPIClient {
 
     @Deprecated
     public BaseAPIClient(String clientID, String tenantName) {
-        this(clientID, String.format(BASE_URL_FORMAT, tenantName), APP_INFO_CDN_URL_FORMAT, tenantName);
+        this(clientID, String.format(BASE_URL_FORMAT, tenantName), AUTH0_US_CDN_URL, tenantName);
     }
 
     public String getClientID() {

--- a/android-core/src/main/java/com/auth0/api/BaseAPIClient.java
+++ b/android-core/src/main/java/com/auth0/api/BaseAPIClient.java
@@ -54,6 +54,7 @@ public abstract class BaseAPIClient {
         this(clientID, baseURL, configurationURL, null);
     }
 
+    @Deprecated
     public BaseAPIClient(String clientID, String tenantName) {
         this(clientID, String.format(BASE_URL_FORMAT, tenantName), String.format(APP_INFO_CDN_URL_FORMAT, clientID), tenantName);
     }

--- a/lock/src/main/java/com/auth0/lock/LockBuilder.java
+++ b/lock/src/main/java/com/auth0/lock/LockBuilder.java
@@ -35,7 +35,6 @@ import com.auth0.api.APIClient;
 import com.auth0.api.ParameterBuilder;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -235,8 +234,9 @@ public class LockBuilder {
     private void resolveConfiguration() {
         if (this.configuration == null && this.domain != null) {
             final Uri domainUri = Uri.parse(this.domain);
-            if (domainUri.getHost().endsWith("auth0.com")) {
-                this.configuration = String.format(APIClient.APP_INFO_CDN_URL_FORMAT, this.clientId);
+            final String host = domainUri.getHost();
+            if (host.endsWith(".auth0.com")) {
+                this.configuration = host.endsWith(".eu.auth0.com") ? APIClient.AUTH0_EU_CDN_URL : APIClient.AUTH0_US_CDN_URL;
             } else {
                 this.configuration = this.domain;
             }

--- a/lock/src/main/java/com/auth0/lock/LockBuilder.java
+++ b/lock/src/main/java/com/auth0/lock/LockBuilder.java
@@ -95,7 +95,9 @@ public class LockBuilder {
      * Set Auth0 account tenant name
      * @param tenant tenant name
      * @return itself
+     * @deprecated since 1.7.0
      */
+    @Deprecated
     public LockBuilder tenant(String tenant) {
         this.tenant = tenant;
         return this;

--- a/lock/src/test/java/com/auth0/lock/LockBuilderTest.java
+++ b/lock/src/test/java/com/auth0/lock/LockBuilderTest.java
@@ -47,11 +47,13 @@ import static org.junit.Assert.assertThat;
 @Config(emulateSdk = 18)
 public class LockBuilderTest {
 
-    public static final String CLIENT_ID = "CLIENTID";
-    public static final String TENANT = "TENANT";
-    public static final String DOMAIN = "domain.com";
-    public static final String CONFIGURATION = "https://config.com";
-    public static final String AUTH0_SUBDOMAIN = "pepe.auth0.com";
+    private static final String CLIENT_ID = "CLIENTID";
+    private static final String TENANT = "TENANT";
+    private static final String DOMAIN = "domain.com";
+    private static final String CONFIGURATION_URL = "https://config.com";
+    private static final String CONFIGURATION_DOMAIN = "config.com";
+    private static final String CONFIGURATION_FULL_URL = "https://config.com/client/" + CLIENT_ID + ".js";
+    private static final String AUTH0_SUBDOMAIN = "pepe.auth0.com";
     
     private LockBuilder builder;
     private Lock lock;
@@ -126,7 +128,7 @@ public class LockBuilderTest {
         assertThat(lock, is(notNullValue()));
         final APIClient apiClient = lock.getAPIClient();
         assertThat(apiClient.getBaseURL(), equalTo("https://domain.com"));
-        assertThat(apiClient.getConfigurationURL(), equalTo("https://domain.com"));
+        assertThat(apiClient.getConfigurationURL(), equalTo("https://domain.com/client/" + CLIENT_ID + ".js"));
     }
 
     @Test
@@ -134,12 +136,12 @@ public class LockBuilderTest {
         lock = builder
                 .clientId(CLIENT_ID)
                 .domainUrl(DOMAIN)
-                .configurationUrl(CONFIGURATION)
+                .configurationUrl(CONFIGURATION_URL)
                 .build();
         assertThat(lock, is(notNullValue()));
         final APIClient apiClient = lock.getAPIClient();
         assertThat(apiClient.getBaseURL(), equalTo("https://domain.com"));
-        assertThat(apiClient.getConfigurationURL(), equalTo(CONFIGURATION));
+        assertThat(apiClient.getConfigurationURL(), equalTo("https://config.com/client/" + CLIENT_ID + ".js"));
 
     }
 
@@ -149,12 +151,12 @@ public class LockBuilderTest {
                 .clientId(CLIENT_ID)
                 .tenant(TENANT)
                 .domainUrl(DOMAIN)
-                .configurationUrl(CONFIGURATION)
+                .configurationUrl(CONFIGURATION_URL)
                 .build();
         assertThat(lock, is(notNullValue()));
         final APIClient apiClient = lock.getAPIClient();
         assertThat(apiClient.getBaseURL(), equalTo("https://domain.com"));
-        assertThat(apiClient.getConfigurationURL(), equalTo(CONFIGURATION));
+        assertThat(apiClient.getConfigurationURL(), equalTo(CONFIGURATION_FULL_URL));
     }
 
     @Test
@@ -174,12 +176,12 @@ public class LockBuilderTest {
         lock = builder
                 .clientId(CLIENT_ID)
                 .domainUrl(AUTH0_SUBDOMAIN)
-                .configurationUrl(CONFIGURATION)
+                .configurationUrl(CONFIGURATION_URL)
                 .build();
         assertThat(lock, is(notNullValue()));
         final APIClient apiClient = lock.getAPIClient();
         assertThat(apiClient.getBaseURL(), equalTo("https://pepe.auth0.com"));
-        assertThat(apiClient.getConfigurationURL(), equalTo(CONFIGURATION));
+        assertThat(apiClient.getConfigurationURL(), equalTo(CONFIGURATION_FULL_URL));
     }
 
     @Test
@@ -194,8 +196,8 @@ public class LockBuilderTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(equalToIgnoringCase("Missing Auth0 credentials. Please make sure you supplied at least ClientID and Tenant."));
         builder
-                .clientId(CLIENT_ID)
-                .build();
+            .clientId(CLIENT_ID)
+            .build();
     }
 
     private LockBuilder basicBuilder() {

--- a/lock/src/test/java/com/auth0/lock/LockBuilderTest.java
+++ b/lock/src/test/java/com/auth0/lock/LockBuilderTest.java
@@ -54,7 +54,8 @@ public class LockBuilderTest {
     private static final String CONFIGURATION_DOMAIN = "config.com";
     private static final String CONFIGURATION_FULL_URL = "https://config.com/client/" + CLIENT_ID + ".js";
     private static final String AUTH0_SUBDOMAIN = "pepe.auth0.com";
-    
+    private static final String EU_DOMAIN = "samples.eu.auth0.com";
+
     private LockBuilder builder;
     private Lock lock;
 
@@ -141,8 +142,19 @@ public class LockBuilderTest {
         assertThat(lock, is(notNullValue()));
         final APIClient apiClient = lock.getAPIClient();
         assertThat(apiClient.getBaseURL(), equalTo("https://domain.com"));
-        assertThat(apiClient.getConfigurationURL(), equalTo("https://config.com/client/" + CLIENT_ID + ".js"));
+        assertThat(apiClient.getConfigurationURL(), equalTo(CONFIGURATION_FULL_URL));
+    }
 
+    @Test
+    public void shouldUseEuropeCDNWhenAuth0DomainIsInEU() throws Exception {
+        lock = builder
+                .clientId(CLIENT_ID)
+                .domainUrl(EU_DOMAIN)
+                .build();
+        assertThat(lock, is(notNullValue()));
+        final APIClient apiClient = lock.getAPIClient();
+        assertThat(apiClient.getBaseURL(), equalTo("https://samples.eu.auth0.com"));
+        assertThat(apiClient.getConfigurationURL(), equalTo("https://cdn.eu.auth0.com/client/" + CLIENT_ID + ".js"));
     }
 
     @Test

--- a/lock/src/test/java/com/auth0/lock/LockBuilderTest.java
+++ b/lock/src/test/java/com/auth0/lock/LockBuilderTest.java
@@ -146,6 +146,19 @@ public class LockBuilderTest {
     }
 
     @Test
+    public void shouldBuildWithConfigurationDomainName() throws Exception {
+        lock = builder
+                .clientId(CLIENT_ID)
+                .domainUrl(DOMAIN)
+                .configurationUrl(CONFIGURATION_DOMAIN)
+                .build();
+        assertThat(lock, is(notNullValue()));
+        final APIClient apiClient = lock.getAPIClient();
+        assertThat(apiClient.getBaseURL(), equalTo("https://domain.com"));
+        assertThat(apiClient.getConfigurationURL(), equalTo(CONFIGURATION_FULL_URL));
+    }
+
+    @Test
     public void shouldUseEuropeCDNWhenAuth0DomainIsInEU() throws Exception {
         lock = builder
                 .clientId(CLIENT_ID)


### PR DESCRIPTION
Fixes #70 by picking EU cdn if domain is from EU region, and fixes #71.
Also tenant configuration for Lock is deprecated.
