### PR TITLE
Feature: Add option to customize the "user is blocked" message

### DIFF
--- a/lock-passwordless/src/main/java/com/auth0/lock/passwordless/LockPasswordlessActivity.java
+++ b/lock-passwordless/src/main/java/com/auth0/lock/passwordless/LockPasswordlessActivity.java
@@ -159,7 +159,8 @@ public class LockPasswordlessActivity extends FragmentActivity {
                 R.string.com_auth0_passwordless_login_error_message,
                 isEmailType()
                         ? R.string.com_auth0_passwordless_login_invalid_credentials_message_email
-                        : R.string.com_auth0_passwordless_login_invalid_credentials_message_sms);
+                        : R.string.com_auth0_passwordless_login_invalid_credentials_message_sms,
+                R.string.com_auth0_db_login_unauthorized_error_message);
 
         ActivityUIHelper.configureScreenModeForActivity(this, lock);
     }

--- a/lock/src/main/java/com/auth0/lock/error/LoginAuthenticationErrorBuilder.java
+++ b/lock/src/main/java/com/auth0/lock/error/LoginAuthenticationErrorBuilder.java
@@ -35,6 +35,8 @@ public class LoginAuthenticationErrorBuilder implements  AuthenticationErrorBuil
     private static final String INVALID_USER_PASSWORD_ERROR = "invalid_user_password";
     private static final String UNAUTHORIZED_ERROR = "unauthorized";
 
+    private static final String USER_IS_BLOCKED_DESCRIPTION = "user is blocked";
+
     private final int titleResource;
     private final int defaultMessageResource;
     private final int invalidCredentialsResource;
@@ -66,7 +68,7 @@ public class LoginAuthenticationErrorBuilder implements  AuthenticationErrorBuil
             final String errorDescription = (String) errorResponse.get(ERROR_DESCRIPTION_KEY);
             if (INVALID_USER_PASSWORD_ERROR.equalsIgnoreCase(errorCode)) {
                 messageResource = invalidCredentialsResource;
-            } else if (UNAUTHORIZED_ERROR.equalsIgnoreCase(errorCode)) {
+            } else if (UNAUTHORIZED_ERROR.equalsIgnoreCase(errorCode) && USER_IS_BLOCKED_DESCRIPTION.equalsIgnoreCase(errorDescription)) {
                 messageResource = unauthorizedResource;
             } else if (errorDescription != null) {
                 return new AuthenticationError(titleResource, errorDescription, throwable);

--- a/lock/src/main/java/com/auth0/lock/error/LoginAuthenticationErrorBuilder.java
+++ b/lock/src/main/java/com/auth0/lock/error/LoginAuthenticationErrorBuilder.java
@@ -38,15 +38,22 @@ public class LoginAuthenticationErrorBuilder implements  AuthenticationErrorBuil
     private final int titleResource;
     private final int defaultMessageResource;
     private final int invalidCredentialsResource;
+    private final int unauthorizedResource;
 
     public LoginAuthenticationErrorBuilder() {
-        this(R.string.com_auth0_db_login_error_title, R.string.com_auth0_db_login_error_message, R.string.com_auth0_db_login_invalid_credentials_error_message);
+        this(R.string.com_auth0_db_login_error_title, R.string.com_auth0_db_login_error_message,
+                R.string.com_auth0_db_login_invalid_credentials_error_message, R.string.com_auth0_db_login_unauthorized_error_message);
     }
 
     public LoginAuthenticationErrorBuilder(int titleResource, int defaultMessageResource, int invalidCredentialsResource) {
+        this(titleResource, defaultMessageResource, invalidCredentialsResource, R.string.com_auth0_db_login_unauthorized_error_message);
+    }
+
+    public LoginAuthenticationErrorBuilder(int titleResource, int defaultMessageResource, int invalidCredentialsResource, int unauthorizedResource) {
         this.titleResource = titleResource;
         this.defaultMessageResource = defaultMessageResource;
         this.invalidCredentialsResource = invalidCredentialsResource;
+        this.unauthorizedResource = unauthorizedResource;
     }
 
     @Override
@@ -59,8 +66,9 @@ public class LoginAuthenticationErrorBuilder implements  AuthenticationErrorBuil
             final String errorDescription = (String) errorResponse.get(ERROR_DESCRIPTION_KEY);
             if (INVALID_USER_PASSWORD_ERROR.equalsIgnoreCase(errorCode)) {
                 messageResource = invalidCredentialsResource;
-            }
-            if (UNAUTHORIZED_ERROR.equalsIgnoreCase(errorCode) && errorDescription != null) {
+            } else if (UNAUTHORIZED_ERROR.equalsIgnoreCase(errorCode)) {
+                messageResource = unauthorizedResource;
+            } else if (errorDescription != null) {
                 return new AuthenticationError(titleResource, errorDescription, throwable);
             }
         }

