### PR TITLE
Use Square Moshi instead of Jackson for Json serialization

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -27,9 +27,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.squareup.okhttp:okhttp:2.5.0'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.4.1'
-    compile 'com.fasterxml.jackson.core:jackson-core:2.4.1'
-    compile 'com.fasterxml.jackson.core:jackson-annotations:2.4.1'
+    compile 'com.squareup.moshi:moshi:1.1.0'
 
     testCompile libraries.testing
     testCompile 'com.squareup.okhttp:mockwebserver:2.5.0'

--- a/core/src/main/java/com/auth0/api/APIClient.java
+++ b/core/src/main/java/com/auth0/api/APIClient.java
@@ -10,6 +10,7 @@ import com.auth0.core.Connection;
 import com.auth0.core.DatabaseUser;
 import com.auth0.core.Strategy;
 import com.auth0.core.UserProfile;
+import com.auth0.util.moshi.MapOfObjects;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -310,7 +311,7 @@ public class APIClient extends BaseAPIClient {
      * @param parameters delegation api parameters
      * @param callback called with delegation api response in success or with the failure reason on error.
      */
-    public void fetchDelegationToken(Map<String, Object> parameters, final BaseCallback<Map<String, Object>> callback) {
+    public void fetchDelegationToken(Map<String, Object> parameters, final BaseCallback<MapOfObjects> callback) {
         newClient.delegation()
                 .addParameters(parameters)
                 .start(callback);

--- a/core/src/main/java/com/auth0/api/AuthenticatedAPIClient.java
+++ b/core/src/main/java/com/auth0/api/AuthenticatedAPIClient.java
@@ -30,7 +30,7 @@ import android.util.Log;
 
 import com.auth0.api.callback.BaseCallback;
 import com.auth0.api.internal.RequestFactory;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.auth0.util.moshi.MoshiObjectMapper;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
 
@@ -109,7 +109,7 @@ public class AuthenticatedAPIClient extends BaseAPIClient {
 
         Log.v(TAG, "Requesting SMS code for phone " + phoneNumber);
 
-        RequestFactory.POST(url, newClient, new Handler(Looper.getMainLooper()), new ObjectMapper(), jwt)
+        RequestFactory.POST(url, newClient, new Handler(Looper.getMainLooper()), new MoshiObjectMapper(), jwt)
                 .addParameters(params)
                 .start(callback);
     }

--- a/core/src/main/java/com/auth0/api/authentication/AuthenticationAPIClient.java
+++ b/core/src/main/java/com/auth0/api/authentication/AuthenticationAPIClient.java
@@ -37,7 +37,8 @@ import com.auth0.core.Auth0;
 import com.auth0.core.DatabaseUser;
 import com.auth0.core.Token;
 import com.auth0.core.UserProfile;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.auth0.util.moshi.MoshiObjectMapper;
+import com.auth0.util.moshi.MapOfObjects;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
 
@@ -69,7 +70,7 @@ public class AuthenticationAPIClient {
     private final Auth0 auth0;
     private final OkHttpClient client;
     private final Handler handler;
-    private final ObjectMapper mapper;
+    private final MoshiObjectMapper mapper;
 
     private String defaultDbConnection = DEFAULT_DB_CONNECTION;
 
@@ -89,7 +90,7 @@ public class AuthenticationAPIClient {
      * @param handler where callback will be called with either the response or error from the server
      */
     public AuthenticationAPIClient(Auth0 auth0, Handler handler) {
-        this(auth0, new OkHttpClient(), handler, new ObjectMapper());
+        this(auth0, new OkHttpClient(), handler, new MoshiObjectMapper());
     }
 
     /**
@@ -104,7 +105,7 @@ public class AuthenticationAPIClient {
         this(new Auth0(clientID, baseURL, configurationURL));
     }
 
-    AuthenticationAPIClient(Auth0 auth0, OkHttpClient client, Handler handler, ObjectMapper mapper) {
+    AuthenticationAPIClient(Auth0 auth0, OkHttpClient client, Handler handler, MoshiObjectMapper mapper) {
         this.auth0 = auth0;
         this.client = client;
         this.handler = handler;
@@ -362,7 +363,7 @@ public class AuthenticationAPIClient {
      *
      * @return a request to configure and start
      */
-    public ParameterizableRequest<Map<String, Object>> delegation() {
+    public ParameterizableRequest<MapOfObjects> delegation() {
         HttpUrl url = HttpUrl.parse(auth0.getDomainUrl()).newBuilder()
                 .addPathSegment("delegation")
                 .build();
@@ -387,7 +388,7 @@ public class AuthenticationAPIClient {
                 .set(ID_TOKEN_KEY, idToken)
                 .set(API_TYPE_KEY, DEFAULT_API_TYPE)
                 .asDictionary();
-        ParameterizableRequest<Map<String, Object>> request = delegation()
+        ParameterizableRequest<MapOfObjects> request = delegation()
                 .addParameters(parameters);
         return new DelegationRequest(request);
     }
@@ -405,7 +406,7 @@ public class AuthenticationAPIClient {
                 .set(REFRESH_TOKEN_KEY, refreshToken)
                 .set(API_TYPE_KEY, DEFAULT_API_TYPE)
                 .asDictionary();
-        ParameterizableRequest<Map<String, Object>> request = delegation()
+        ParameterizableRequest<MapOfObjects> request = delegation()
                 .addParameters(parameters);
         return new DelegationRequest(request);
     }

--- a/core/src/main/java/com/auth0/api/authentication/DelegationRequest.java
+++ b/core/src/main/java/com/auth0/api/authentication/DelegationRequest.java
@@ -27,6 +27,7 @@ package com.auth0.api.authentication;
 import com.auth0.api.ParameterizableRequest;
 import com.auth0.api.callback.BaseCallback;
 import com.auth0.api.callback.RefreshIdTokenCallback;
+import com.auth0.util.moshi.MapOfObjects;
 
 import java.util.Map;
 
@@ -39,9 +40,9 @@ public class DelegationRequest {
     private static final String EXPIRES_IN_KEY = "expires_in";
     private static final String ID_TOKEN_KEY = "id_token";
 
-    private final ParameterizableRequest<Map<String, Object>> request;
+    private final ParameterizableRequest<MapOfObjects> request;
 
-    DelegationRequest(ParameterizableRequest<Map<String, Object>> request) {
+    DelegationRequest(ParameterizableRequest<MapOfObjects> request) {
         this.request = request;
     }
 
@@ -60,12 +61,12 @@ public class DelegationRequest {
      * @param callback called either on success or failure
      */
     public void start(final RefreshIdTokenCallback callback) {
-        request.start(new BaseCallback<Map<String, Object>>() {
+        request.start(new BaseCallback<MapOfObjects>() {
             @Override
-            public void onSuccess(final Map<String, Object> payload) {
-                final String id_token = (String) payload.get(ID_TOKEN_KEY);
-                final String token_type = (String) payload.get(TOKEN_TYPE_KEY);
-                final Integer expires_in = (Integer) payload.get(EXPIRES_IN_KEY);
+            public void onSuccess(final MapOfObjects payload) {
+                final String id_token = payload.getAsString(ID_TOKEN_KEY);
+                final String token_type =  payload.getAsString(TOKEN_TYPE_KEY);
+                final Integer expires_in = payload.getAsInteger(EXPIRES_IN_KEY);
                 callback.onSuccess(id_token, token_type, expires_in);
             }
 

--- a/core/src/main/java/com/auth0/api/internal/ApplicationInfoRequest.java
+++ b/core/src/main/java/com/auth0/api/internal/ApplicationInfoRequest.java
@@ -31,8 +31,8 @@ import com.auth0.api.APIClientException;
 import com.auth0.api.ParameterizableRequest;
 import com.auth0.api.callback.BaseCallback;
 import com.auth0.core.Application;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
+import com.auth0.util.moshi.MoshiObjectMapper;
+import com.auth0.util.moshi.MoshiObjectReader;
 import com.squareup.okhttp.Callback;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
@@ -50,8 +50,8 @@ class ApplicationInfoRequest extends BaseRequest<Application> implements Callbac
 
     private static final String TAG = ApplicationInfoRequest.class.getName();
 
-    public ApplicationInfoRequest(Handler handler, OkHttpClient client, HttpUrl url, ObjectMapper mapper) {
-        super(handler, url, client, mapper.reader(Application.class), null);
+    public ApplicationInfoRequest(Handler handler, OkHttpClient client, HttpUrl url, MoshiObjectMapper mapper) {
+        super(handler, url, client, new MoshiObjectReader(mapper,Application.class), null);
     }
 
     @Override

--- a/core/src/main/java/com/auth0/api/internal/BaseRequest.java
+++ b/core/src/main/java/com/auth0/api/internal/BaseRequest.java
@@ -33,8 +33,9 @@ import com.auth0.api.AuthorizableRequest;
 import com.auth0.api.RequestBodyBuildException;
 import com.auth0.api.ParameterizableRequest;
 import com.auth0.api.callback.BaseCallback;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.ObjectWriter;
+import com.auth0.util.moshi.MoshiObjectReader;
+import com.auth0.util.moshi.MoshiObjectWriter;
+import com.auth0.util.moshi.MapOfObjects;
 import com.squareup.okhttp.Callback;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
@@ -54,16 +55,15 @@ abstract class BaseRequest<T> implements ParameterizableRequest<T>, Authorizable
     private final Map<String, Object> parameters;
     private final HttpUrl url;
     private final OkHttpClient client;
-    private final ObjectReader reader;
-    private final ObjectWriter writer;
-
+    private final MoshiObjectReader<T> reader;
+    private final MoshiObjectWriter writer;
     private BaseCallback<T> callback;
 
-    protected BaseRequest(Handler handler, HttpUrl url, OkHttpClient client, ObjectReader reader, ObjectWriter writer) {
+    protected BaseRequest(Handler handler, HttpUrl url, OkHttpClient client, MoshiObjectReader reader, MoshiObjectWriter writer) {
         this(handler, url, client, reader, writer, null);
     }
 
-    public BaseRequest(Handler handler, HttpUrl url, OkHttpClient client, ObjectReader reader, ObjectWriter writer, BaseCallback<T> callback) {
+    public BaseRequest(Handler handler, HttpUrl url, OkHttpClient client, MoshiObjectReader reader, MoshiObjectWriter writer, BaseCallback<T> callback) {
         this.handler = handler;
         this.url = url;
         this.client = client;
@@ -111,12 +111,12 @@ abstract class BaseRequest<T> implements ParameterizableRequest<T>, Authorizable
         return parameters;
     }
 
-    protected ObjectReader getReader() {
+    protected MoshiObjectReader<T> getReader() {
         return reader;
     }
 
     protected RequestBody buildBody() throws RequestBodyBuildException {
-        return JsonRequestBodyBuilder.createBody(parameters, writer);
+        return JsonRequestBodyBuilder.createBody(new MapOfObjects(parameters),MapOfObjects.class, writer);
     }
 
     private static abstract class CallbackTask<T> implements Runnable {

--- a/core/src/main/java/com/auth0/api/internal/RequestFactory.java
+++ b/core/src/main/java/com/auth0/api/internal/RequestFactory.java
@@ -30,11 +30,10 @@ import com.auth0.api.AuthorizableRequest;
 import com.auth0.api.ParameterizableRequest;
 import com.auth0.api.Request;
 import com.auth0.core.Application;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.auth0.util.moshi.MoshiObjectMapper;
+import com.auth0.util.moshi.MapOfObjects;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
-
-import java.util.Map;
 
 public class RequestFactory {
 
@@ -46,43 +45,43 @@ public class RequestFactory {
         CLIENT_INFO = clientInfo;
     }
 
-    public static <T> ParameterizableRequest<T> GET(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper, Class<T> clazz) {
+    public static <T> ParameterizableRequest<T> GET(HttpUrl url, OkHttpClient client, Handler handler, MoshiObjectMapper mapper, Class<T> clazz) {
         return addMetricHeader(new SimpleRequest<>(handler, url, client, mapper, "GET", clazz));
     }
 
-    public static <T> ParameterizableRequest<T> POST(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper, Class<T> clazz) {
+    public static <T> ParameterizableRequest<T> POST(HttpUrl url, OkHttpClient client, Handler handler, MoshiObjectMapper mapper, Class<T> clazz) {
         return addMetricHeader(new SimpleRequest<>(handler, url, client, mapper, "POST", clazz));
     }
 
-    public static ParameterizableRequest<Map<String, Object>> rawPOST(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper) {
-        final SimpleRequest<Map<String, Object>> request = new SimpleRequest<>(handler, url, client, mapper, "POST");
+    public static ParameterizableRequest<MapOfObjects> rawPOST(HttpUrl url, OkHttpClient client, Handler handler, MoshiObjectMapper mapper) {
+        final SimpleRequest<MapOfObjects> request = new SimpleRequest<>(handler, url, client, mapper, "POST");
         addMetricHeader(request);
         return request;
     }
 
-    public static ParameterizableRequest<Void> POST(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper) {
+    public static ParameterizableRequest<Void> POST(HttpUrl url, OkHttpClient client, Handler handler, MoshiObjectMapper mapper) {
         return addMetricHeader(new VoidRequest(handler, url, client, mapper, "POST"));
     }
 
-    public static ParameterizableRequest<Void> POST(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper, String jwt) {
+    public static ParameterizableRequest<Void> POST(HttpUrl url, OkHttpClient client, Handler handler, MoshiObjectMapper mapper, String jwt) {
         final AuthorizableRequest<Void> request = new VoidRequest(handler, url, client, mapper, "POST")
                 .setBearer(jwt);
         return addMetricHeader(request);
     }
 
-    public static <T> ParameterizableRequest<T> PUT(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper, Class<T> clazz) {
+    public static <T> ParameterizableRequest<T> PUT(HttpUrl url, OkHttpClient client, Handler handler, MoshiObjectMapper mapper, Class<T> clazz) {
         return addMetricHeader(new SimpleRequest<>(handler, url, client, mapper, "PUT", clazz));
     }
 
-    public static <T> ParameterizableRequest<T> PATCH(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper, Class<T> clazz) {
+    public static <T> ParameterizableRequest<T> PATCH(HttpUrl url, OkHttpClient client, Handler handler, MoshiObjectMapper mapper, Class<T> clazz) {
         return addMetricHeader(new SimpleRequest<>(handler, url, client, mapper, "GET", clazz));
     }
 
-    public static <T> ParameterizableRequest<T> DELETE(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper, Class<T> clazz) {
+    public static <T> ParameterizableRequest<T> DELETE(HttpUrl url, OkHttpClient client, Handler handler, MoshiObjectMapper mapper, Class<T> clazz) {
         return addMetricHeader(new SimpleRequest<>(handler, url, client, mapper, "DELETE", clazz));
     }
 
-    public static Request<Application> newApplicationInfoRequest(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper) {
+    public static Request<Application> newApplicationInfoRequest(HttpUrl url, OkHttpClient client, Handler handler, MoshiObjectMapper mapper) {
         return addMetricHeader(new ApplicationInfoRequest(handler, client, url, mapper));
     }
 

--- a/core/src/main/java/com/auth0/core/Application.java
+++ b/core/src/main/java/com/auth0/core/Application.java
@@ -1,31 +1,27 @@
 package com.auth0.core;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.squareup.moshi.Json;
 
 import java.util.ArrayList;
 import java.util.List;
+
 
 import static com.auth0.util.CheckHelper.checkArgument;
 
 /**
  * Class with your Auth0's application information and the list of enabled connections (DB, Social, Enterprise, Passwordless).
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class Application {
+public class Application extends ApplicationJson {
+    private transient List<Strategy> socialStrategies;
+    private transient List<Strategy> enterpriseStrategies;
+    private transient Strategy databaseStrategy;
 
-    private String id;
-    private String tenant;
-    private String authorizeURL;
-    private String callbackURL;
-    private String subscription;
-    private boolean hasAllowedOrigins;
-    private List<Strategy> strategies;
-    private List<Strategy> socialStrategies;
-    private List<Strategy> enterpriseStrategies;
-    private Strategy databaseStrategy;
-
+    @SuppressWarnings("unused") // Moshi uses this!
+    private Application() {
+        socialStrategies=null;
+        enterpriseStrategies=null;
+        databaseStrategy=null;
+    }
     /**
      * Creates a new application instance
      * @param id app id.
@@ -36,18 +32,14 @@ public class Application {
      * @param hasAllowedOrigins if the app allows other origins
      * @param strategies list of the strategies enabled for the app (Social, DB, etc).
      */
-    @JsonCreator
-    public Application(@JsonProperty(value = "id") String id,
-                       @JsonProperty(value = "tenant") String tenant,
-                       @JsonProperty(value = "authorize") String authorizeURL,
-                       @JsonProperty(value = "callback") String callbackURL,
-                       @JsonProperty(value = "subscription") String subscription,
-                       @JsonProperty(value = "hasAllowedOrigins") boolean hasAllowedOrigins,
-                       @JsonProperty(value = "strategies") List<Strategy> strategies) {
-        checkArgument(id != null, "id must be non-null");
-        checkArgument(tenant != null, "tenant must be non-null");
-        checkArgument(authorizeURL != null, "authorize must be non-null");
-        checkArgument(strategies != null && strategies.size() > 0, "Must have at least 1 strategy");
+    public Application(
+            String id,
+            String tenant,
+            String authorizeURL,
+            String callbackURL,
+            String subscription,
+            boolean hasAllowedOrigins,
+            List<Strategy> strategies) {
         this.id = id;
         this.tenant = tenant;
         this.authorizeURL = authorizeURL;
@@ -55,6 +47,19 @@ public class Application {
         this.subscription = subscription;
         this.hasAllowedOrigins = hasAllowedOrigins;
         this.strategies = strategies;
+        init();
+    }
+
+    private void checkValid( String id, String tenant,  String authorizeURL, List<Strategy> strategies) {
+        checkArgument(id != null, "id must be non-null");
+        checkArgument(tenant != null, "tenant must be non-null");
+        checkArgument(authorizeURL != null, "authorize must be non-null");
+        checkArgument(strategies != null && strategies.size() > 0, "Must have at least 1 strategy");
+    }
+
+    private void init()
+    {
+        checkValid(id, tenant, authorizeURL, strategies);
         this.socialStrategies = new ArrayList<>();
         this.enterpriseStrategies = new ArrayList<>();
         for(Strategy strategy: strategies) {
@@ -72,7 +77,6 @@ public class Application {
             }
         }
     }
-
     /**
      * Returns the id of the application.
      * @return an ID

--- a/core/src/main/java/com/auth0/core/ApplicationJson.java
+++ b/core/src/main/java/com/auth0/core/ApplicationJson.java
@@ -1,0 +1,25 @@
+package com.auth0.core;
+
+import com.squareup.moshi.Json;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.auth0.util.CheckHelper.checkArgument;
+
+/**
+ * Class with your Auth0's application information and the list of enabled connections (DB, Social, Enterprise, Passwordless).
+ */
+public class ApplicationJson {
+    @Json(name = "id") String id;
+    @Json(name = "tenant") String tenant;
+    @Json(name = "authorize") String authorizeURL;
+    @Json(name = "callback") String callbackURL;
+    @Json(name = "subscription") String subscription;
+    @Json(name = "hasAllowedOrigins") boolean hasAllowedOrigins;
+    @Json(name = "strategies") List<Strategy> strategies;
+
+    @SuppressWarnings("unused") // Moshi uses this!
+    ApplicationJson() {
+    }
+}

--- a/core/src/main/java/com/auth0/core/ApplicationJsonAdapter.java
+++ b/core/src/main/java/com/auth0/core/ApplicationJsonAdapter.java
@@ -13,6 +13,6 @@ public class ApplicationJsonAdapter {
     }
     @ToJson
     ApplicationJson toJson(Application a) {
-        return (ApplicationJson)a;
+        return a;
     }
 }

--- a/core/src/main/java/com/auth0/core/ApplicationJsonAdapter.java
+++ b/core/src/main/java/com/auth0/core/ApplicationJsonAdapter.java
@@ -1,0 +1,18 @@
+package com.auth0.core;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+
+/**
+ * Created by daely on 5/13/2016.
+ */
+public class ApplicationJsonAdapter {
+    @FromJson
+    Application fromJson(ApplicationJson a) {
+        return new Application(a.id,a.tenant,a.authorizeURL,a.callbackURL,a.subscription,a.hasAllowedOrigins,a.strategies);
+    }
+    @ToJson
+    ApplicationJson toJson(Application a) {
+        return (ApplicationJson)a;
+    }
+}

--- a/core/src/main/java/com/auth0/core/Connection.java
+++ b/core/src/main/java/com/auth0/core/Connection.java
@@ -3,8 +3,8 @@ package com.auth0.core;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import com.auth0.util.moshi.MapOfObjects;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -12,29 +12,36 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+
 import static com.auth0.util.CheckHelper.checkArgument;
 
 /**
  * Class with a Auth0 connection info
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Connection implements Parcelable {
 
-    private String name;
+    private transient String name;
 
     private Map<String, Object> values;
 
+    @SuppressWarnings("unused") // Moshi uses this!
+    private  Connection() {
+        name=null;
+    }
     /**
      * Creates a new connection instance
      * @param values Connection values
      */
-    @JsonCreator
     public Connection(Map<String, Object> values) {
+        this.values = values;
+        init();
+    }
+
+    private void init() {
         checkArgument(values != null && values.size() > 0, "Must have at least one value");
         final String name = (String) values.remove("name");
         checkArgument(name != null, "Must have a non-null name");
         this.name = name;
-        this.values = values;
     }
 
     /**
@@ -130,4 +137,9 @@ public class Connection implements Parcelable {
             return new Connection[size];
         }
     };
+
+    public MapOfObjects toMap() {
+        //NOT IMPLEMENTED
+        return null;
+    }
 }

--- a/core/src/main/java/com/auth0/core/ConnectionJsonAdapter.java
+++ b/core/src/main/java/com/auth0/core/ConnectionJsonAdapter.java
@@ -1,0 +1,19 @@
+package com.auth0.core;
+
+import com.auth0.util.moshi.MapOfObjects;
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+
+/**
+ * Created by daely on 5/13/2016.
+ */
+public class ConnectionJsonAdapter {
+    @FromJson
+    Connection fromJson(MapOfObjects om) {
+        return new Connection(om.map);
+    }
+    @ToJson
+    MapOfObjects toJson(Connection c) {
+        return c.toMap();
+    }
+}

--- a/core/src/main/java/com/auth0/core/DatabaseUser.java
+++ b/core/src/main/java/com/auth0/core/DatabaseUser.java
@@ -24,27 +24,26 @@
 
 package com.auth0.core;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.squareup.moshi.Json;
+
+import static com.auth0.util.CheckHelper.checkArgument;
 
 /**
  * Value holder for Database Sign Up operation
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class DatabaseUser {
+public class DatabaseUser extends DatabaseUserJson{
 
-    private final String email;
-    private final String username;
-    private final boolean emailVerified;
-
-    public DatabaseUser(@JsonProperty(value = "email", required = true) String email,
-                        @JsonProperty("username") String username,
-                        @JsonProperty("email_verified") boolean emailVerified) {
+    public DatabaseUser(String email,
+                        String username,
+                        boolean emailVerified) {
         this.email = email;
         this.username = username;
         this.emailVerified = emailVerified;
+        init();
     }
-
+    private void init() {
+        checkArgument(email != null, "email must be non-null");
+    }
     public String getEmail() {
         return email;
     }
@@ -56,4 +55,6 @@ public class DatabaseUser {
     public boolean isEmailVerified() {
         return emailVerified;
     }
+
+
 }

--- a/core/src/main/java/com/auth0/core/DatabaseUserJson.java
+++ b/core/src/main/java/com/auth0/core/DatabaseUserJson.java
@@ -1,5 +1,5 @@
 /*
- * JsonRequestBodyBuilder.java
+ * DatabaseUser.java
  *
  * Copyright (c) 2015 Auth0 (http://auth0.com)
  *
@@ -22,27 +22,28 @@
  * THE SOFTWARE.
  */
 
-package com.auth0.api.internal;
+package com.auth0.core;
 
-import com.auth0.api.RequestBodyBuildException;
-import com.auth0.util.moshi.MoshiObjectWriter;
-import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.RequestBody;
+import com.squareup.moshi.Json;
 
-import java.lang.reflect.Type;
+import static com.auth0.util.CheckHelper.checkArgument;
 
 /**
- * Converts a POJO to JSON stored in a {@link com.squareup.okhttp.RequestBody}
+ * Value holder for Database Sign Up operation
  */
-abstract class JsonRequestBodyBuilder {
+public class DatabaseUserJson {
 
-    private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+    @Json(name="email")
+    protected  String email;
+    @Json(name="username")
+    protected  String username;
+    @Json(name="email_verified")
+    protected  boolean emailVerified;
 
-    public static <T> RequestBody createBody(T pojo, Type typeOfT, MoshiObjectWriter writer) throws RequestBodyBuildException {
-        try {
-            return RequestBody.create(JSON, writer.writeValueAsBytes(pojo,typeOfT));
-        } catch (Exception e) {
-            throw new RequestBodyBuildException("Failed to convert " + pojo.getClass().getName() + " to JSON", e);
-        }
+    @SuppressWarnings("unused") // Moshi uses this!
+    DatabaseUserJson() {
+        email=null;
+        username=null;
+        emailVerified=false;
     }
 }

--- a/core/src/main/java/com/auth0/core/DatabaseUserJsonAdapter.java
+++ b/core/src/main/java/com/auth0/core/DatabaseUserJsonAdapter.java
@@ -12,6 +12,6 @@ public class DatabaseUserJsonAdapter {
         return new DatabaseUser(duj.email,duj.username,duj.emailVerified);
     }
     @ToJson DatabaseUserJson toJson(DatabaseUser du) {
-        return (DatabaseUserJson) du;
+        return  du;
     }
 }

--- a/core/src/main/java/com/auth0/core/DatabaseUserJsonAdapter.java
+++ b/core/src/main/java/com/auth0/core/DatabaseUserJsonAdapter.java
@@ -1,0 +1,17 @@
+package com.auth0.core;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+
+/**
+ * Created by daely on 5/13/2016.
+ */
+public class DatabaseUserJsonAdapter {
+    @FromJson
+    DatabaseUser fromJson(DatabaseUserJson duj) {
+        return new DatabaseUser(duj.email,duj.username,duj.emailVerified);
+    }
+    @ToJson DatabaseUserJson toJson(DatabaseUser du) {
+        return (DatabaseUserJson) du;
+    }
+}

--- a/core/src/main/java/com/auth0/core/Strategy.java
+++ b/core/src/main/java/com/auth0/core/Strategy.java
@@ -1,26 +1,32 @@
 package com.auth0.core;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.squareup.moshi.Json;
 
 import java.util.List;
+
+
+import static com.auth0.util.CheckHelper.checkArgument;
 
 /**
  * Class with Auth0 authentication strategy info
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class Strategy {
+public class Strategy extends StrategyJson {
+    private transient Strategies strategyMetadata;
 
-    private String name;
-    private List<Connection> connections;
-    private Strategies strategyMetadata;
-
-    @JsonCreator
-    public Strategy(@JsonProperty(value = "name", required = true) String name,
-                    @JsonProperty(value = "connections", required = true) List<Connection> connections) {
+    @SuppressWarnings("unused") // Moshi uses this!
+    private Strategy() {
+        strategyMetadata=null;
+    }
+    public Strategy(String name,
+                    List<Connection> connections) {
         this.name = name;
         this.connections = connections;
+        init();
+    }
+
+    private void init() {
+        checkArgument(name != null, "name must be non-null");
+        checkArgument(connections != null, "connections must be non-null");
         this.strategyMetadata = Strategies.fromName(name);
     }
 

--- a/core/src/main/java/com/auth0/core/StrategyJson.java
+++ b/core/src/main/java/com/auth0/core/StrategyJson.java
@@ -1,0 +1,24 @@
+package com.auth0.core;
+
+import com.squareup.moshi.Json;
+
+import java.util.List;
+
+import static com.auth0.util.CheckHelper.checkArgument;
+
+/**
+ * Class with Auth0 authentication strategy info
+ */
+//@JsonIgnoreProperties(ignoreUnknown = true)
+public class StrategyJson {
+
+    @Json(name="name")
+    protected String name;
+    @Json(name="connections")
+    protected List<Connection> connections;
+
+    @SuppressWarnings("unused") // Moshi uses this!
+    protected StrategyJson() {
+
+    }
+}

--- a/core/src/main/java/com/auth0/core/StrategyJsonAdapter.java
+++ b/core/src/main/java/com/auth0/core/StrategyJsonAdapter.java
@@ -1,0 +1,17 @@
+package com.auth0.core;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+
+/**
+ * Created by daely on 5/13/2016.
+ */
+public class StrategyJsonAdapter {
+    @FromJson
+    Strategy fromJson(StrategyJson s) {
+        return new Strategy(s.name,s.connections);
+    }
+    @ToJson StrategyJson toJson(Strategy s) {
+        return (StrategyJson) s;
+    }
+}

--- a/core/src/main/java/com/auth0/core/StrategyJsonAdapter.java
+++ b/core/src/main/java/com/auth0/core/StrategyJsonAdapter.java
@@ -12,6 +12,6 @@ public class StrategyJsonAdapter {
         return new Strategy(s.name,s.connections);
     }
     @ToJson StrategyJson toJson(Strategy s) {
-        return (StrategyJson) s;
+        return  s;
     }
 }

--- a/core/src/main/java/com/auth0/core/Token.java
+++ b/core/src/main/java/com/auth0/core/Token.java
@@ -3,29 +3,35 @@ package com.auth0.core;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.squareup.moshi.Json;
+
+import static com.auth0.util.CheckHelper.checkArgument;
 
 /**
  * Class that holds a user's token information.
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class Token implements Parcelable {
+public class Token extends TokenJson implements Parcelable {
 
-    private String idToken;
-    private String accessToken;
-    private String type;
-    private String refreshToken;
+    @SuppressWarnings("unused") // Moshi uses this!
+    private Token() {
 
-    public Token(@JsonProperty(value = "id_token", required = true) String idToken,
-                 @JsonProperty(value = "access_token") String accessToken,
-                 @JsonProperty(value = "token_type") String type,
-                 @JsonProperty(value = "refresh_token") String refreshToken) {
+    }
+    public Token( String idToken,
+                 String accessToken,
+                 String type,
+                 String refreshToken) {
         this.idToken = idToken;
         this.accessToken = accessToken;
         this.type = type;
         this.refreshToken = refreshToken;
+		init();
     }
+
+    private void init()
+    {
+        checkArgument(idToken != null, "idToken must be non-null");
+    }
+
 
     public String getIdToken() {
         return idToken;

--- a/core/src/main/java/com/auth0/core/Token.java
+++ b/core/src/main/java/com/auth0/core/Token.java
@@ -13,7 +13,7 @@ import static com.auth0.util.CheckHelper.checkArgument;
 public class Token extends TokenJson implements Parcelable {
 
     @SuppressWarnings("unused") // Moshi uses this!
-    private Token() {
+    public Token() {
 
     }
     public Token( String idToken,

--- a/core/src/main/java/com/auth0/core/TokenJson.java
+++ b/core/src/main/java/com/auth0/core/TokenJson.java
@@ -1,0 +1,27 @@
+package com.auth0.core;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import com.squareup.moshi.Json;
+
+import static com.auth0.util.CheckHelper.checkArgument;
+
+/**
+ * Class that holds a user's token information.
+ */
+public class TokenJson {
+    @Json(name = "id_token")
+    protected String idToken;
+    @Json(name = "access_token")
+    protected String accessToken;
+    @Json(name = "token_type")
+    protected String type;
+    @Json(name = "refresh_token")
+    protected String refreshToken;
+
+    @SuppressWarnings("unused") // Moshi uses this!
+    protected TokenJson() {
+
+    }
+}

--- a/core/src/main/java/com/auth0/core/TokenJson.java
+++ b/core/src/main/java/com/auth0/core/TokenJson.java
@@ -24,4 +24,8 @@ public class TokenJson {
     protected TokenJson() {
 
     }
+
+    public boolean isEmpty() {
+        return idToken==null&&accessToken==null&&type==null&&refreshToken==null;
+    }
 }

--- a/core/src/main/java/com/auth0/core/TokenJsonAdapter.java
+++ b/core/src/main/java/com/auth0/core/TokenJsonAdapter.java
@@ -9,10 +9,12 @@ import com.squareup.moshi.ToJson;
 public class TokenJsonAdapter {
     @FromJson
     Token fromJson(TokenJson t) {
+        if(t==null||t.isEmpty())
+            return new Token(); //empty
         return new Token(t.idToken,t.accessToken,t.type,t.refreshToken);
     }
     @ToJson
     TokenJson toJson(Token t) {
-        return (TokenJson) t;
+        return  t;
     }
 }

--- a/core/src/main/java/com/auth0/core/TokenJsonAdapter.java
+++ b/core/src/main/java/com/auth0/core/TokenJsonAdapter.java
@@ -1,0 +1,18 @@
+package com.auth0.core;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+
+/**
+ * Created by daely on 5/13/2016.
+ */
+public class TokenJsonAdapter {
+    @FromJson
+    Token fromJson(TokenJson t) {
+        return new Token(t.idToken,t.accessToken,t.type,t.refreshToken);
+    }
+    @ToJson
+    TokenJson toJson(Token t) {
+        return (TokenJson) t;
+    }
+}

--- a/core/src/main/java/com/auth0/core/UserIdentity.java
+++ b/core/src/main/java/com/auth0/core/UserIdentity.java
@@ -3,17 +3,15 @@ package com.auth0.core;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.squareup.moshi.Json;
 
 import java.util.HashMap;
 import java.util.Map;
 
+
 /**
  * Class that holds the information from a Identity Provider like Facebook or Twitter.
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserIdentity implements Parcelable {
 
     private static final String USER_ID_KEY = "user_id";
@@ -23,13 +21,32 @@ public class UserIdentity implements Parcelable {
     private static final String ACCESS_TOKEN_KEY = "access_token";
     private static final String ACCESS_TOKEN_SECRET_KEY = "access_token_secret";
     private static final String PROFILE_DATA_KEY = "profileData";
+
+    @Json(name=USER_ID_KEY)
     private final String id;
+    @Json(name=CONNECTION_KEY)
     private final String connection;
+    @Json(name=PROVIDER_KEY)
     private final String provider;
+    @Json(name=IS_SOCIAL_KEY)
     private final boolean social;
+    @Json(name=ACCESS_TOKEN_KEY)
     private final String accessToken;
+    @Json(name=ACCESS_TOKEN_SECRET_KEY)
     private final String accessTokenSecret;
+    @Json(name=PROFILE_DATA_KEY)
     private final Map<String, Object> profileInfo;
+
+    @SuppressWarnings("unused") // Moshi uses this!
+    private UserIdentity() {
+        id=null;
+        connection=null;
+        provider=null;
+        social=false;
+        accessToken=null;
+        accessTokenSecret=null;
+        profileInfo=null;
+    }
 
     @SuppressWarnings("unchecked")
     public UserIdentity(Map<String, Object> values) {
@@ -50,16 +67,26 @@ public class UserIdentity implements Parcelable {
         this.accessToken = (String) values.get(ACCESS_TOKEN_KEY);
         this.accessTokenSecret = (String) values.get(ACCESS_TOKEN_SECRET_KEY);
         this.profileInfo = (Map<String, Object>) values.get(PROFILE_DATA_KEY);
+        init();
     }
-
-    @JsonCreator
-    public UserIdentity(@JsonProperty(value = USER_ID_KEY) String id,
-                        @JsonProperty(value = CONNECTION_KEY) String connection,
-                        @JsonProperty(value = PROVIDER_KEY) String provider,
-                        @JsonProperty(value = IS_SOCIAL_KEY, required = false) boolean social,
-                        @JsonProperty(value = ACCESS_TOKEN_KEY, required = false) String accessToken,
-                        @JsonProperty(value = ACCESS_TOKEN_SECRET_KEY, required = false) String accessTokenSecret,
-                        @JsonProperty(value = PROFILE_DATA_KEY, required = false) Map<String, Object> profileInfo) {
+    Map<String,Object> toMap() {
+        HashMap<String, Object> res=new HashMap<String,Object>();
+        res.put(USER_ID_KEY,id);
+        res.put(CONNECTION_KEY,connection);
+        res.put(PROVIDER_KEY,provider);
+        res.put(IS_SOCIAL_KEY,social);
+        res.put(ACCESS_TOKEN_KEY,accessToken);
+        res.put(ACCESS_TOKEN_SECRET_KEY,accessTokenSecret);
+        res.put(PROFILE_DATA_KEY,profileInfo);
+        return res;
+    }
+    public UserIdentity( String id,
+                        String connection,
+                        String provider,
+                        boolean social,
+                        String accessToken,
+                        String accessTokenSecret,
+                        Map<String, Object> profileInfo) {
         this.id = id;
         this.connection = connection;
         this.provider = provider;
@@ -67,6 +94,12 @@ public class UserIdentity implements Parcelable {
         this.accessToken = accessToken;
         this.accessTokenSecret = accessTokenSecret;
         this.profileInfo = profileInfo;
+        init();
+    }
+    private void init() {
+//        checkArgument(id != null, "id must be non-null");
+//        checkArgument(connection != null, "connection must be non-null");
+//        checkArgument(provider != null, "provider must be non-null");
     }
 
     /**

--- a/core/src/main/java/com/auth0/core/UserIdentityJsonAdapter.java
+++ b/core/src/main/java/com/auth0/core/UserIdentityJsonAdapter.java
@@ -1,0 +1,20 @@
+package com.auth0.core;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+
+import java.util.Map;
+
+/**
+ * Created by daely on 5/13/2016.
+ */
+public class UserIdentityJsonAdapter {
+    @FromJson
+    UserIdentity fromJson(Map<String,Object> m) {
+        return new UserIdentity(m);
+    }
+    @ToJson
+    Map<String,Object> toJson(UserIdentity ui) {
+        return ui.toMap();
+    }
+}

--- a/core/src/main/java/com/auth0/core/UserProfile.java
+++ b/core/src/main/java/com/auth0/core/UserProfile.java
@@ -3,8 +3,6 @@ package com.auth0.core;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -21,8 +19,15 @@ import static com.auth0.util.CheckHelper.checkArgument;
 /**
  * Class that holds the information of a user's profile
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
+//@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserProfile implements Parcelable {
+    private static final String USER_ID_KEY = "user_id";
+    private static final String NAME_KEY = "name";
+    private static final String NICKNAME_KEY = "nickname";
+    private static final String EMAIL_KEY = "email";
+    private static final String PICTURE_URL_KEY = "picture";
+    private static final String CREATED_AT_KEY = "created_at";
+    private static final String IDENTITIES_KEY = "identities";
 
     private String id;
     private String name;
@@ -33,28 +38,35 @@ public class UserProfile implements Parcelable {
     private Map<String, Object> extraInfo;
     private List<UserIdentity> identities;
 
-    @JsonCreator
+    @SuppressWarnings("unused") // Moshi uses this!
+    public UserProfile() {
+
+    }
     @SuppressWarnings("unchecked")
     public UserProfile(Map<String, Object> values) {
         checkArgument(values != null, "must supply non-null values");
         HashMap<String, Object> info = new HashMap<String, Object>(values);
-        String id = (String) info.remove("user_id");
+        String id = (String) info.remove(USER_ID_KEY);
         checkArgument(id != null, "profile must have a user id");
         this.id = id;
-        this.name = (String) info.remove("name");
-        this.nickname = (String) info.remove("nickname");
-        this.email = (String) info.remove("email");
-        this.pictureURL = (String) info.remove("picture");
+        this.name = (String) info.remove(NAME_KEY);
+        this.nickname = (String) info.remove(NICKNAME_KEY);
+        this.email = (String) info.remove(EMAIL_KEY);
+        this.pictureURL = (String) info.remove(PICTURE_URL_KEY);
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
         sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
         try {
-            String created_at = (String) info.remove("created_at");
+            String created_at = (String) info.remove(CREATED_AT_KEY);
             this.createdAt = created_at != null ? sdf.parse(created_at) : null;
         } catch (ParseException e) {
             throw new IllegalArgumentException("Invalid created_at value", e);
         }
-        this.identities = buildIdentities((List<Map<String, Object>>) info.remove("identities"));
+        this.identities = buildIdentities((List<Map<String, Object>>) info.remove(IDENTITIES_KEY));
         this.extraInfo = info;
+    }
+    public Map<String,Object> toMap() {
+//        throw new Exception("Not Implemented");
+        return null;
     }
 
     public String getId() {
@@ -169,4 +181,5 @@ public class UserProfile implements Parcelable {
             return new UserProfile[size];
         }
     };
+
 }

--- a/core/src/main/java/com/auth0/core/UserProfileJsonAdapter.java
+++ b/core/src/main/java/com/auth0/core/UserProfileJsonAdapter.java
@@ -1,0 +1,21 @@
+package com.auth0.core;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Created by daely on 5/13/2016.
+ */
+public class UserProfileJsonAdapter {
+    @FromJson
+    UserProfile fromJson(Map<String,Object> m) {
+        return new UserProfile(m);
+    }
+    @ToJson
+    Map<String,Object> toJson(UserProfile up) {
+       return up.toMap();
+    }
+}

--- a/core/src/main/java/com/auth0/util/Telemetry.java
+++ b/core/src/main/java/com/auth0/util/Telemetry.java
@@ -28,8 +28,7 @@ import android.util.Base64;
 import android.util.Log;
 
 import com.auth0.android.BuildConfig;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.auth0.util.moshi.MoshiObjectMapper;
 
 import java.nio.charset.Charset;
 import java.util.HashMap;
@@ -66,10 +65,10 @@ public class Telemetry {
         }
         String clientInfo = null;
         try {
-            String json = new ObjectMapper().writeValueAsString(info);
+            String json = new MoshiObjectMapper().writeValueAsString(info);
             Log.v(TAG, "Telemetry JSON is " + json);
             clientInfo = Base64.encodeToString(json.getBytes(Charset.defaultCharset()), Base64.URL_SAFE | Base64.NO_WRAP);
-        } catch (JsonProcessingException e) {
+        } catch (Exception e) {
             Log.w(TAG, "Failed to build client info", e);
         }
         return clientInfo;

--- a/core/src/main/java/com/auth0/util/moshi/MapOfObjects.java
+++ b/core/src/main/java/com/auth0/util/moshi/MapOfObjects.java
@@ -1,0 +1,60 @@
+package com.auth0.util.moshi;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * encapsulate a Map for customizing Json serialization/deserialization
+ * Created by daely on 5/12/2016.
+ */
+public class MapOfObjects {
+    public final Map<String,Object> map;
+    public MapOfObjects() {
+        map=new HashMap<String,Object>();
+    }
+    public MapOfObjects(Map<String,Object> map) {
+        this.map=map;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        MapOfObjects mapOfObjects = (MapOfObjects) o;
+
+        return map.equals(mapOfObjects.map);
+
+    }
+    public String getAsString(String key) {
+        return (String) map.get(key);
+    }
+    public Integer getAsInteger(String key) {
+        Object tmp=map.get(key);
+        if(tmp==null) return  null;
+        return toInteger(tmp);
+    }
+    /**
+     * fix an issue with gson/moshi, that can cause an integer in Json to be parsed as Double
+     * see also http://stackoverflow.com/questions/21920436/object-autoconvert-to-double-with-serialization-gson
+     * @param obj
+     * @return
+     */
+    private Integer toInteger(Object obj) {
+        Integer expires_in=null;
+        if(obj instanceof Integer)
+            expires_in = (Integer) obj;
+        else if(obj instanceof Double) {
+            double tmp_ = (Double) obj;
+            expires_in = (int) Math.round(tmp_);
+        } else if(obj instanceof Float) {
+            float tmp_ = (Float) obj;
+            expires_in = (int) Math.round(tmp_);
+        }
+        return expires_in;
+    }
+    @Override
+    public int hashCode() {
+        return map.hashCode();
+    }
+}

--- a/core/src/main/java/com/auth0/util/moshi/MapOfObjectsAdapter.java
+++ b/core/src/main/java/com/auth0/util/moshi/MapOfObjectsAdapter.java
@@ -1,0 +1,19 @@
+package com.auth0.util.moshi;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+
+import java.util.Map;
+
+/**
+ * Created by daely on 5/12/2016.
+ */
+public class MapOfObjectsAdapter {
+    @FromJson
+    MapOfObjects fromJson(Map<String,Object> m) {
+        return new MapOfObjects(m);
+    }
+    @ToJson
+    Map<String,Object> toJson(MapOfObjects o) {
+        return o.map;
+    }}

--- a/core/src/main/java/com/auth0/util/moshi/MapOfStrings.java
+++ b/core/src/main/java/com/auth0/util/moshi/MapOfStrings.java
@@ -1,0 +1,34 @@
+package com.auth0.util.moshi;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * encapsulate a Map for customizing Json serialization/deserialization
+ * Created by daely on 5/12/2016.
+ */
+public class MapOfStrings {
+    public final Map<String,String> map;
+    public MapOfStrings() {
+        map=new HashMap<String,String>();
+    }
+    public MapOfStrings(Map<String,String> map) {
+        this.map=map;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        MapOfStrings mapOfStrings = (MapOfStrings) o;
+
+        return map.equals(mapOfStrings.map);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return map.hashCode();
+    }
+}

--- a/core/src/main/java/com/auth0/util/moshi/MapOfStringsAdapter.java
+++ b/core/src/main/java/com/auth0/util/moshi/MapOfStringsAdapter.java
@@ -1,0 +1,20 @@
+package com.auth0.util.moshi;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.ToJson;
+
+import java.util.Map;
+
+/**
+ * encapsulate a Map for customizing Json serialization/deserialization
+ * Created by daely on 5/12/2016.
+ */
+public class MapOfStringsAdapter {
+    @FromJson
+    MapOfStrings fromJson(Map<String,String> m) {
+        return new MapOfStrings(m);
+    }
+    @ToJson
+    Map<String,String> toJson(MapOfStrings o) {
+        return o.map;
+    }}

--- a/core/src/main/java/com/auth0/util/moshi/MoshiObjectMapper.java
+++ b/core/src/main/java/com/auth0/util/moshi/MoshiObjectMapper.java
@@ -1,0 +1,67 @@
+package com.auth0.util.moshi;
+
+import com.auth0.core.ApplicationJsonAdapter;
+import com.auth0.core.ConnectionJsonAdapter;
+import com.auth0.core.DatabaseUserJsonAdapter;
+import com.auth0.core.StrategyJsonAdapter;
+import com.auth0.core.TokenJsonAdapter;
+import com.auth0.core.UserIdentityJsonAdapter;
+import com.auth0.core.UserProfileJsonAdapter;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import okio.Okio;
+
+/**
+ * Created by daely on 5/12/2016.
+ */
+public class MoshiObjectMapper {
+    public final Moshi moshi;
+
+    private static Moshi configureMoshi() {
+        Moshi res=new Moshi.Builder()
+                .add(new ApplicationJsonAdapter())
+                .add(new ConnectionJsonAdapter())
+                .add(new DatabaseUserJsonAdapter())
+                .add(new StrategyJsonAdapter())
+                .add(new TokenJsonAdapter())
+                .add(new UserIdentityJsonAdapter())
+                .add(new UserProfileJsonAdapter())
+                .add(new MapOfObjectsAdapter())
+                .add(new MapOfStringsAdapter())
+                .build();
+        return res;
+    }
+    public MoshiObjectMapper() {
+        moshi= configureMoshi();
+    }
+
+    public  <T> T readValue(String json,Type typeOfT) throws IOException {
+        JsonAdapter<T> adapter=moshi.adapter(typeOfT);
+        return adapter.fromJson(json);
+    }
+    public  <T> T readValue(InputStream inputStream, Type typeOfT) throws IOException {
+        JsonAdapter<T> adapter=moshi.adapter(typeOfT);
+        return adapter.fromJson(Okio.buffer(Okio.source(inputStream)));
+    }
+    public  <T> T readValue(File file, Type typeOfT) throws IOException {
+        JsonAdapter<T> adapter=moshi.adapter(typeOfT);
+        return adapter.fromJson(Okio.buffer(Okio.source(file)));
+    }
+    public String writeValueAsString(Map<String, Object> map) {
+        MapOfObjects om = new MapOfObjects(map);
+        JsonAdapter<MapOfObjects> adapter=moshi.adapter( MapOfObjects.class );
+        return adapter.toJson(om);
+    }
+    public <T> byte[] writeValueAsBytes(T pojo,Type typeOfT) {
+        JsonAdapter<T> adapter= moshi.adapter(typeOfT);
+        return adapter.toJson(pojo).getBytes();
+    }
+
+}

--- a/core/src/main/java/com/auth0/util/moshi/MoshiObjectReader.java
+++ b/core/src/main/java/com/auth0/util/moshi/MoshiObjectReader.java
@@ -1,0 +1,26 @@
+package com.auth0.util.moshi;
+
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+
+/**
+ * Created by daely on 5/12/2016.
+ */
+public class MoshiObjectReader<T> {
+    MoshiObjectMapper mapper;
+    Type type;
+    public MoshiObjectReader(MoshiObjectMapper mapper, Type type) {
+        this.mapper=mapper;
+        this.type=type;
+    }
+
+    public T readValue(String s) throws IOException {
+        return mapper.readValue(s,type);
+    }
+
+    public T readValue(InputStream byteStream) throws IOException {
+        return mapper.readValue(byteStream,type);
+    }
+}

--- a/core/src/main/java/com/auth0/util/moshi/MoshiObjectWriter.java
+++ b/core/src/main/java/com/auth0/util/moshi/MoshiObjectWriter.java
@@ -1,0 +1,18 @@
+package com.auth0.util.moshi;
+
+import java.lang.reflect.Type;
+
+/**
+ * Created by daely on 5/12/2016.
+ */
+public class MoshiObjectWriter {
+    MoshiObjectMapper mapper;
+    public MoshiObjectWriter(MoshiObjectMapper mapper)
+    {
+        this.mapper=mapper;
+    }
+
+    public <T> byte[] writeValueAsBytes(T pojo,Type typeOfT) {
+        return mapper.writeValueAsBytes(pojo,typeOfT);
+    }
+}

--- a/core/src/test/java/com/auth0/api/authentication/AuthenticationAPIClientTest.java
+++ b/core/src/test/java/com/auth0/api/authentication/AuthenticationAPIClientTest.java
@@ -37,8 +37,9 @@ import com.auth0.util.AuthenticationAPI;
 import com.auth0.util.MockAuthenticationCallback;
 import com.auth0.util.MockBaseCallback;
 import com.auth0.util.MockRefreshIdTokenCallback;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.auth0.util.moshi.MoshiObjectMapper;
+import com.auth0.util.moshi.MapOfObjects;
+import com.auth0.util.moshi.MapOfStrings;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 import org.junit.After;
@@ -422,7 +423,7 @@ public class AuthenticationAPIClientTest {
     public void shouldCallDelegation() throws Exception {
         mockAPI.willReturnGenericDelegationToken();
 
-        final MockBaseCallback<Map<String, Object>> callback = new MockBaseCallback<>();
+        final MockBaseCallback<MapOfObjects> callback = new MockBaseCallback<>();
         client.delegation()
                 .start(callback);
 
@@ -435,7 +436,7 @@ public class AuthenticationAPIClientTest {
 
         Map<String, Object> payload = new HashMap<>();
         payload.put("token", GENERIC_TOKEN);
-        assertThat(callback, hasPayload(payload));
+        assertThat(callback, hasPayload(new MapOfObjects(payload)));
     }
 
     @Test
@@ -628,7 +629,7 @@ public class AuthenticationAPIClientTest {
     }
 
     private Map<String, String> bodyFromRequest(RecordedRequest request) throws java.io.IOException {
-        return new ObjectMapper().readValue(request.getBody().inputStream(), new TypeReference<Map<String, String>>() {
-        });
+        MapOfStrings res=  new MoshiObjectMapper().readValue(request.getBody().inputStream(), MapOfStrings.class);
+        return res.map;
     }
 }

--- a/core/src/test/java/com/auth0/api/internal/BaseRequestTest.java
+++ b/core/src/test/java/com/auth0/api/internal/BaseRequestTest.java
@@ -29,8 +29,8 @@ import android.os.Handler;
 import com.auth0.android.BuildConfig;
 import com.auth0.api.ParameterizableRequest;
 import com.auth0.api.callback.BaseCallback;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.ObjectWriter;
+import com.auth0.util.moshi.MoshiObjectReader;
+import com.auth0.util.moshi.MoshiObjectWriter;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
@@ -68,9 +68,9 @@ public class BaseRequestTest {
     @Mock
     private OkHttpClient client;
     @Mock
-    private ObjectReader reader;
+    private MoshiObjectReader reader;
     @Mock
-    private ObjectWriter writer;
+    private MoshiObjectWriter writer;
     @Captor
     private ArgumentCaptor<Runnable> captor;
 

--- a/core/src/test/java/com/auth0/core/UserIdentityTest.java
+++ b/core/src/test/java/com/auth0/core/UserIdentityTest.java
@@ -25,8 +25,7 @@
 package com.auth0.core;
 
 import com.auth0.android.BuildConfig;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
+import com.auth0.util.moshi.MoshiObjectMapper;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,7 +57,7 @@ public class UserIdentityTest {
                 "\", \"provider\": \"" +
                 AUTH0 +
                 "\"}";
-        final UserIdentity identity = new ObjectMapper().readValue(json, UserIdentity.class);
+        final UserIdentity identity = new MoshiObjectMapper().readValue(json, UserIdentity.class);
         assertThat(identity, is(notNullValue()));
         assertThat(identity.getId(), equalTo(USER_ID));
         assertThat(identity.getProvider(), equalTo(AUTH0));
@@ -74,7 +73,7 @@ public class UserIdentityTest {
                 "\", \"provider\": \"" +
                 AUTH0 +
                 "\", \"isSocial\": \"null\" }";
-        final UserIdentity identity = new ObjectMapper().readValue(json, UserIdentity.class);
+        final UserIdentity identity = new MoshiObjectMapper().readValue(json, UserIdentity.class);
         assertThat(identity, is(notNullValue()));
         assertThat(identity.getId(), equalTo(USER_ID));
         assertThat(identity.getProvider(), equalTo(AUTH0));

--- a/lock-passwordless/src/main/java/com/auth0/lock/passwordless/task/LoadCountriesTask.java
+++ b/lock-passwordless/src/main/java/com/auth0/lock/passwordless/task/LoadCountriesTask.java
@@ -28,11 +28,11 @@ import android.content.Context;
 import android.os.AsyncTask;
 import android.util.Log;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.auth0.util.moshi.MoshiObjectMapper;
+import com.auth0.util.moshi.MapOfStrings;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 public abstract class LoadCountriesTask extends AsyncTask<String, Void, Map<String, String>> {
@@ -49,16 +49,15 @@ public abstract class LoadCountriesTask extends AsyncTask<String, Void, Map<Stri
     @Override
     protected Map<String, String> doInBackground(String... params) {
 
-        Map<String, String> codes;
+        MapOfStrings codes;
         try {
-            TypeReference<HashMap<String, String>> typeRef = new TypeReference<HashMap<String, String>>() {};
-            codes = new ObjectMapper().readValue(context.getAssets().open(params[0]), typeRef);
-            Log.d(TAG, "Loaded " + codes.size() + " countries");
+            codes = new MoshiObjectMapper().readValue(context.getAssets().open(params[0]), MapOfStrings.class);
+            Log.d(TAG, "Loaded " + codes.map.size() + " countries");
         } catch (IOException e) {
-            codes = new HashMap<>();
+            codes = new MapOfStrings();
             Log.e(TAG, "Failed to load countries JSON file", e);
         }
-        return codes;
+        return codes.map;
     }
 
     public Context getContext() {

--- a/lock/src/test/java/com/auth0/lock/ConfigurationTest.java
+++ b/lock/src/test/java/com/auth0/lock/ConfigurationTest.java
@@ -27,7 +27,7 @@ package com.auth0.lock;
 import com.auth0.core.Application;
 import com.auth0.core.Connection;
 import com.auth0.core.Strategy;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.auth0.util.moshi.MoshiObjectMapper;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -77,7 +77,7 @@ public class ConfigurationTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        ObjectMapper mapper = new ObjectMapper();
+        MoshiObjectMapper mapper = new MoshiObjectMapper();
         application = mapper.readValue(new File("src/test/resources/appinfo.json"), Application.class);
     }
 


### PR DESCRIPTION
Motivation: method count: 
jackson, before proguard took more than 8300 methods. After substituting it with Moshi, method count is reduced by ~6300 methods, so that I am able to run my app that uses lock.android in debug mode without proguarding it. 
Certainly Jackson is more powerful and the orginal code was more elegant, but method counts of all the libs included with Lock.Android was a big problem for me and I think for many other potential android customers for auth0. In my personal fork of Lock.Android I also strip all code related to social authentication, since I used only passwordless, so that I can reduce method count even further.