### PR TITLE
Add option to force webview on adfs connections

### DIFF
--- a/lock/src/main/java/com/auth0/lock/Configuration.java
+++ b/lock/src/main/java/com/auth0/lock/Configuration.java
@@ -24,6 +24,8 @@
 
 package com.auth0.lock;
 
+import android.support.annotation.NonNull;
+
 import com.auth0.core.Application;
 import com.auth0.core.Connection;
 import com.auth0.core.Strategies;
@@ -80,6 +82,11 @@ public class Configuration {
 
     public Application getApplication() {
         return application;
+    }
+
+    public boolean shouldUseNativeAuthentication(Connection connection, @NonNull List<String> enterpriseConnectionsUsingWebForm) {
+        final Strategy strategy = getApplication().strategyForConnection(connection);
+        return strategy.isResourceOwnerEnabled() && !enterpriseConnectionsUsingWebForm.contains(connection.getName());
     }
 
     private Connection filterDatabaseConnections(Strategy databaseStrategy, Set<String> connections, String defaultDatabaseName) {

--- a/lock/src/main/java/com/auth0/lock/Lock.java
+++ b/lock/src/main/java/com/auth0/lock/Lock.java
@@ -114,6 +114,7 @@ public class Lock {
 
     private Configuration configuration;
     private List<String> connections;
+    private List<String> enterpriseConnectionsUsingWebForm;
     private String defaultDatabaseConnection;
     private boolean signUpEnabled;
     private boolean changePasswordEnabled;
@@ -265,6 +266,10 @@ public class Lock {
         return connections;
     }
 
+    public List<String> getEnterpriseConnectionsUsingWebForm() {
+        return enterpriseConnectionsUsingWebForm;
+    }
+
     public String getDefaultDatabaseConnection() {
         return defaultDatabaseConnection;
     }
@@ -362,6 +367,7 @@ public class Lock {
         private boolean useEmail;
         private String defaultDBConnectionName;
         private List<String> connections;
+        private List<String> enterpriseConnectionsUsingWebForm;
         private boolean fullscreen;
         private boolean disableSignUp;
         private boolean disableChangePassword;
@@ -491,6 +497,11 @@ public class Lock {
             return this;
         }
 
+        public Builder enterpriseConnectionsUsingWebForm(String... connectionNames) {
+            this.enterpriseConnectionsUsingWebForm = Arrays.asList(connectionNames);
+            return this;
+        }
+
         /**
          * Specify the DB connection used by Lock.
          *
@@ -596,6 +607,7 @@ public class Lock {
             lock.defaultProvider.setParameters(parameters);
             lock.useEmail = useEmail;
             lock.connections = connections;
+            lock.enterpriseConnectionsUsingWebForm = enterpriseConnectionsUsingWebForm;
             lock.defaultDatabaseConnection = defaultDBConnectionName;
             lock.fullScreen = fullscreen;
             lock.signUpEnabled = !disableSignUp;

--- a/lock/src/main/java/com/auth0/lock/Lock.java
+++ b/lock/src/main/java/com/auth0/lock/Lock.java
@@ -49,6 +49,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.squareup.otto.Bus;
 
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -134,6 +135,7 @@ public class Lock {
         this.signUpEnabled = true;
         this.changePasswordEnabled = true;
         this.credentialStore = new NullCredentialStore();
+        this.enterpriseConnectionsUsingWebForm = new ArrayList<>();
     }
 
     /**
@@ -381,6 +383,7 @@ public class Lock {
             this.useEmail = true;
             this.fullscreen = false;
             this.parameters = ParameterBuilder.newBuilder().asDictionary();
+            this.enterpriseConnectionsUsingWebForm = new ArrayList<>();
             this.store = new NullCredentialStore();
             this.providers = new HashMap<>();
             this.sendSdkInfo = true;

--- a/lock/src/main/java/com/auth0/lock/fragment/DatabaseLoginFragment.java
+++ b/lock/src/main/java/com/auth0/lock/fragment/DatabaseLoginFragment.java
@@ -255,8 +255,7 @@ public class DatabaseLoginFragment extends BaseTitledFragment {
         if (connection != null) {
             final Configuration configuration = LockContext.getLock(getActivity()).getConfiguration();
             final Strategy strategy = configuration.getApplication().strategyForConnection(connection);
-            if ( (enterpriseConnectionsUsingWebForm == null || !enterpriseConnectionsUsingWebForm.contains(connection.getName()))
-                    && strategy.isResourceOwnerEnabled()) {
+            if (strategy.isResourceOwnerEnabled() && !enterpriseConnectionsUsingWebForm.contains(connection.getName())) {
                 bus.post(new EnterpriseAuthenticationRequest(connection));
             } else {
                 bus.post(new IdentityProviderAuthenticationRequestEvent(connection.getName(), usernameField.getText().toString()));

--- a/lock/src/main/java/com/auth0/lock/fragment/DatabaseLoginFragment.java
+++ b/lock/src/main/java/com/auth0/lock/fragment/DatabaseLoginFragment.java
@@ -58,6 +58,8 @@ import com.auth0.lock.util.DomainMatcher;
 import com.auth0.lock.validation.LoginValidator;
 import com.auth0.lock.widget.CredentialField;
 
+import java.util.List;
+
 public class DatabaseLoginFragment extends BaseTitledFragment {
 
     public static final String AD_ENTERPRISE_CONNECTION_ARGUMENT = "AD_ENTERPRISE_CONNECTION_ARGUMENT";
@@ -85,12 +87,14 @@ public class DatabaseLoginFragment extends BaseTitledFragment {
     private Connection enterpriseConnection;
     private Connection defaultConnection;
     private boolean requiresUsername;
+    private List<String> enterpriseConnectionsUsingWebForm;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         final Bundle arguments = getArguments() != null ? getArguments() : new Bundle();
         final Lock lock = LockContext.getLock(getActivity());
+        enterpriseConnectionsUsingWebForm = lock.getEnterpriseConnectionsUsingWebForm();
         Configuration configuration = lock.getConfiguration();
         if (arguments.containsKey(AD_ENTERPRISE_CONNECTION_ARGUMENT)) {
             enterpriseConnection = arguments.getParcelable(AD_ENTERPRISE_CONNECTION_ARGUMENT);
@@ -251,7 +255,8 @@ public class DatabaseLoginFragment extends BaseTitledFragment {
         if (connection != null) {
             final Configuration configuration = LockContext.getLock(getActivity()).getConfiguration();
             final Strategy strategy = configuration.getApplication().strategyForConnection(connection);
-            if (strategy.isResourceOwnerEnabled()) {
+            if ( (enterpriseConnectionsUsingWebForm == null || !enterpriseConnectionsUsingWebForm.contains(connection.getName()))
+                    && strategy.isResourceOwnerEnabled()) {
                 bus.post(new EnterpriseAuthenticationRequest(connection));
             } else {
                 bus.post(new IdentityProviderAuthenticationRequestEvent(connection.getName(), usernameField.getText().toString()));

--- a/lock/src/main/java/com/auth0/lock/fragment/DatabaseLoginFragment.java
+++ b/lock/src/main/java/com/auth0/lock/fragment/DatabaseLoginFragment.java
@@ -254,8 +254,7 @@ public class DatabaseLoginFragment extends BaseTitledFragment {
         final Connection connection = matcher.getConnection();
         if (connection != null) {
             final Configuration configuration = LockContext.getLock(getActivity()).getConfiguration();
-            final Strategy strategy = configuration.getApplication().strategyForConnection(connection);
-            if (strategy.isResourceOwnerEnabled() && !enterpriseConnectionsUsingWebForm.contains(connection.getName())) {
+            if (configuration.shouldUseNativeAuthentication(connection, enterpriseConnectionsUsingWebForm)) {
                 bus.post(new EnterpriseAuthenticationRequest(connection));
             } else {
                 bus.post(new IdentityProviderAuthenticationRequestEvent(connection.getName(), usernameField.getText().toString()));


### PR DESCRIPTION
To force the use of webview on certain connections the user can specify the connections in the Lock.Builder

```java
    new Lock.Builder()
        .loadFromApplication(this)
        .closable(true)
        .useEmail(true)
        /* other options */
        .enterpriseConnectionsUsingWebForm("connection1", "connection2")

```

Closes #158