--- a/lock/src/main/res/values/strings.xml
+++ b/lock/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="com_auth0_db_login_error_title">There was an error logging in</string>
     <string name="com_auth0_db_login_error_message">There was an error processing the sign in.</string>
     <string name="com_auth0_db_login_invalid_credentials_error_message">Wrong email or password.</string>
+    <string name="com_auth0_db_login_unauthorized_error_message">User is blocked.</string>
     <string name="com_auth0_db_signup_error_title">There was an error signing up</string>
     <string name="com_auth0_db_signup_error_message">There was an error processing the sign up.</string>
     <string name="com_auth0_db_signup_user_already_exists_error_message">The user already exists.</string>

--- a/lock/src/test/java/com/auth0/lock/error/LoginAuthenticationErrorBuilderTest.java
+++ b/lock/src/test/java/com/auth0/lock/error/LoginAuthenticationErrorBuilderTest.java
@@ -86,9 +86,19 @@ public class LoginAuthenticationErrorBuilderTest {
     }
 
     @Test
-    public void shouldReturnCustomUnauthorizedMessage() throws Exception {
+    public void shouldReturnUnauthorizedMessage() throws Exception {
         Map<String, Object> errors = new HashMap<>();
         errors.put(AuthenticationErrorBuilder.ERROR_KEY, "unauthorized");
+        Throwable exception = new APIClientException("error", 401, errors);
+        AuthenticationError error = builder.buildFrom(exception);
+        assertThat(error, hasMessage(R.string.com_auth0_db_login_unauthorized_error_message));
+        assertThat(error.getThrowable(), equalTo(exception));
+    }
+
+    @Test
+    public void shouldReturnCustomErrorMessage() throws Exception {
+        Map<String, Object> errors = new HashMap<>();
+        errors.put(AuthenticationErrorBuilder.ERROR_KEY, "other_error");
         errors.put("error_description", "custom error");
         Throwable exception = new APIClientException("error", 401, errors);
         AuthenticationError error = builder.buildFrom(exception);

--- a/lock/src/test/java/com/auth0/lock/error/LoginAuthenticationErrorBuilderTest.java
+++ b/lock/src/test/java/com/auth0/lock/error/LoginAuthenticationErrorBuilderTest.java
@@ -86,12 +86,24 @@ public class LoginAuthenticationErrorBuilderTest {
     }
 
     @Test
-    public void shouldReturnUnauthorizedMessage() throws Exception {
+    public void shouldReturnUserIsBlockedMessage() throws Exception {
         Map<String, Object> errors = new HashMap<>();
         errors.put(AuthenticationErrorBuilder.ERROR_KEY, "unauthorized");
+        errors.put("error_description", "user is blocked");
         Throwable exception = new APIClientException("error", 401, errors);
         AuthenticationError error = builder.buildFrom(exception);
         assertThat(error, hasMessage(R.string.com_auth0_db_login_unauthorized_error_message));
+        assertThat(error.getThrowable(), equalTo(exception));
+    }
+
+    @Test
+    public void shouldReturnCustomUnauthorizedMessage() throws Exception {
+        Map<String, Object> errors = new HashMap<>();
+        errors.put(AuthenticationErrorBuilder.ERROR_KEY, "unauthorized");
+        errors.put("error_description", "custom error");
+        Throwable exception = new APIClientException("error", 401, errors);
+        AuthenticationError error = builder.buildFrom(exception);
+        assertThat(error.getMessage(RuntimeEnvironment.application), equalTo("custom error"));
         assertThat(error.getThrowable(), equalTo(exception));
     }
 


### PR DESCRIPTION
In cases where the response is:

```json
{
  "error": "unauthorized",
  "error_description": "user is blocked"
}
```

We don't use the 'error_description', instead we use a string resource that can be customized/translated

Closes issue #140