### PR TITLE
New LogIn/SignUp Flow, first showing Social Buttons

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/Configuration.java
@@ -63,6 +63,7 @@ public class Configuration {
 
     private Application application;
 
+    private boolean useSocialBigButtons;
     private boolean signUpEnabled;
     private boolean changePasswordEnabled;
     private boolean usernameRequired;
@@ -219,6 +220,7 @@ public class Configuration {
     private void parseLocalOptions(Options options) {
         usernameStyle = options.usernameStyle();
         loginAfterSignUp = options.loginAfterSignUp();
+        useSocialBigButtons = options.useSocialBigButtons();
 
         if (getDefaultDatabaseConnection() != null) {
             //let user disable signUp only if connection have enabled it.
@@ -257,6 +259,10 @@ public class Configuration {
         }
         final List<Connection> connections = activeDirectoryStrategy.getConnections();
         return !connections.isEmpty() ? connections.get(0) : null;
+    }
+
+    public boolean useSocialBigButtons() {
+        return useSocialBigButtons;
     }
 
     public boolean isSignUpEnabled() {

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -336,6 +336,20 @@ public class Lock {
         }
 
         /**
+         * Whether to use the new Big Social Buttons flow or not. The Big Social Buttons flow is
+         * where if social and db/enterprise connections are found, only Social is displayed in the
+         * main screen. To access the other connection types, the user needs to click a link.
+         * Defaults to true.
+         *
+         * @param socialBigButtons flow or classic
+         * @return the current builder instance
+         */
+        public Builder useSocialBigButtons(boolean socialBigButtons) {
+            options.setUseSocialBigButtons(socialBigButtons);
+            return this;
+        }
+
+        /**
          * Uses the given AuthProviderResolver to ask for Native IdentityProviders.
          *
          * @param resolver the AuthProviderResolver to use

--- a/lib/src/main/java/com/auth0/android/lock/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/Options.java
@@ -52,6 +52,7 @@ class Options implements Parcelable {
     private boolean closable;
     private boolean fullscreen;
     private int usernameStyle;
+    private boolean useSocialBigButtons;
     private boolean useCodePasswordless;
     private boolean signUpEnabled;
     private boolean changePasswordEnabled;
@@ -64,6 +65,7 @@ class Options implements Parcelable {
 
     public Options() {
         usernameStyle = UsernameStyle.DEFAULT;
+        useSocialBigButtons = true;
         signUpEnabled = true;
         changePasswordEnabled = true;
         loginAfterSignUp = true;
@@ -79,6 +81,7 @@ class Options implements Parcelable {
         usePKCE = in.readByte() != WITHOUT_DATA;
         closable = in.readByte() != WITHOUT_DATA;
         fullscreen = in.readByte() != WITHOUT_DATA;
+        useSocialBigButtons = in.readByte() != WITHOUT_DATA;
         signUpEnabled = in.readByte() != WITHOUT_DATA;
         changePasswordEnabled = in.readByte() != WITHOUT_DATA;
         loginAfterSignUp = in.readByte() != WITHOUT_DATA;
@@ -124,6 +127,7 @@ class Options implements Parcelable {
         dest.writeByte((byte) (usePKCE ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (closable ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (fullscreen ? HAS_DATA : WITHOUT_DATA));
+        dest.writeByte((byte) (useSocialBigButtons ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (signUpEnabled ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (changePasswordEnabled ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (loginAfterSignUp ? HAS_DATA : WITHOUT_DATA));
@@ -274,6 +278,14 @@ class Options implements Parcelable {
             authenticationParameters.put(DEVICE_KEY, Build.MODEL);
         }
         this.authenticationParameters = authenticationParameters;
+    }
+
+    public boolean useSocialBigButtons() {
+        return useSocialBigButtons;
+    }
+
+    public void setUseSocialBigButtons(boolean useSocialBigButtons) {
+        this.useSocialBigButtons = useSocialBigButtons;
     }
 
     public boolean loginAfterSignUp() {

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -326,6 +326,11 @@ public class ClassicLockView extends PercentRelativeLayout implements View.OnCli
         bus.post(event);
     }
 
+    @Override
+    public void showActionButton(boolean show) {
+        actionButton.setVisibility(show ? VISIBLE : GONE);
+    }
+
     /**
      * Notifies this forms and its child views that the keyboard state changed, so that
      * it can change the layout in order to fit all the fields.

--- a/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
@@ -102,9 +102,11 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
                 lockWidget.showActionButton(false);
             } else {
                 addSeparator();
+                addModeSelector();
                 changeFormMode(ModeSelectionView.Mode.LOG_IN);
             }
         } else {
+            addModeSelector();
             changeFormMode(ModeSelectionView.Mode.LOG_IN);
         }
     }

--- a/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
@@ -47,16 +47,21 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
     private static final int MULTIPLE_FORMS_POSITION = 2;
 
     private final LockWidgetForm lockWidget;
+    private boolean showSocial;
     private boolean showDatabase;
     private boolean showEnterprise;
+    private boolean showModeSelection;
+    private boolean showSocialBigButtons;
 
     private boolean keyboardIsOpen;
+    private boolean showingOtherProviderForm;
 
     private SignUpFormView signUpForm;
     private LogInFormView logInForm;
     private SocialView socialLayout;
     private CustomFieldsFormView customFieldsForm;
     private TextView orSeparatorMessage;
+    private TextView continueWithOtherProvider;
 
     private LinearLayout formsHolder;
     private ModeSelectionView modeSelectionView;
@@ -73,27 +78,17 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
     }
 
     private void init() {
-        boolean showSocial = !lockWidget.getConfiguration().getSocialStrategies().isEmpty();
+        showSocial = !lockWidget.getConfiguration().getSocialStrategies().isEmpty();
         showDatabase = lockWidget.getConfiguration().getDefaultDatabaseConnection() != null;
         showEnterprise = !lockWidget.getConfiguration().getEnterpriseStrategies().isEmpty();
-        boolean showModeSelection = showDatabase && lockWidget.getConfiguration().isSignUpEnabled();
+        showModeSelection = showDatabase && lockWidget.getConfiguration().isSignUpEnabled();
+        showSocialBigButtons = true; //TODO: Make it configurable from the Builder
 
-        int verticalMargin = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_vertical_margin_field);
-        int horizontalMargin = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_horizontal_margin);
-
-        if (showModeSelection) {
-            Log.v(TAG, "SignUp enabled. Adding the Login/SignUp Mode Switcher");
-            modeSelectionView = new ModeSelectionView(getContext(), this);
-            modeSelectionView.setId(R.id.com_auth0_lock_form_selector);
-            LayoutParams modeSelectionParams = new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-            modeSelectionParams.addRule(ALIGN_PARENT_TOP);
-            modeSelectionParams.setMargins(horizontalMargin, verticalMargin, horizontalMargin, verticalMargin);
-            addView(modeSelectionView, modeSelectionParams);
-        }
         formsHolder = new LinearLayout(getContext());
-        formsHolder.setGravity(CENTER_IN_PARENT);
         formsHolder.setOrientation(LinearLayout.VERTICAL);
         formsHolder.setGravity(Gravity.CENTER);
+
+        int horizontalMargin = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_horizontal_margin);
         LayoutParams holderParams = new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
         holderParams.addRule(BELOW, R.id.com_auth0_lock_form_selector);
         holderParams.addRule(CENTER_VERTICAL);
@@ -101,20 +96,50 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
         addView(formsHolder, holderParams);
 
         if (showSocial) {
-            addSocialLayout(showDatabase || showEnterprise);
-            if (showDatabase || showEnterprise) {
+            addSocialLayout();
+            if (showSocialBigButtons) {
+                addContinueWithOtherProviderLink();
+                lockWidget.showActionButton(false);
+            } else {
                 addSeparator();
+                changeFormMode(ModeSelectionView.Mode.LOG_IN);
             }
+        } else {
+            changeFormMode(ModeSelectionView.Mode.LOG_IN);
         }
-        changeFormMode(ModeSelectionView.Mode.LOG_IN);
     }
 
-    private void addSocialLayout(boolean smallButtons) {
+
+    private void addModeSelector() {
+        if (showModeSelection) {
+            int verticalMargin = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_vertical_margin_field);
+            int horizontalMargin = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_horizontal_margin);
+            Log.v(TAG, "SignUp enabled. Adding the Login/SignUp Mode Switcher");
+
+            modeSelectionView = new ModeSelectionView(getContext(), this);
+            modeSelectionView.setId(R.id.com_auth0_lock_form_selector);
+            LayoutParams modeSelectionParams = new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+            modeSelectionParams.addRule(ALIGN_PARENT_TOP);
+            modeSelectionParams.setMargins(horizontalMargin, verticalMargin, horizontalMargin, verticalMargin);
+            addView(modeSelectionView, modeSelectionParams);
+        }
+    }
+
+    private void removeModeSelector() {
+        removeView(modeSelectionView);
+        modeSelectionView = null;
+    }
+
+    private void addSocialLayout() {
+        boolean smallButtons = !showSocialBigButtons && (showDatabase || showEnterprise);
         socialLayout = new SocialView(lockWidget, smallButtons);
         formsHolder.addView(socialLayout);
     }
 
     private void addSeparator() {
+        if (!showDatabase && !showEnterprise) {
+            return;
+        }
         orSeparatorMessage = new TextView(getContext());
         orSeparatorMessage.setText(R.string.com_auth0_lock_forms_separator);
         orSeparatorMessage.setTextColor(ContextCompat.getColor(getContext(), R.color.com_auth0_lock_text));
@@ -123,6 +148,34 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
         int verticalPadding = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_vertical_margin_field);
         orSeparatorMessage.setPadding(0, verticalPadding, 0, verticalPadding);
         formsHolder.addView(orSeparatorMessage, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+    }
+
+    private void addContinueWithOtherProviderLink() {
+        if (!showDatabase && !showEnterprise) {
+            return;
+        }
+        continueWithOtherProvider = new TextView(getContext());
+        continueWithOtherProvider.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                showingOtherProviderForm = true;
+                lockWidget.showActionButton(true);
+                formsHolder.removeView(socialLayout);
+                removeView(continueWithOtherProvider);
+                socialLayout = null;
+                addModeSelector();
+                changeFormMode(ModeSelectionView.Mode.LOG_IN);
+            }
+        });
+        continueWithOtherProvider.setText("Sign in or Sign up with email");
+        continueWithOtherProvider.setTextColor(ContextCompat.getColor(getContext(), R.color.com_auth0_lock_text));
+        continueWithOtherProvider.setTextSize(TypedValue.COMPLEX_UNIT_PX, getResources().getDimension(R.dimen.com_auth0_lock_title_text));
+        continueWithOtherProvider.setGravity(Gravity.CENTER_HORIZONTAL);
+        int verticalPadding = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_vertical_margin_field);
+        LayoutParams linkParams = new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        linkParams.addRule(ALIGN_PARENT_BOTTOM);
+        linkParams.setMargins(0, verticalPadding, 0, verticalPadding);
+        addView(continueWithOtherProvider, linkParams);
     }
 
     /**
@@ -188,9 +241,10 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
         int parentHeight = MeasureSpec.getSize(heightMeasureSpec);
         int modeSelectionHeight = ViewUtils.measureViewHeight(modeSelectionView);
         int separatorHeight = ViewUtils.measureViewHeight(orSeparatorMessage);
+        int continueWithOtherProviderHeight = ViewUtils.measureViewHeight(continueWithOtherProvider);
         int socialHeight = ViewUtils.measureViewHeight(socialLayout);
         int fieldsHeight = ViewUtils.measureViewHeight(getExistingForm());
-        int sumHeight = modeSelectionHeight + separatorHeight + socialHeight + fieldsHeight;
+        int sumHeight = modeSelectionHeight + separatorHeight + continueWithOtherProviderHeight + socialHeight + fieldsHeight;
 
         Log.v(TAG, String.format("Parent height %d, FormReal height %d", parentHeight, sumHeight));
         setMeasuredDimension(getMeasuredWidth(), sumHeight);
@@ -248,7 +302,20 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
      * @return true if it was handled, false otherwise
      */
     public boolean onBackPressed() {
-        return logInForm != null && logInForm.onBackPressed();
+        if (logInForm != null && logInForm.onBackPressed()) {
+            return true;
+        } else if (showSocial && showingOtherProviderForm) {
+            showingOtherProviderForm = false;
+            lockWidget.showTopBanner(false);
+            lockWidget.showBottomBanner(false);
+            lockWidget.showActionButton(false);
+            removePreviousForm();
+            removeModeSelector();
+            addSocialLayout();
+            addContinueWithOtherProviderLink();
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
@@ -167,7 +167,13 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
                 changeFormMode(ModeSelectionView.Mode.LOG_IN);
             }
         });
-        continueWithOtherProvider.setText("Sign in or Sign up with email");
+        int textRes;
+        if (lockWidget.getConfiguration().isSignUpEnabled()) {
+            textRes = R.string.com_auth0_lock_action_continue_signin_signup_with_email;
+        } else {
+            textRes = R.string.com_auth0_lock_action_continue_signin_with_email;
+        }
+        continueWithOtherProvider.setText(textRes);
         continueWithOtherProvider.setTextColor(ContextCompat.getColor(getContext(), R.color.com_auth0_lock_text));
         continueWithOtherProvider.setTextSize(TypedValue.COMPLEX_UNIT_PX, getResources().getDimension(R.dimen.com_auth0_lock_title_text));
         continueWithOtherProvider.setGravity(Gravity.CENTER_HORIZONTAL);

--- a/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
@@ -51,7 +51,7 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
     private boolean showDatabase;
     private boolean showEnterprise;
     private boolean showModeSelection;
-    private boolean showSocialBigButtons;
+    private boolean useSocialBigButtons;
 
     private boolean keyboardIsOpen;
     private boolean showingOtherProviderForm;
@@ -82,7 +82,7 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
         showDatabase = lockWidget.getConfiguration().getDefaultDatabaseConnection() != null;
         showEnterprise = !lockWidget.getConfiguration().getEnterpriseStrategies().isEmpty();
         showModeSelection = showDatabase && lockWidget.getConfiguration().isSignUpEnabled();
-        showSocialBigButtons = true; //TODO: Make it configurable from the Builder
+        useSocialBigButtons = lockWidget.getConfiguration().useSocialBigButtons();
 
         formsHolder = new LinearLayout(getContext());
         formsHolder.setOrientation(LinearLayout.VERTICAL);
@@ -97,7 +97,7 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
 
         if (showSocial) {
             addSocialLayout();
-            if (showSocialBigButtons) {
+            if (useSocialBigButtons) {
                 addContinueWithOtherProviderLink();
                 lockWidget.showActionButton(false);
             } else {
@@ -131,7 +131,7 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
     }
 
     private void addSocialLayout() {
-        boolean smallButtons = !showSocialBigButtons && (showDatabase || showEnterprise);
+        boolean smallButtons = !useSocialBigButtons && (showDatabase || showEnterprise);
         socialLayout = new SocialView(lockWidget, smallButtons);
         formsHolder.addView(socialLayout);
     }

--- a/lib/src/main/java/com/auth0/android/lock/views/interfaces/LockWidgetForm.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/interfaces/LockWidgetForm.java
@@ -35,4 +35,6 @@ public interface LockWidgetForm extends LockWidgetSocial {
     void showBottomBanner(boolean show);
 
     void showTopBanner(boolean show);
+
+    void showActionButton(boolean show);
 }

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -119,6 +119,8 @@
     <string name="com_auth0_lock_action_forgot_password">Don\'t remember your password?</string>
     <string name="com_auth0_lock_action_login_with_corporate">Please enter your corporate credentials at %s</string>
     <string name="com_auth0_lock_action_retry">Retry</string>
+    <string name="com_auth0_lock_action_continue_signin_signup_with_email">Sign in or Sign up with email</string>
+    <string name="com_auth0_lock_action_continue_signin_with_email">Sign in with email</string>
     <string name="com_auth0_lock_single_sign_on_enabled">Single Sign On Enabled</string>
     <string name="com_auth0_lock_forms_separator">OR</string>
     <string name="com_auth0_lock_passwordless_sms_forms_separator">Otherwise, enter your phone to sign in or create an account</string>

--- a/lib/src/test/java/com/auth0/android/lock/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/OptionsTest.java
@@ -191,6 +191,20 @@ public class OptionsTest {
     }
 
     @Test
+    public void shouldUseSocialBigButtons() {
+        Options options = new Options();
+        options.setAccount(auth0);
+        options.setUseSocialBigButtons(true);
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.useSocialBigButtons(), is(equalTo(parceledOptions.useSocialBigButtons())));
+    }
+
+    @Test
     public void shouldBeChangePasswordEnabled() {
         Options options = new Options();
         options.setAccount(auth0);
@@ -376,6 +390,7 @@ public class OptionsTest {
         assertTrue(options != parceledOptions); //assure correct Parcelable object testing
         assertThat(options.useBrowser(), is(false));
         assertThat(options.usePKCE(), is(false));
+        assertThat(options.useSocialBigButtons(), is(true));
         assertThat(options.isSignUpEnabled(), is(true));
         assertThat(options.isChangePasswordEnabled(), is(true));
         assertThat(options.loginAfterSignUp(), is(true));
@@ -393,6 +408,7 @@ public class OptionsTest {
         options.setFullscreen(true);
         options.setUseBrowser(true);
         options.setUsePKCE(true);
+        options.setUseSocialBigButtons(true);
         options.setUsernameStyle(UsernameStyle.EMAIL);
         options.setSignUpEnabled(true);
         options.setLoginAfterSignUp(true);
@@ -408,6 +424,7 @@ public class OptionsTest {
         assertThat(options.isFullscreen(), is(equalTo(parceledOptions.isFullscreen())));
         assertThat(options.useBrowser(), is(equalTo(parceledOptions.useBrowser())));
         assertThat(options.usePKCE(), is(equalTo(parceledOptions.usePKCE())));
+        assertThat(options.useSocialBigButtons(), is(equalTo(parceledOptions.useSocialBigButtons())));
         assertThat(options.usernameStyle(), is(equalTo(parceledOptions.usernameStyle())));
         assertThat(options.isSignUpEnabled(), is(equalTo(parceledOptions.isSignUpEnabled())));
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
@@ -423,6 +440,7 @@ public class OptionsTest {
         options.setFullscreen(false);
         options.setUseBrowser(false);
         options.setUsePKCE(false);
+        options.setUseSocialBigButtons(false);
         options.setUsernameStyle(UsernameStyle.USERNAME);
         options.setSignUpEnabled(false);
         options.setLoginAfterSignUp(false);
@@ -438,6 +456,7 @@ public class OptionsTest {
         assertThat(options.isFullscreen(), is(equalTo(parceledOptions.isFullscreen())));
         assertThat(options.useBrowser(), is(equalTo(parceledOptions.useBrowser())));
         assertThat(options.usePKCE(), is(equalTo(parceledOptions.usePKCE())));
+        assertThat(options.useSocialBigButtons(), is(equalTo(parceledOptions.useSocialBigButtons())));
         assertThat(options.usernameStyle(), is(equalTo(parceledOptions.usernameStyle())));
         assertThat(options.isSignUpEnabled(), is(equalTo(parceledOptions.isSignUpEnabled())));
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));


### PR DESCRIPTION
New flow GIFs:
* With only 3 social connections: http://g.recordit.co/n90YVIBJpJ.gif
* With 3 social connections and DB connection: http://g.recordit.co/vtOxxrpWSJ.gif

The "old" flow is working as on v2.

TODO: Update docs telling that there's a new option in `Lock.Builder` to set which flow to use. By default, it will now use the new one. The setter is `useSocialBigButtons(boolean)`