### PR TITLE
Update readme for v1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,21 +186,20 @@ public class HomeActivity extends Activity {
 }
 ```
 
-Then just start `LockPasswordlessActivity` especifying the passwordless type you want to use:
+Then just start `LockPasswordlessActivity` especifying the passwordless type you want to use, so for **Email**
 
 ```java
 LockPasswordlessActivity.showFrom(MyActivity.this, LockPasswordlessActivity.MODE_EMAIL_CODE);
 ```
 
-Or 
+or just for **SMS**
 
 ```java
 LockPasswordlessActivity.showFrom(MyActivity.this, LockPasswordlessActivity.MODE_SMS_CODE);
 ```
 
-And you'll see the Email/SMS login screen
+and you'll see the **SMS** login screen
 
-[![Lock.png](http://blog.auth0.com.s3.amazonaws.com/Lock-SMS-Android-Screenshot.png)](https://auth0.com)
 [![Lock.png](http://blog.auth0.com.s3.amazonaws.com/Lock-SMS-Android-Screenshot.png)](https://auth0.com)
 
 ##Proguard

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Then in your `AndroidManifest.xml` register the following activities:
     <!--Auth0 Lock Passwordless End-->
 ```
 
-Just like LockActivity, when a user authenticates successfully, LockPasswordlessActivity will send an Action using LocalBroadcaster manager and then finish itself (by calling finish()). The activity that is interested in receiving this Action (In this case the one that will show Lock) needs to register a listener in the LocalBroadcastManager:
+Just like `LockActivity`, when a user authenticates successfully, `LockPasswordlessActivity` will send an Action using `LocalBroadcastManager` and then finish itself (by calling `finish()`). The activity that is interested in receiving this `Action` (In this case the one that will show Lock) needs to register a listener in the `LocalBroadcastManager`:
 
 ```java
 // This activity will show Lock

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ public class MyApplication extends Application {
 
 `LockActivity` will handle Email/Password, Enterprise & Social authentication based on your Application's connections enabled in your Auth0's Dashboard.
 
-When a user authenticates successfully, LockActivity will send an Action using LocalBroadcaster manager and then finish itself (by calling finish()). The activity that is interested in receiving this Action (In this case the one that will show Lock) needs to register a listener in the LocalBroadcastManager:
+When a user authenticates successfully, `LockActivity` will send an `Action` using `LocalBroadcastManager` and then finish itself (by calling `finish()`). The activity that is interested in receiving this `Action` (in this case the one that will show Lock) needs to register a listener in the `LocalBroadcastManager`:
 
 ```java
 // This activity will show Lock
@@ -153,7 +153,7 @@ Then in your `AndroidManifest.xml` register the following activities:
     <!--Auth0 Lock Passwordless End-->
 ```
 
-Just like `LockActivity`, when a user authenticates successfully, `LockPasswordlessActivity` will send an Action using `LocalBroadcastManager` and then finish itself (by calling `finish()`). The activity that is interested in receiving this `Action` (In this case the one that will show Lock) needs to register a listener in the `LocalBroadcastManager`:
+Just like `LockActivity`, when a user authenticates successfully, `LockPasswordlessActivity` will send an `Action` using `LocalBroadcastManager` and then finish itself (by calling `finish()`). The activity that is interested in receiving this `Action` (in this case the one that will show Lock) needs to register a listener in the `LocalBroadcastManager`:
 
 ```java
 // This activity will show Lock
@@ -192,18 +192,15 @@ Then just start `LockPasswordlessActivity` especifying the passwordless type you
 LockPasswordlessActivity.showFrom(MyActivity.this, LockPasswordlessActivity.MODE_EMAIL_CODE);
 ```
 
-And you'll see the Email login screen
-
-[![Lock.png](http://blog.auth0.com.s3.amazonaws.com/Lock-Email-Android-Screenshot.png)](https://auth0.com)
-
 Or 
 
 ```java
 LockPasswordlessActivity.showFrom(MyActivity.this, LockPasswordlessActivity.MODE_SMS_CODE);
 ```
 
-And you'll see the SMS login screen
+And you'll see the Email/SMS login screen
 
+[![Lock.png](http://blog.auth0.com.s3.amazonaws.com/Lock-SMS-Android-Screenshot.png)](https://auth0.com)
 [![Lock.png](http://blog.auth0.com.s3.amazonaws.com/Lock-SMS-Android-Screenshot.png)](https://auth0.com)
 
 ##Proguard

--- a/README.md
+++ b/README.md
@@ -56,26 +56,24 @@ Also, you'll need to add *Internet* permission to your application:
 <uses-permission android:name="android.permission.INTERNET"/>
 ```
 
