### PR TITLE
handle network errors on webview flow

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     package="com.auth0.android.lock.app">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:allowBackup="true"

--- a/lock/src/main/java/com/auth0/android/lock/provider/WebViewActivity.java
+++ b/lock/src/main/java/com/auth0/android/lock/provider/WebViewActivity.java
@@ -33,6 +33,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.View;
 import android.webkit.WebChromeClient;
 import android.webkit.WebResourceError;
@@ -46,8 +47,9 @@ import com.auth0.android.lock.R;
 
 public class WebViewActivity extends AppCompatActivity {
 
+    private static final String TAG = WebViewActivity.class.getSimpleName();
+    private static final String KEY_REDIRECT_URI = "redirect_uri";
     public static final String CONNECTION_NAME_EXTRA = "serviceName";
-    public static final String KEY_REDIRECT_URI = "redirect_uri";
 
     private WebView webView;
     private ProgressBar progressBar;
@@ -152,8 +154,14 @@ public class WebViewActivity extends AppCompatActivity {
     }
 
     private boolean isNetworkAvailable() {
+        boolean available = true;
         ConnectivityManager connectivityManager = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
-        return activeNetworkInfo != null && activeNetworkInfo.isConnectedOrConnecting();
+        try {
+            NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
+            available = activeNetworkInfo != null && activeNetworkInfo.isConnectedOrConnecting();
+        } catch (SecurityException e) {
+            Log.w(TAG, "Could not check for Network status. Please, be sure to include the android.permission.ACCESS_NETWORK_STATE permission in the manifest");
+        }
+        return available;
     }
 }

--- a/lock/src/main/java/com/auth0/android/lock/provider/WebViewActivity.java
+++ b/lock/src/main/java/com/auth0/android/lock/provider/WebViewActivity.java
@@ -24,15 +24,22 @@
 
 package com.auth0.android.lock.provider;
 
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
+import android.webkit.WebChromeClient;
+import android.webkit.WebResourceError;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.widget.Button;
 import android.widget.ProgressBar;
 
 import com.auth0.android.lock.R;
@@ -44,6 +51,7 @@ public class WebViewActivity extends AppCompatActivity {
 
     private WebView webView;
     private ProgressBar progressBar;
+    private Button retryButton;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -60,15 +68,41 @@ public class WebViewActivity extends AppCompatActivity {
             bar.setTitle(serviceName);
         }
         webView = (WebView) findViewById(R.id.com_auth0_lock_webview);
+        webView.setVisibility(View.INVISIBLE);
         progressBar = (ProgressBar) findViewById(R.id.com_auth0_lock_progressbar);
+        progressBar.setIndeterminate(true);
+        progressBar.setMax(100);
+        retryButton = (Button) findViewById(R.id.com_auth0_lock_retry);
+        retryButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                retryButton.setVisibility(View.GONE);
+                startUrlLoading();
+            }
+        });
+
+        startUrlLoading();
     }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
+    private void startUrlLoading() {
+        if (!isNetworkAvailable()) {
+            renderNetworkError();
+            return;
+        }
+
         final Intent intent = getIntent();
         final Uri uri = intent.getData();
         final String redirectUrl = uri.getQueryParameter(KEY_REDIRECT_URI);
+        webView.setWebChromeClient(new WebChromeClient() {
+            @Override
+            public void onProgressChanged(WebView view, int newProgress) {
+                super.onProgressChanged(view, newProgress);
+                if (newProgress > 0) {
+                    progressBar.setIndeterminate(false);
+                    progressBar.setProgress(newProgress);
+                }
+            }
+        });
         webView.setWebViewClient(new WebViewClient() {
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
@@ -85,18 +119,41 @@ public class WebViewActivity extends AppCompatActivity {
             @Override
             public void onPageFinished(WebView view, String url) {
                 super.onPageFinished(view, url);
+                progressBar.setProgress(100);
+                progressBar.setIndeterminate(true);
                 progressBar.setVisibility(View.GONE);
+                webView.setVisibility(View.VISIBLE);
             }
 
             @Override
             public void onPageStarted(WebView view, String url, Bitmap favicon) {
                 super.onPageStarted(view, url, favicon);
+                progressBar.setProgress(0);
+                progressBar.setIndeterminate(false);
                 progressBar.setVisibility(View.VISIBLE);
             }
+
+            @Override
+            public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
+                super.onReceivedError(view, request, error);
+                renderNetworkError();
+            }
+
         });
         webView.getSettings().setJavaScriptEnabled(true);
         webView.getSettings().setSupportZoom(true);
         webView.getSettings().setBuiltInZoomControls(true);
         webView.loadUrl(uri.toString());
+    }
+
+    private void renderNetworkError() {
+        webView.setVisibility(View.INVISIBLE);
+        retryButton.setVisibility(View.VISIBLE);
+    }
+
+    private boolean isNetworkAvailable() {
+        ConnectivityManager connectivityManager = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
+        return activeNetworkInfo != null && activeNetworkInfo.isConnectedOrConnecting();
     }
 }

--- a/lock/src/main/java/com/auth0/android/lock/provider/WebViewActivity.java
+++ b/lock/src/main/java/com/auth0/android/lock/provider/WebViewActivity.java
@@ -58,7 +58,6 @@ public class WebViewActivity extends AppCompatActivity {
     private ProgressBar progressBar;
     private View errorView;
     private TextView errorMessage;
-    private boolean isShowingError;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -80,12 +79,12 @@ public class WebViewActivity extends AppCompatActivity {
         progressBar.setIndeterminate(true);
         progressBar.setMax(100);
         errorView = findViewById(R.id.com_auth0_lock_error_view);
+        errorView.setVisibility(View.GONE);
         errorMessage = (TextView) findViewById(R.id.com_auth0_lock_text);
         Button retryButton = (Button) findViewById(R.id.com_auth0_lock_retry);
         retryButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                isShowingError = false;
                 errorView.setVisibility(View.GONE);
                 startUrlLoading();
             }
@@ -107,7 +106,7 @@ public class WebViewActivity extends AppCompatActivity {
             @Override
             public void onProgressChanged(WebView view, int newProgress) {
                 super.onProgressChanged(view, newProgress);
-                if (newProgress > 10) {
+                if (newProgress > 0) {
                     progressBar.setIndeterminate(false);
                     progressBar.setProgress(newProgress);
                 }
@@ -132,6 +131,7 @@ public class WebViewActivity extends AppCompatActivity {
                 progressBar.setProgress(0);
                 progressBar.setIndeterminate(true);
                 progressBar.setVisibility(View.GONE);
+                final boolean isShowingError = errorView.getVisibility() == View.VISIBLE;
                 webView.setVisibility(isShowingError ? View.INVISIBLE : View.VISIBLE);
             }
 
@@ -139,7 +139,6 @@ public class WebViewActivity extends AppCompatActivity {
             public void onPageStarted(WebView view, String url, Bitmap favicon) {
                 super.onPageStarted(view, url, favicon);
                 progressBar.setProgress(0);
-                progressBar.setIndeterminate(false);
                 progressBar.setVisibility(View.VISIBLE);
             }
 
@@ -165,7 +164,6 @@ public class WebViewActivity extends AppCompatActivity {
     }
 
     private void renderLoadError(String description) {
-        isShowingError = true;
         errorMessage.setText(description);
         webView.setVisibility(View.INVISIBLE);
         errorView.setVisibility(View.VISIBLE);

--- a/lock/src/main/res/layout/com_auth0_lock_activity_web_view.xml
+++ b/lock/src/main/res/layout/com_auth0_lock_activity_web_view.xml
@@ -28,17 +28,29 @@
     android:layout_height="match_parent"
     tools:context="com.auth0.android.lock.provider.WebViewActivity">
 
-    <ProgressBar
-        android:id="@+id/com_auth0_lock_progressbar"
-        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-        android:indeterminate="true"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="gone" />
-
     <WebView
         android:id="@+id/com_auth0_lock_webview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@+id/com_auth0_lock_progressbar" />
+        android:layout_alignParentTop="true"
+        android:visibility="invisible" />
+
+    <ProgressBar
+        android:id="@+id/com_auth0_lock_progressbar"
+        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
+    <Button
+        android:id="@+id/com_auth0_lock_retry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:text="Retry"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
 </RelativeLayout>

--- a/lock/src/main/res/layout/com_auth0_lock_activity_web_view.xml
+++ b/lock/src/main/res/layout/com_auth0_lock_activity_web_view.xml
@@ -44,13 +44,29 @@
         android:visibility="gone"
         tools:visibility="visible" />
 
-    <Button
-        android:id="@+id/com_auth0_lock_retry"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:text="Retry"
-        android:visibility="gone"
-        tools:visibility="visible" />
+    <RelativeLayout
+        android:id="@+id/com_auth0_lock_error_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/com_auth0_lock_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:textSize="20sp" />
+
+        <Button
+            android:id="@+id/com_auth0_lock_retry"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:layout_below="@id/com_auth0_lock_text"
+            android:layout_marginTop="10dp"
+            android:text="Retry" />
+
+    </RelativeLayout>
+
 
 </RelativeLayout>

--- a/lock/src/main/res/values/strings.xml
+++ b/lock/src/main/res/values/strings.xml
@@ -102,4 +102,5 @@
 
     <!-- Lock General -->
     <string name="com_auth0_lock_header_title">Lock</string>
+    <string name="com_auth0_lock_network_error">Network error</string>
 </resources>


### PR DESCRIPTION
Check for network status before using the webview. Also let the user retry if there was an error. Note: for this to work, we now require ACCESS_NETWORK_STATE permission.