-Finally, Make your Application class (The one that extends from `android.app.Application`) implement the interface `com.auth0.lock.LockProvider` and add the following code:
+Finally, before you use any Lock functionality you need to configure the Lock instance. 
+One way to do it would be in your Application subclass (the one that extends from `android.app.Application`), as seen in the following example:
 
 ```java
-public class MyApplication extends Application implements LockProvider {
-
-  private Lock lock;
+public class MyApplication extends Application {
 
   public void onCreate() {
     super.onCreate();
-    lock = new Lock.Builder()
-      .loadFromApplication(this)
-      /** Other configuration goes here */
-      .closable(true)
-      .build();
+
+    /** Set up Lock */
+    LockContext.configureLock(
+      new Lock.Builder()
+        .loadFromApplication(this)
+        /** Other configuration goes here */
+        .closable(true)
+      );
   }
 
-  @Override
-  public Lock getLock() {
-    return lock;
-  }
 }
 ```
 
@@ -135,7 +133,7 @@ And you'll see our native login screen
 
 ### Passwordless
 
-`LockPasswordlessActivity` authenticates users by sending them an Email or SMS (Similar to how WhatsApp authenticates you). In order to be able to authenticate the user, your application must have the SMS/Email connection enabled and configured in your [dashboard](https://manage.auth0.com/#/connections/passwordless).
+`LockPasswordlessActivity` authenticates users by sending them an Email or SMS (similar to how WhatsApp authenticates you). In order to be able to authenticate the user, your application must have the SMS/Email connection enabled and configured in your [dashboard](https://manage.auth0.com/#/connections/passwordless).
 
 `LockPasswordlessActivity` is part of the library `lock-passwordless` and you can add it with this line in your `build.gradle`:
 ```gradle
@@ -155,7 +153,7 @@ Then in your `AndroidManifest.xml` register the following activities:
     <!--Auth0 Lock Passwordless End-->
 ```
 
-When a user authenticates successfully, LockPasswordlessActivity will send an Action using LocalBroadcaster manager and then finish itself (by calling finish()). The activity that is interested in receiving this Action (In this case the one that will show Lock) needs to register a listener in the LocalBroadcastManager:
+Just like LockActivity, when a user authenticates successfully, LockPasswordlessActivity will send an Action using LocalBroadcaster manager and then finish itself (by calling finish()). The activity that is interested in receiving this Action (In this case the one that will show Lock) needs to register a listener in the LocalBroadcastManager:
 
 ```java
 // This activity will show Lock

--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ Lock for Android
 * **Integrates** your Android app with **Auth0**.
 * Provides a **beautiful native UI** to log your users in.
 * Provides support for **Social Providers** (Facebook, Twitter, etc.), **Enterprise Providers** (AD, LDAP, etc.) and **Username & Password**.
-* Passwordless authentication using **SMS**.
+* Passwordless authentication using **SMS** and **Email**.
 
 ## Requirements
 
 Android API level 15+ is required in order to use Lock's UI.
-If you'll create your own API and just call Auth0 API via the `com.auth0.android:core:1.11.+`, the minimum required API level is 9.
+If you'll create your own API and just call Auth0 API via the `com.auth0.android:core:1.12.+`, the minimum required API level is 9.
 
 ##Install
 
 Lock is available both in [Maven Central](http://search.maven.org) and [JCenter](https://bintray.com/bintray/jcenter). To start using *Lock* add these lines to your `build.gradle` dependencies file:
 
 ```gradle
-compile 'com.auth0.android:lock:1.11.+'
+compile 'com.auth0.android:lock:1.12.+'
 ```
 
 Once it's installed, you'll need to configure LockActivity in your`AndroidManifest.xml`, inside the `application` tag:
@@ -40,7 +40,7 @@ Once it's installed, you'll need to configure LockActivity in your`AndroidManife
     <action android:name="android.intent.action.VIEW"/>
     <category android:name="android.intent.category.DEFAULT"/>
     <category android:name="android.intent.category.BROWSABLE"/>
-    <data android:scheme="a0INSERT_YOUR_APP_CLIENT_ID" android:host="@string/auth0_domain"/>
+    <data android:scheme="a0<INSERT_YOUR_APP_CLIENT_ID>" android:host="@string/auth0_domain"/>
   </intent-filter>
 </activity>
 <meta-data android:name="com.auth0.lock.client-id" android:value="@string/auth0_client_id"/>
@@ -133,29 +133,29 @@ And you'll see our native login screen
 
 > By default all social authentication will be done using an external browser, if you want native integration please check [our docs](https://auth0.com/docs/libraries/lock-android/native-social-authentication).
 
-### SMS
+### Passwordless
 
-`LockSMSActivity` authenticates users by sending them an SMS (Similar to how WhatsApp authenticates you). In order to be able to authenticate the user, your application must have the SMS connection enabled and configured in your [dashboard](https://manage.auth0.com/#/connections/passwordless).
+`LockPasswordlessActivity` authenticates users by sending them an Email or SMS (Similar to how WhatsApp authenticates you). In order to be able to authenticate the user, your application must have the SMS/Email connection enabled and configured in your [dashboard](https://manage.auth0.com/#/connections/passwordless).
 
-`LockSMSActivity` is part of the library `lock-sms` and you can add it with this line in your `build.gradle`:
+`LockPasswordlessActivity` is part of the library `lock-passwordless` and you can add it with this line in your `build.gradle`:
 ```gradle
-compile 'com.auth0.android:lock-sms:1.11.+'
+compile 'com.auth0.android:lock-passwordless:1.12.+'
 ```
 
 Then in your `AndroidManifest.xml` register the following activities:
 ```xml
-    <!--Auth0 Lock SMS-->
+    <!--Auth0 Lock Passwordless-->
     <activity
-      android:name="com.auth0.lock.sms.LockSMSActivity"
+      android:name="com.auth0.lock.passwordless.LockPasswordlessActivity"
       android:theme="@style/Lock.Theme"
       android:label="@string/app_name"
       android:screenOrientation="portrait"
       android:launchMode="singleTask"/>
-    <activity android:name="com.auth0.lock.sms.CountryCodeActivity" android:theme="@style/Lock.Theme"/>
-    <!--Auth0 Lock SMS End-->
+    <activity android:name="com.auth0.lock.passwordless.CountryCodeActivity" android:theme="@style/Lock.Theme"/>
+    <!--Auth0 Lock Passwordless End-->
 ```
 
-When a user authenticates successfully, LockActivity will send an Action using LocalBroadcaster manager and then finish itself (by calling finish()). The activity that is interested in receiving this Action (In this case the one that will show Lock) needs to register a listener in the LocalBroadcastManager:
+When a user authenticates successfully, LockPasswordlessActivity will send an Action using LocalBroadcaster manager and then finish itself (by calling finish()). The activity that is interested in receiving this Action (In this case the one that will show Lock) needs to register a listener in the LocalBroadcastManager:
 
 ```java
 // This activity will show Lock
@@ -188,13 +188,23 @@ public class HomeActivity extends Activity {
 }
 ```
 
-Then just start `LockSMSActivity`
+Then just start `LockPasswordlessActivity` especifying the passwordless type you want to use:
 
 ```java
-startActivity(new Intent(this, LockSMSActivity.class));
+LockPasswordlessActivity.showFrom(MyActivity.this, LockPasswordlessActivity.MODE_EMAIL_CODE);
 ```
 
-And you'll see SMS login screen
+And you'll see the Email login screen
+
+[![Lock.png](http://blog.auth0.com.s3.amazonaws.com/Lock-Email-Android-Screenshot.png)](https://auth0.com)
+
+Or 
+
+```java
+LockPasswordlessActivity.showFrom(MyActivity.this, LockPasswordlessActivity.MODE_SMS_CODE);
+```
+
+And you'll see the SMS login screen
 
 [![Lock.png](http://blog.auth0.com.s3.amazonaws.com/Lock-SMS-Android-Screenshot.png)](https://auth0.com)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,43 +45,6 @@
         <activity android:name="com.auth0.identity.web.WebViewActivity" android:theme="@style/MyLock.Theme"/>
         <!--Auth0 Lock Embedded WebView End-->
 
-        <!--Auth0 Lock SMS-->
-        <activity
-            android:name="com.auth0.lock.sms.LockSMSActivity"
-            android:theme="@style/MyLock.Theme"
-            android:label="@string/app_name"
-            android:screenOrientation="portrait"
-            android:launchMode="singleTask">
-            <!--<intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="https" />
-                <data android:scheme="http" />
-                <data android:host="@string/auth0_domain_name" android:pathPrefix="/android/com.auth0.app.Lock/sms"/>
-            </intent-filter>-->
-        </activity>
-        <activity android:name="com.auth0.lock.sms.CountryCodeActivity" android:theme="@style/MyLock.Theme"/>
-        <!--Auth0 Lock SMS End-->
-
-        <!--Auth0 Lock Email-->
-        <activity
-            android:name="com.auth0.lock.email.LockEmailActivity"
-            android:theme="@style/MyLock.Theme"
-            android:label="@string/app_name"
-            android:screenOrientation="portrait"
-            android:launchMode="singleTask">
-            <!--<intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="https" />
-                <data android:scheme="http" />
-                <data android:host="@string/auth0_domain_name" android:pathPrefix="/android/com.auth0.app.Lock/email"/>
-            </intent-filter>-->
-        </activity>
-        <!--Auth0 Lock Email End-->
-
         <!--Auth0 Lock Passwordless-->
         <activity
             android:name="com.auth0.lock.passwordless.LockPasswordlessActivity"

--- a/app/src/main/java/com/auth0/app/LockApplication.java
+++ b/app/src/main/java/com/auth0/app/LockApplication.java
@@ -30,27 +30,24 @@ import com.auth0.core.Strategies;
 import com.auth0.facebook.FacebookIdentityProvider;
 import com.auth0.googleplus.GooglePlusIdentityProvider;
 import com.auth0.lock.Lock;
-import com.auth0.lock.LockProvider;
+import com.auth0.lock.LockContext;
 
-public class LockApplication extends Application implements LockProvider {
-
-    private Lock lock;
+public class LockApplication extends Application {
 
     @Override
     public void onCreate() {
         super.onCreate();
-        lock = new Lock.Builder()
-                .loadFromApplication(this)
-                .closable(true)
-                .useEmail(true)
-                .fullscreen(false)
-                .withIdentityProvider(Strategies.Facebook, new FacebookIdentityProvider(this))
-                .withIdentityProvider(Strategies.GooglePlus, new GooglePlusIdentityProvider(this))
-                .build();
+
+        LockContext.configureLock(
+                new Lock.Builder()
+                        .loadFromApplication(this)
+                        .closable(true)
+                        .useEmail(true)
+                        .fullscreen(false)
+                        .useWebView(true)
+                        .withIdentityProvider(Strategies.Facebook, new FacebookIdentityProvider(this))
+                        .withIdentityProvider(Strategies.GooglePlus, new GooglePlusIdentityProvider(this))
+        );
     }
 
-    @Override
-    public Lock getLock() {
-        return lock;
-    }
 }


### PR DESCRIPTION
Modify example code to use LockContext instead of implementing LockProvider
Add lock-passwordless for sms and email (deprecating lock-sms)

Sample app:
- Remove unused/deprecated activities in the manifest
- Use LockContext