### PR TITLE
Show/Enable specific database forms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ As in the previous version, `Lock` can be configured with extra options. Check b
 1. `isClosable` has been renamed to `closable` By default, it's not closable.
 1. `setFullscreen` has been renamed to `fullscreen`. By default, it's not fullscreen.
 1. `shouldLoginAfterSignUp` has been renamed to `loginAfterSignUp`.
-1. `disableSignupAction` has been renamed to `disableSignUp`.
-1. `disableResetAction` has been renamed to `disableChangePassword`.
+1. `disableSignupAction` has been renamed to `allowSignUp`.
+1. `disableResetAction` has been renamed to `allowForgotPassword`.
 1. `defaultUserPasswordConnection` has been renamed to `setDefaultDatabaseConnection`.
 1. `setConnections` has been renamed to `onlyUseConnections`.
 1. `setAuthenticationParameters` has been renamed to `withAuthenticationParameters`.

--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
@@ -180,6 +180,8 @@ public class DemoActivity extends AppCompatActivity implements View.OnClickListe
                 .loginAfterSignUp(false)
                 .initialScreen(InitialScreen.FORGOT_PASSWORD)
                 .allowForgotPassword(true)
+                .allowSignIn(false)
+                .allowSignUp(false)
 //                .setDefaultDatabaseConnection("mfa-connection")
                 .usePKCE(true)
                 .closable(true)

--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
@@ -40,6 +40,7 @@ import com.auth0.android.lock.CustomField.FieldType;
 import com.auth0.android.lock.Lock;
 import com.auth0.android.lock.LockCallback;
 import com.auth0.android.lock.PasswordlessLock;
+import com.auth0.android.lock.enums.InitialScreen;
 import com.auth0.android.lock.utils.LockException;
 import com.auth0.authentication.ParameterBuilder;
 import com.auth0.authentication.result.Authentication;
@@ -177,6 +178,8 @@ public class DemoActivity extends AppCompatActivity implements View.OnClickListe
                 .withProviderResolver(new AuthProviderHandler())
                 .withSignUpFields(customFields)
                 .loginAfterSignUp(false)
+                .initialScreen(InitialScreen.FORGOT_PASSWORD)
+                .allowForgotPassword(true)
 //                .setDefaultDatabaseConnection("mfa-connection")
                 .usePKCE(true)
                 .closable(true)

--- a/lib/src/main/java/com/auth0/android/lock/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/Configuration.java
@@ -63,7 +63,7 @@ public class Configuration {
 
     private Application application;
 
-    private boolean allowSignIn;
+    private boolean allowLogIn;
     private boolean allowSignUp;
     private boolean allowForgotPassword;
     private boolean usernameRequired;
@@ -223,7 +223,7 @@ public class Configuration {
 
         if (getDefaultDatabaseConnection() != null) {
             //let user disable signIn only if connection have enabled it.
-            allowSignIn = options.allowSignIn();
+            allowLogIn = options.allowLogIn();
 
             //let user disable signUp only if connection have enabled it.
             allowSignUp = getDefaultDatabaseConnection().booleanForKey(SHOW_SIGNUP_KEY);
@@ -263,8 +263,8 @@ public class Configuration {
         return !connections.isEmpty() ? connections.get(0) : null;
     }
 
-    public boolean allowSignIn() {
-        return allowSignIn;
+    public boolean allowLogIn() {
+        return allowLogIn;
     }
 
     public boolean allowSignUp() {

--- a/lib/src/main/java/com/auth0/android/lock/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/Configuration.java
@@ -63,8 +63,9 @@ public class Configuration {
 
     private Application application;
 
-    private boolean signUpEnabled;
-    private boolean changePasswordEnabled;
+    private boolean allowSignIn;
+    private boolean allowSignUp;
+    private boolean allowForgotPassword;
     private boolean usernameRequired;
     @UsernameStyle
     private int usernameStyle;
@@ -221,16 +222,19 @@ public class Configuration {
         loginAfterSignUp = options.loginAfterSignUp();
 
         if (getDefaultDatabaseConnection() != null) {
-            //let user disable signUp only if connection have enabled it.
-            signUpEnabled = getDefaultDatabaseConnection().booleanForKey(SHOW_SIGNUP_KEY);
-            if (signUpEnabled && !options.allowSignUp()) {
-                signUpEnabled = false;
-            }
+            //let user disable signIn only if connection have enabled it.
+            allowSignIn = options.allowSignIn();
 
             //let user disable signUp only if connection have enabled it.
-            changePasswordEnabled = getDefaultDatabaseConnection().booleanForKey(SHOW_FORGOT_KEY);
-            if (changePasswordEnabled && !options.allowForgotPassword()) {
-                changePasswordEnabled = false;
+            allowSignUp = getDefaultDatabaseConnection().booleanForKey(SHOW_SIGNUP_KEY);
+            if (allowSignUp && !options.allowSignUp()) {
+                allowSignUp = false;
+            }
+
+            //let user disable password reset only if connection have enabled it.
+            allowForgotPassword = getDefaultDatabaseConnection().booleanForKey(SHOW_FORGOT_KEY);
+            if (allowForgotPassword && !options.allowForgotPassword()) {
+                allowForgotPassword = false;
             }
 
             usernameRequired = getDefaultDatabaseConnection().booleanForKey(REQUIRES_USERNAME_KEY);
@@ -259,12 +263,16 @@ public class Configuration {
         return !connections.isEmpty() ? connections.get(0) : null;
     }
 
-    public boolean isSignUpEnabled() {
-        return signUpEnabled;
+    public boolean allowSignIn() {
+        return allowSignIn;
     }
 
-    public boolean isChangePasswordEnabled() {
-        return changePasswordEnabled;
+    public boolean allowSignUp() {
+        return allowSignUp;
+    }
+
+    public boolean allowForgotPassword() {
+        return allowForgotPassword;
     }
 
     public boolean isUsernameRequired() {

--- a/lib/src/main/java/com/auth0/android/lock/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/Configuration.java
@@ -224,10 +224,13 @@ public class Configuration {
         usernameStyle = options.usernameStyle();
         loginAfterSignUp = options.loginAfterSignUp();
 
-        if (getDefaultDatabaseConnection() != null) {
+        final boolean dbAvailable = getDefaultDatabaseConnection() != null;
+        final boolean enterpriseAvailable = !getEnterpriseStrategies().isEmpty();
+        if (dbAvailable || enterpriseAvailable) {
             //let user disable logIn only if connection have enabled it.
             allowLogIn = options.allowLogIn();
-
+        }
+        if (dbAvailable) {
             //let user disable signUp only if connection have enabled it.
             allowSignUp = getDefaultDatabaseConnection().booleanForKey(SHOW_SIGNUP_KEY);
             if (allowSignUp && !options.allowSignUp()) {

--- a/lib/src/main/java/com/auth0/android/lock/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/Configuration.java
@@ -223,13 +223,13 @@ public class Configuration {
         if (getDefaultDatabaseConnection() != null) {
             //let user disable signUp only if connection have enabled it.
             signUpEnabled = getDefaultDatabaseConnection().booleanForKey(SHOW_SIGNUP_KEY);
-            if (signUpEnabled && !options.isSignUpEnabled()) {
+            if (signUpEnabled && !options.allowSignUp()) {
                 signUpEnabled = false;
             }
 
             //let user disable signUp only if connection have enabled it.
             changePasswordEnabled = getDefaultDatabaseConnection().booleanForKey(SHOW_FORGOT_KEY);
-            if (changePasswordEnabled && !options.isChangePasswordEnabled()) {
+            if (changePasswordEnabled && !options.allowForgotPassword()) {
                 changePasswordEnabled = false;
             }
 

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -298,7 +298,7 @@ public class Lock {
          * @return the current builder instance
          */
         public Builder allowSignIn(boolean allow) {
-            options.setAllowSignIn(allow);
+            options.setAllowLogIn(allow);
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -293,22 +293,32 @@ public class Lock {
         }
 
         /**
-         * Sign Up can be disabled locally, regardless the Dashboard configuration.
+         * Sign In can be enabled/disabled locally, regardless the Dashboard configuration.
          *
          * @return the current builder instance
          */
-        public Builder disableSignUp() {
-            options.setSignUpEnabled(false);
+        public Builder allowSignIn(boolean allow) {
+            options.setAllowSignIn(allow);
             return this;
         }
 
         /**
-         * Password change can be disabled locally, regardless the Dashboard configuration.
+         * Sign Up can be enabled/disabled locally, regardless the Dashboard configuration.
          *
          * @return the current builder instance
          */
-        public Builder disableChangePassword() {
-            options.setChangePasswordEnabled(false);
+        public Builder allowSignUp(boolean allow) {
+            options.setAllowSignUp(allow);
+            return this;
+        }
+
+        /**
+         * Password reset can be enabled/disabled locally, regardless the Dashboard configuration.
+         *
+         * @return the current builder instance
+         */
+        public Builder allowForgotPassword(boolean allow) {
+            options.setAllowForgotPassword(allow);
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -36,6 +36,7 @@ import android.util.Log;
 
 import com.auth0.Auth0;
 import com.auth0.android.lock.LockCallback.LockEvent;
+import com.auth0.android.lock.enums.InitialScreen;
 import com.auth0.android.lock.enums.UsernameStyle;
 import com.auth0.android.lock.provider.AuthProviderResolver;
 import com.auth0.android.lock.provider.ProviderResolverManager;
@@ -289,6 +290,17 @@ public class Lock {
          */
         public Builder withUsernameStyle(@UsernameStyle int style) {
             options.setUsernameStyle(style);
+            return this;
+        }
+
+        /**
+         * Decide which screen is going to show first when launching the Lock Activity.
+         *
+         * @param screen a valid InitialScreen.
+         * @return the current builder instance
+         */
+        public Builder initialScreen(@InitialScreen int screen) {
+            options.setInitialScreen(screen);
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/Options.java
@@ -53,8 +53,9 @@ class Options implements Parcelable {
     private boolean fullscreen;
     private int usernameStyle;
     private boolean useCodePasswordless;
-    private boolean signUpEnabled;
-    private boolean changePasswordEnabled;
+    private boolean allowSignIn;
+    private boolean allowSignUp;
+    private boolean allowForgotPassword;
     private boolean loginAfterSignUp;
     private String defaultDatabaseConnection;
     private List<String> connections;
@@ -64,8 +65,9 @@ class Options implements Parcelable {
 
     public Options() {
         usernameStyle = UsernameStyle.DEFAULT;
-        signUpEnabled = true;
-        changePasswordEnabled = true;
+        allowSignIn = true;
+        allowSignUp = true;
+        allowForgotPassword = true;
         loginAfterSignUp = true;
         useCodePasswordless = true;
         authenticationParameters = new HashMap<>();
@@ -79,8 +81,9 @@ class Options implements Parcelable {
         usePKCE = in.readByte() != WITHOUT_DATA;
         closable = in.readByte() != WITHOUT_DATA;
         fullscreen = in.readByte() != WITHOUT_DATA;
-        signUpEnabled = in.readByte() != WITHOUT_DATA;
-        changePasswordEnabled = in.readByte() != WITHOUT_DATA;
+        allowSignIn = in.readByte() != WITHOUT_DATA;
+        allowSignUp = in.readByte() != WITHOUT_DATA;
+        allowForgotPassword = in.readByte() != WITHOUT_DATA;
         loginAfterSignUp = in.readByte() != WITHOUT_DATA;
         useCodePasswordless = in.readByte() != WITHOUT_DATA;
         defaultDatabaseConnection = in.readString();
@@ -124,8 +127,9 @@ class Options implements Parcelable {
         dest.writeByte((byte) (usePKCE ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (closable ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (fullscreen ? HAS_DATA : WITHOUT_DATA));
-        dest.writeByte((byte) (signUpEnabled ? HAS_DATA : WITHOUT_DATA));
-        dest.writeByte((byte) (changePasswordEnabled ? HAS_DATA : WITHOUT_DATA));
+        dest.writeByte((byte) (allowSignIn ? HAS_DATA : WITHOUT_DATA));
+        dest.writeByte((byte) (allowSignUp ? HAS_DATA : WITHOUT_DATA));
+        dest.writeByte((byte) (allowForgotPassword ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (loginAfterSignUp ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (useCodePasswordless ? HAS_DATA : WITHOUT_DATA));
         dest.writeString(defaultDatabaseConnection);
@@ -221,20 +225,28 @@ class Options implements Parcelable {
         this.usernameStyle = usernameStyle;
     }
 
-    public boolean isSignUpEnabled() {
-        return signUpEnabled;
+    public void setAllowSignIn(boolean allowSignIn) {
+        this.allowSignIn = allowSignIn;
     }
 
-    public void setSignUpEnabled(boolean signUpEnabled) {
-        this.signUpEnabled = signUpEnabled;
+    public boolean allowSignIn() {
+        return allowSignIn;
     }
 
-    public boolean isChangePasswordEnabled() {
-        return changePasswordEnabled;
+    public boolean allowSignUp() {
+        return allowSignUp;
     }
 
-    public void setChangePasswordEnabled(boolean changePasswordEnabled) {
-        this.changePasswordEnabled = changePasswordEnabled;
+    public void setAllowSignUp(boolean allowSignUp) {
+        this.allowSignUp = allowSignUp;
+    }
+
+    public void setAllowForgotPassword(boolean allowForgotPassword) {
+        this.allowForgotPassword = allowForgotPassword;
+    }
+
+    public boolean allowForgotPassword() {
+        return allowForgotPassword;
     }
 
     public String getDefaultDatabaseConnection() {

--- a/lib/src/main/java/com/auth0/android/lock/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/Options.java
@@ -53,7 +53,7 @@ class Options implements Parcelable {
     private boolean fullscreen;
     private int usernameStyle;
     private boolean useCodePasswordless;
-    private boolean allowSignIn;
+    private boolean allowLogIn;
     private boolean allowSignUp;
     private boolean allowForgotPassword;
     private boolean loginAfterSignUp;
@@ -65,7 +65,7 @@ class Options implements Parcelable {
 
     public Options() {
         usernameStyle = UsernameStyle.DEFAULT;
-        allowSignIn = true;
+        allowLogIn = true;
         allowSignUp = true;
         allowForgotPassword = true;
         loginAfterSignUp = true;
@@ -81,7 +81,7 @@ class Options implements Parcelable {
         usePKCE = in.readByte() != WITHOUT_DATA;
         closable = in.readByte() != WITHOUT_DATA;
         fullscreen = in.readByte() != WITHOUT_DATA;
-        allowSignIn = in.readByte() != WITHOUT_DATA;
+        allowLogIn = in.readByte() != WITHOUT_DATA;
         allowSignUp = in.readByte() != WITHOUT_DATA;
         allowForgotPassword = in.readByte() != WITHOUT_DATA;
         loginAfterSignUp = in.readByte() != WITHOUT_DATA;
@@ -127,7 +127,7 @@ class Options implements Parcelable {
         dest.writeByte((byte) (usePKCE ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (closable ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (fullscreen ? HAS_DATA : WITHOUT_DATA));
-        dest.writeByte((byte) (allowSignIn ? HAS_DATA : WITHOUT_DATA));
+        dest.writeByte((byte) (allowLogIn ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (allowSignUp ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (allowForgotPassword ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (loginAfterSignUp ? HAS_DATA : WITHOUT_DATA));
@@ -225,12 +225,12 @@ class Options implements Parcelable {
         this.usernameStyle = usernameStyle;
     }
 
-    public void setAllowSignIn(boolean allowSignIn) {
-        this.allowSignIn = allowSignIn;
+    public void setAllowLogIn(boolean allowLogIn) {
+        this.allowLogIn = allowLogIn;
     }
 
-    public boolean allowSignIn() {
-        return allowSignIn;
+    public boolean allowLogIn() {
+        return allowLogIn;
     }
 
     public boolean allowSignUp() {

--- a/lib/src/main/java/com/auth0/android/lock/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/Options.java
@@ -31,6 +31,7 @@ import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
 import com.auth0.Auth0;
+import com.auth0.android.lock.enums.InitialScreen;
 import com.auth0.android.lock.enums.UsernameStyle;
 import com.auth0.authentication.AuthenticationAPIClient;
 
@@ -62,9 +63,11 @@ class Options implements Parcelable {
     private List<String> enterpriseConnectionsUsingWebForm;
     private HashMap<String, Object> authenticationParameters;
     private List<CustomField> customFields;
+    private int initialScreen;
 
     public Options() {
         usernameStyle = UsernameStyle.DEFAULT;
+        initialScreen = InitialScreen.LOG_IN;
         allowLogIn = true;
         allowSignUp = true;
         allowForgotPassword = true;
@@ -88,6 +91,7 @@ class Options implements Parcelable {
         useCodePasswordless = in.readByte() != WITHOUT_DATA;
         defaultDatabaseConnection = in.readString();
         usernameStyle = in.readInt();
+        initialScreen = in.readInt();
         if (in.readByte() == HAS_DATA) {
             connections = new ArrayList<>();
             in.readList(connections, String.class.getClassLoader());
@@ -134,6 +138,7 @@ class Options implements Parcelable {
         dest.writeByte((byte) (useCodePasswordless ? HAS_DATA : WITHOUT_DATA));
         dest.writeString(defaultDatabaseConnection);
         dest.writeInt(usernameStyle);
+        dest.writeInt(initialScreen);
         if (connections == null) {
             dest.writeByte((byte) (WITHOUT_DATA));
         } else {
@@ -315,5 +320,14 @@ class Options implements Parcelable {
     @NonNull
     public List<CustomField> getCustomFields() {
         return customFields;
+    }
+
+    public void setInitialScreen(@InitialScreen int screen) {
+        this.initialScreen = screen;
+    }
+
+    @InitialScreen
+    public int initialScreen() {
+        return initialScreen;
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/enums/InitialScreen.java
+++ b/lib/src/main/java/com/auth0/android/lock/enums/InitialScreen.java
@@ -1,0 +1,42 @@
+/*
+ * InitialScreen.java
+ *
+ * Copyright (c) 2016 Auth0 (http://auth0.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.auth0.android.lock.enums;
+
+import android.support.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import static com.auth0.android.lock.enums.InitialScreen.FORGOT_PASSWORD;
+import static com.auth0.android.lock.enums.InitialScreen.LOG_IN;
+import static com.auth0.android.lock.enums.InitialScreen.SIGN_UP;
+
+@IntDef({LOG_IN, SIGN_UP, FORGOT_PASSWORD})
+@Retention(RetentionPolicy.SOURCE)
+public @interface InitialScreen {
+    int LOG_IN = 0;
+    int SIGN_UP = 1;
+    int FORGOT_PASSWORD = 2;
+}

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -157,7 +157,7 @@ public class ClassicLockView extends PercentRelativeLayout implements View.OnCli
             actionButton.setVisibility(GONE);
         }
 
-        if (getConfiguration().allowForgotPassword() && getConfiguration().getInitialScreen() == InitialScreen.FORGOT_PASSWORD) {
+        if (configuration.allowForgotPassword() && configuration.getInitialScreen() == InitialScreen.FORGOT_PASSWORD) {
             showChangePasswordForm(true);
         }
     }
@@ -272,9 +272,12 @@ public class ClassicLockView extends PercentRelativeLayout implements View.OnCli
      */
     public boolean onBackPressed() {
         if (subForm != null) {
-            showSignUpTerms(subForm instanceof CustomFieldsFormView);
-            removeSubForm();
-            return true;
+            final boolean shouldDisplayPreviousForm = configuration.allowLogIn() || configuration.allowSignUp();
+            if (shouldDisplayPreviousForm) {
+                showSignUpTerms(subForm instanceof CustomFieldsFormView);
+                removeSubForm();
+                return true;
+            }
         }
 
         return formLayout != null && formLayout.onBackPressed();

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -40,6 +40,7 @@ import android.widget.TextView;
 
 import com.auth0.android.lock.Configuration;
 import com.auth0.android.lock.R;
+import com.auth0.android.lock.enums.InitialScreen;
 import com.auth0.android.lock.events.DatabaseLoginEvent;
 import com.auth0.android.lock.events.DatabaseSignUpEvent;
 import com.auth0.android.lock.events.FetchApplicationEvent;
@@ -154,6 +155,10 @@ public class ClassicLockView extends PercentRelativeLayout implements View.OnCli
         boolean showEnterprise = !configuration.getEnterpriseStrategies().isEmpty();
         if (!showDatabase && !showEnterprise) {
             actionButton.setVisibility(GONE);
+        }
+
+        if (getConfiguration().allowForgotPassword() && getConfiguration().getInitialScreen() == InitialScreen.FORGOT_PASSWORD) {
+            showChangePasswordForm(true);
         }
     }
 

--- a/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
@@ -76,7 +76,7 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
         boolean showSocial = !lockWidget.getConfiguration().getSocialStrategies().isEmpty();
         showDatabase = lockWidget.getConfiguration().getDefaultDatabaseConnection() != null;
         showEnterprise = !lockWidget.getConfiguration().getEnterpriseStrategies().isEmpty();
-        boolean showModeSelection = showDatabase && lockWidget.getConfiguration().isSignUpEnabled();
+        boolean showModeSelection = showDatabase && lockWidget.getConfiguration().allowSignUp();
 
         int verticalMargin = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_vertical_margin_field);
         int horizontalMargin = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_horizontal_margin);

--- a/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
@@ -76,7 +76,7 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
         boolean showSocial = !lockWidget.getConfiguration().getSocialStrategies().isEmpty();
         showDatabase = lockWidget.getConfiguration().getDefaultDatabaseConnection() != null;
         showEnterprise = !lockWidget.getConfiguration().getEnterpriseStrategies().isEmpty();
-        boolean showModeSelection = showDatabase && lockWidget.getConfiguration().allowSignUp();
+        boolean showModeSelection = lockWidget.getConfiguration().allowLogIn() && lockWidget.getConfiguration().allowSignUp();
 
         int verticalMargin = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_vertical_margin_field);
         int horizontalMargin = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_horizontal_margin);
@@ -106,7 +106,11 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
                 addSeparator();
             }
         }
-        changeFormMode(ModeSelectionView.Mode.LOG_IN);
+        if (lockWidget.getConfiguration().allowLogIn()) {
+            changeFormMode(ModeSelectionView.Mode.LOG_IN);
+        } else if (lockWidget.getConfiguration().allowSignUp()) {
+            changeFormMode(ModeSelectionView.Mode.SIGN_UP);
+        }
     }
 
     private void addSocialLayout(boolean smallButtons) {

--- a/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
@@ -38,6 +38,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.auth0.android.lock.R;
+import com.auth0.android.lock.enums.InitialScreen;
 import com.auth0.android.lock.events.DatabaseSignUpEvent;
 import com.auth0.android.lock.views.interfaces.LockWidgetForm;
 
@@ -106,10 +107,21 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
                 addSeparator();
             }
         }
-        if (lockWidget.getConfiguration().allowLogIn()) {
-            changeFormMode(ModeSelectionView.Mode.LOG_IN);
-        } else if (lockWidget.getConfiguration().allowSignUp()) {
-            changeFormMode(ModeSelectionView.Mode.SIGN_UP);
+        displayInitialScreen();
+    }
+
+    private void displayInitialScreen() {
+        if (!showDatabase && !showEnterprise) {
+            return;
+        }
+        int initialScreen = lockWidget.getConfiguration().getInitialScreen();
+        switch (initialScreen) {
+            case InitialScreen.FORGOT_PASSWORD:
+            case InitialScreen.LOG_IN:
+                changeFormMode(ModeSelectionView.Mode.LOG_IN);
+            case InitialScreen.SIGN_UP:
+                changeFormMode(ModeSelectionView.Mode.SIGN_UP);
+                break;
         }
     }
 

--- a/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
@@ -85,7 +85,7 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
         usernameInput.setDataType(ValidatedInputView.DataType.USERNAME);
 
         fallbackToDatabase = lockWidget.getConfiguration().getDefaultDatabaseConnection() != null;
-        changePasswordEnabled = fallbackToDatabase && lockWidget.getConfiguration().isChangePasswordEnabled();
+        changePasswordEnabled = fallbackToDatabase && lockWidget.getConfiguration().allowForgotPassword();
         changePasswordBtn.setVisibility(changePasswordEnabled ? VISIBLE : GONE);
         changePasswordBtn.setOnClickListener(new OnClickListener() {
             @Override

--- a/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
@@ -147,6 +147,62 @@ public class ConfigurationTest {
         assertThat(configuration.getExtraSignUpFields(), contains(options.getCustomFields().toArray()));
     }
 
+    @Test
+    public void shouldSetCorrectInitialScreenIfLogInIsDisabled() throws Exception {
+        options.setConnections(Collections.singletonList(USERNAME_PASSWORD_AUTHENTICATION));
+        options.setAllowLogIn(false);
+        options.setAllowSignUp(true);
+        options.setAllowForgotPassword(true);
+        configuration = new Configuration(application, options);
+
+        assertThat(configuration.getInitialScreen(), is(InitialScreen.SIGN_UP));
+
+        options.setConnections(Collections.singletonList(USERNAME_PASSWORD_AUTHENTICATION));
+        options.setAllowLogIn(false);
+        options.setAllowSignUp(false);
+        options.setAllowForgotPassword(true);
+        configuration = new Configuration(application, options);
+
+        assertThat(configuration.getInitialScreen(), is(InitialScreen.FORGOT_PASSWORD));
+    }
+
+    @Test
+    public void shouldSetCorrectInitialScreenIfSignUpIsDisabled() throws Exception {
+        options.setConnections(Collections.singletonList(USERNAME_PASSWORD_AUTHENTICATION));
+        options.setAllowLogIn(true);
+        options.setAllowSignUp(false);
+        options.setAllowForgotPassword(true);
+        configuration = new Configuration(application, options);
+
+        assertThat(configuration.getInitialScreen(), is(InitialScreen.LOG_IN));
+
+        options.setConnections(Collections.singletonList(USERNAME_PASSWORD_AUTHENTICATION));
+        options.setAllowLogIn(false);
+        options.setAllowSignUp(false);
+        options.setAllowForgotPassword(true);
+        configuration = new Configuration(application, options);
+
+        assertThat(configuration.getInitialScreen(), is(InitialScreen.FORGOT_PASSWORD));
+    }
+
+    @Test
+    public void shouldSetCorrectInitialScreenIfForgotPasswordIsDisabled() throws Exception {
+        options.setConnections(Collections.singletonList(USERNAME_PASSWORD_AUTHENTICATION));
+        options.setAllowLogIn(true);
+        options.setAllowSignUp(false);
+        options.setAllowForgotPassword(false);
+        configuration = new Configuration(application, options);
+
+        assertThat(configuration.getInitialScreen(), is(InitialScreen.LOG_IN));
+
+        options.setConnections(Collections.singletonList(USERNAME_PASSWORD_AUTHENTICATION));
+        options.setAllowLogIn(false);
+        options.setAllowSignUp(true);
+        options.setAllowForgotPassword(false);
+        configuration = new Configuration(application, options);
+
+        assertThat(configuration.getInitialScreen(), is(InitialScreen.SIGN_UP));
+    }
 
     @Test
     public void shouldPreferPasswordlessEmailOverSMSWhenBothAvailable() throws Exception {

--- a/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
@@ -100,7 +100,7 @@ public class ConfigurationTest {
     public void shouldKeepApplicationDefaultsIfOptionsAreNotModified() throws Exception {
         configuration = new Configuration(application, options);
         assertThat(configuration.isUsernameRequired(), is(false));
-        assertThat(configuration.allowSignIn(), is(true));
+        assertThat(configuration.allowLogIn(), is(true));
         assertThat(configuration.allowSignUp(), is(true));
         assertThat(configuration.allowForgotPassword(), is(true));
         assertThat(configuration.loginAfterSignUp(), is(true));
@@ -111,14 +111,14 @@ public class ConfigurationTest {
     @Test
     public void shouldMergeApplicationWithOptionsIfDefaultDatabaseExists() throws Exception {
         options.setConnections(Collections.singletonList(USERNAME_PASSWORD_AUTHENTICATION));
-        options.setAllowSignIn(false);
+        options.setAllowLogIn(false);
         options.setAllowSignUp(false);
         options.setAllowForgotPassword(false);
         options.setLoginAfterSignUp(false);
         options.setUsernameStyle(UsernameStyle.USERNAME);
         configuration = new Configuration(application, options);
         assertThat(configuration.isUsernameRequired(), is(false));
-        assertThat(configuration.allowSignIn(), is(false));
+        assertThat(configuration.allowLogIn(), is(false));
         assertThat(configuration.allowSignUp(), is(false));
         assertThat(configuration.allowForgotPassword(), is(false));
         assertThat(configuration.loginAfterSignUp(), is(false));

--- a/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
@@ -25,6 +25,7 @@
 package com.auth0.android.lock;
 
 import com.auth0.android.lock.CustomField.FieldType;
+import com.auth0.android.lock.enums.InitialScreen;
 import com.auth0.android.lock.enums.PasswordlessMode;
 import com.auth0.android.lock.enums.UsernameStyle;
 import com.auth0.android.lock.utils.Application;
@@ -105,6 +106,7 @@ public class ConfigurationTest {
         assertThat(configuration.allowForgotPassword(), is(true));
         assertThat(configuration.loginAfterSignUp(), is(true));
         assertThat(configuration.getUsernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
+        assertThat(configuration.getInitialScreen(), is(equalTo(InitialScreen.LOG_IN)));
         assertThat(configuration.hasExtraFields(), is(false));
     }
 

--- a/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
@@ -100,8 +100,9 @@ public class ConfigurationTest {
     public void shouldKeepApplicationDefaultsIfOptionsAreNotModified() throws Exception {
         configuration = new Configuration(application, options);
         assertThat(configuration.isUsernameRequired(), is(false));
-        assertThat(configuration.isSignUpEnabled(), is(true));
-        assertThat(configuration.isChangePasswordEnabled(), is(true));
+        assertThat(configuration.allowSignIn(), is(true));
+        assertThat(configuration.allowSignUp(), is(true));
+        assertThat(configuration.allowForgotPassword(), is(true));
         assertThat(configuration.loginAfterSignUp(), is(true));
         assertThat(configuration.getUsernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
         assertThat(configuration.hasExtraFields(), is(false));
@@ -110,14 +111,16 @@ public class ConfigurationTest {
     @Test
     public void shouldMergeApplicationWithOptionsIfDefaultDatabaseExists() throws Exception {
         options.setConnections(Collections.singletonList(USERNAME_PASSWORD_AUTHENTICATION));
+        options.setAllowSignIn(false);
         options.setAllowSignUp(false);
         options.setAllowForgotPassword(false);
         options.setLoginAfterSignUp(false);
         options.setUsernameStyle(UsernameStyle.USERNAME);
         configuration = new Configuration(application, options);
         assertThat(configuration.isUsernameRequired(), is(false));
-        assertThat(configuration.isSignUpEnabled(), is(false));
-        assertThat(configuration.isChangePasswordEnabled(), is(false));
+        assertThat(configuration.allowSignIn(), is(false));
+        assertThat(configuration.allowSignUp(), is(false));
+        assertThat(configuration.allowForgotPassword(), is(false));
         assertThat(configuration.loginAfterSignUp(), is(false));
         assertThat(configuration.getUsernameStyle(), is(equalTo(UsernameStyle.USERNAME)));
         assertThat(configuration.hasExtraFields(), is(false));
@@ -129,8 +132,8 @@ public class ConfigurationTest {
         options.setAllowSignUp(true);
         options.setAllowForgotPassword(true);
         configuration = new Configuration(application, options);
-        assertThat(configuration.isSignUpEnabled(), is(false));
-        assertThat(configuration.isChangePasswordEnabled(), is(false));
+        assertThat(configuration.allowSignUp(), is(false));
+        assertThat(configuration.allowForgotPassword(), is(false));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
@@ -110,8 +110,8 @@ public class ConfigurationTest {
     @Test
     public void shouldMergeApplicationWithOptionsIfDefaultDatabaseExists() throws Exception {
         options.setConnections(Collections.singletonList(USERNAME_PASSWORD_AUTHENTICATION));
-        options.setSignUpEnabled(false);
-        options.setChangePasswordEnabled(false);
+        options.setAllowSignUp(false);
+        options.setAllowForgotPassword(false);
         options.setLoginAfterSignUp(false);
         options.setUsernameStyle(UsernameStyle.USERNAME);
         configuration = new Configuration(application, options);
@@ -126,8 +126,8 @@ public class ConfigurationTest {
     @Test
     public void shouldNotMergeApplicationWithOptionsIfApplicationIsRestrictive() throws Exception {
         options.setConnections(Collections.singletonList(RESTRICTIVE_DATABASE));
-        options.setSignUpEnabled(true);
-        options.setChangePasswordEnabled(true);
+        options.setAllowSignUp(true);
+        options.setAllowForgotPassword(true);
         configuration = new Configuration(application, options);
         assertThat(configuration.isSignUpEnabled(), is(false));
         assertThat(configuration.isChangePasswordEnabled(), is(false));

--- a/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
@@ -150,44 +150,31 @@ public class ConfigurationTest {
     @Test
     public void shouldSetCorrectInitialScreenIfLogInIsDisabled() throws Exception {
         options.setConnections(Collections.singletonList(USERNAME_PASSWORD_AUTHENTICATION));
+        options.setInitialScreen(InitialScreen.LOG_IN);
         options.setAllowLogIn(false);
         options.setAllowSignUp(true);
         options.setAllowForgotPassword(true);
         configuration = new Configuration(application, options);
 
         assertThat(configuration.getInitialScreen(), is(InitialScreen.SIGN_UP));
-
-        options.setConnections(Collections.singletonList(USERNAME_PASSWORD_AUTHENTICATION));
-        options.setAllowLogIn(false);
-        options.setAllowSignUp(false);
-        options.setAllowForgotPassword(true);
-        configuration = new Configuration(application, options);
-
-        assertThat(configuration.getInitialScreen(), is(InitialScreen.FORGOT_PASSWORD));
     }
 
     @Test
     public void shouldSetCorrectInitialScreenIfSignUpIsDisabled() throws Exception {
         options.setConnections(Collections.singletonList(USERNAME_PASSWORD_AUTHENTICATION));
+        options.setInitialScreen(InitialScreen.SIGN_UP);
         options.setAllowLogIn(true);
         options.setAllowSignUp(false);
         options.setAllowForgotPassword(true);
         configuration = new Configuration(application, options);
 
         assertThat(configuration.getInitialScreen(), is(InitialScreen.LOG_IN));
-
-        options.setConnections(Collections.singletonList(USERNAME_PASSWORD_AUTHENTICATION));
-        options.setAllowLogIn(false);
-        options.setAllowSignUp(false);
-        options.setAllowForgotPassword(true);
-        configuration = new Configuration(application, options);
-
-        assertThat(configuration.getInitialScreen(), is(InitialScreen.FORGOT_PASSWORD));
     }
 
     @Test
     public void shouldSetCorrectInitialScreenIfForgotPasswordIsDisabled() throws Exception {
         options.setConnections(Collections.singletonList(USERNAME_PASSWORD_AUTHENTICATION));
+        options.setInitialScreen(InitialScreen.FORGOT_PASSWORD);
         options.setAllowLogIn(true);
         options.setAllowSignUp(false);
         options.setAllowForgotPassword(false);
@@ -196,6 +183,7 @@ public class ConfigurationTest {
         assertThat(configuration.getInitialScreen(), is(InitialScreen.LOG_IN));
 
         options.setConnections(Collections.singletonList(USERNAME_PASSWORD_AUTHENTICATION));
+        options.setInitialScreen(InitialScreen.FORGOT_PASSWORD);
         options.setAllowLogIn(false);
         options.setAllowSignUp(true);
         options.setAllowForgotPassword(false);

--- a/lib/src/test/java/com/auth0/android/lock/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/OptionsTest.java
@@ -6,6 +6,7 @@ import android.support.v7.appcompat.BuildConfig;
 
 import com.auth0.Auth0;
 import com.auth0.android.lock.CustomField.FieldType;
+import com.auth0.android.lock.enums.InitialScreen;
 import com.auth0.android.lock.enums.UsernameStyle;
 
 import org.junit.Before;
@@ -121,20 +122,6 @@ public class OptionsTest {
     }
 
     @Test
-    public void shouldUseEmailUsernameStyle() {
-        Options options = new Options();
-        options.setAccount(auth0);
-        options.setUsernameStyle(UsernameStyle.EMAIL);
-
-        Parcel parcel = Parcel.obtain();
-        options.writeToParcel(parcel, 0);
-        parcel.setDataPosition(0);
-
-        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(options.usernameStyle(), is(equalTo(parceledOptions.usernameStyle())));
-    }
-
-    @Test
     public void shouldNotLoginAfterSignUp() {
         Options options = new Options();
         options.setAccount(auth0);
@@ -146,6 +133,62 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
+    }
+
+    @Test
+    public void shouldChangeInitialScreenToLogIn() {
+        Options options = new Options();
+        options.setAccount(auth0);
+        options.setInitialScreen(InitialScreen.LOG_IN);
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.initialScreen(), is(equalTo(parceledOptions.initialScreen())));
+    }
+
+    @Test
+    public void shouldChangeInitialScreenToSignUp() {
+        Options options = new Options();
+        options.setAccount(auth0);
+        options.setInitialScreen(InitialScreen.SIGN_UP);
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.initialScreen(), is(equalTo(parceledOptions.initialScreen())));
+    }
+
+    @Test
+    public void shouldChangeInitialScreenToForgotPassword() {
+        Options options = new Options();
+        options.setAccount(auth0);
+        options.setInitialScreen(InitialScreen.FORGOT_PASSWORD);
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.initialScreen(), is(equalTo(parceledOptions.initialScreen())));
+    }
+
+    @Test
+    public void shouldUseEmailUsernameStyle() {
+        Options options = new Options();
+        options.setAccount(auth0);
+        options.setUsernameStyle(UsernameStyle.EMAIL);
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.usernameStyle(), is(equalTo(parceledOptions.usernameStyle())));
     }
 
     @Test
@@ -407,6 +450,7 @@ public class OptionsTest {
         options.setUseBrowser(true);
         options.setUsePKCE(true);
         options.setUsernameStyle(UsernameStyle.EMAIL);
+        options.setInitialScreen(InitialScreen.LOG_IN);
         options.setAllowLogIn(true);
         options.setAllowSignUp(true);
         options.setAllowForgotPassword(true);
@@ -424,6 +468,7 @@ public class OptionsTest {
         assertThat(options.useBrowser(), is(equalTo(parceledOptions.useBrowser())));
         assertThat(options.usePKCE(), is(equalTo(parceledOptions.usePKCE())));
         assertThat(options.usernameStyle(), is(equalTo(parceledOptions.usernameStyle())));
+        assertThat(options.initialScreen(), is(equalTo(parceledOptions.initialScreen())));
         assertThat(options.allowLogIn(), is(equalTo(parceledOptions.allowLogIn())));
         assertThat(options.allowSignUp(), is(equalTo(parceledOptions.allowSignUp())));
         assertThat(options.allowForgotPassword(), is(equalTo(parceledOptions.allowForgotPassword())));
@@ -440,6 +485,7 @@ public class OptionsTest {
         options.setUseBrowser(false);
         options.setUsePKCE(false);
         options.setUsernameStyle(UsernameStyle.USERNAME);
+        options.setInitialScreen(InitialScreen.SIGN_UP);
         options.setAllowLogIn(false);
         options.setAllowSignUp(false);
         options.setAllowForgotPassword(false);
@@ -456,6 +502,7 @@ public class OptionsTest {
         assertThat(options.useBrowser(), is(equalTo(parceledOptions.useBrowser())));
         assertThat(options.usePKCE(), is(equalTo(parceledOptions.usePKCE())));
         assertThat(options.usernameStyle(), is(equalTo(parceledOptions.usernameStyle())));
+        assertThat(options.initialScreen(), is(equalTo(parceledOptions.initialScreen())));
         assertThat(options.allowLogIn(), is(equalTo(parceledOptions.allowLogIn())));
         assertThat(options.allowSignUp(), is(equalTo(parceledOptions.allowSignUp())));
         assertThat(options.allowForgotPassword(), is(equalTo(parceledOptions.allowForgotPassword())));

--- a/lib/src/test/java/com/auth0/android/lock/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/OptionsTest.java
@@ -177,31 +177,45 @@ public class OptionsTest {
     }
 
     @Test
-    public void shouldBeSignUpEnabled() {
+    public void shouldAllowSignIn() {
         Options options = new Options();
         options.setAccount(auth0);
-        options.setSignUpEnabled(true);
+        options.setAllowSignIn(true);
 
         Parcel parcel = Parcel.obtain();
         options.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(options.isSignUpEnabled(), is(equalTo(parceledOptions.isSignUpEnabled())));
+        assertThat(options.allowSignIn(), is(equalTo(parceledOptions.allowSignIn())));
     }
 
     @Test
-    public void shouldBeChangePasswordEnabled() {
+    public void shouldAllowSignUp() {
         Options options = new Options();
         options.setAccount(auth0);
-        options.setChangePasswordEnabled(true);
+        options.setAllowSignUp(true);
 
         Parcel parcel = Parcel.obtain();
         options.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(options.isChangePasswordEnabled(), is(equalTo(parceledOptions.isChangePasswordEnabled())));
+        assertThat(options.allowSignUp(), is(equalTo(parceledOptions.allowSignUp())));
+    }
+
+    @Test
+    public void shouldAllowForgotPassword() {
+        Options options = new Options();
+        options.setAccount(auth0);
+        options.setAllowForgotPassword(true);
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.allowForgotPassword(), is(equalTo(parceledOptions.allowForgotPassword())));
     }
 
     @Test
@@ -376,8 +390,9 @@ public class OptionsTest {
         assertTrue(options != parceledOptions); //assure correct Parcelable object testing
         assertThat(options.useBrowser(), is(false));
         assertThat(options.usePKCE(), is(false));
-        assertThat(options.isSignUpEnabled(), is(true));
-        assertThat(options.isChangePasswordEnabled(), is(true));
+        assertThat(options.allowSignIn(), is(true));
+        assertThat(options.allowSignUp(), is(true));
+        assertThat(options.allowForgotPassword(), is(true));
         assertThat(options.loginAfterSignUp(), is(true));
         assertThat(options.useCodePasswordless(), is(true));
     }
@@ -388,13 +403,14 @@ public class OptionsTest {
         Options options = new Options();
         options.setAccount(auth0);
 
-        options.setChangePasswordEnabled(true);
-        options.setClosable(true);
         options.setFullscreen(true);
         options.setUseBrowser(true);
         options.setUsePKCE(true);
         options.setUsernameStyle(UsernameStyle.EMAIL);
-        options.setSignUpEnabled(true);
+        options.setAllowSignIn(true);
+        options.setAllowSignUp(true);
+        options.setAllowForgotPassword(true);
+        options.setClosable(true);
         options.setLoginAfterSignUp(true);
 
 
@@ -403,13 +419,14 @@ public class OptionsTest {
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(options.isChangePasswordEnabled(), is(equalTo(parceledOptions.isChangePasswordEnabled())));
         assertThat(options.isClosable(), is(equalTo(parceledOptions.isClosable())));
         assertThat(options.isFullscreen(), is(equalTo(parceledOptions.isFullscreen())));
         assertThat(options.useBrowser(), is(equalTo(parceledOptions.useBrowser())));
         assertThat(options.usePKCE(), is(equalTo(parceledOptions.usePKCE())));
         assertThat(options.usernameStyle(), is(equalTo(parceledOptions.usernameStyle())));
-        assertThat(options.isSignUpEnabled(), is(equalTo(parceledOptions.isSignUpEnabled())));
+        assertThat(options.allowSignIn(), is(equalTo(parceledOptions.allowSignIn())));
+        assertThat(options.allowSignUp(), is(equalTo(parceledOptions.allowSignUp())));
+        assertThat(options.allowForgotPassword(), is(equalTo(parceledOptions.allowForgotPassword())));
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
     }
 
@@ -418,13 +435,14 @@ public class OptionsTest {
         Options options = new Options();
         options.setAccount(auth0);
 
-        options.setChangePasswordEnabled(false);
         options.setClosable(false);
         options.setFullscreen(false);
         options.setUseBrowser(false);
         options.setUsePKCE(false);
         options.setUsernameStyle(UsernameStyle.USERNAME);
-        options.setSignUpEnabled(false);
+        options.setAllowSignIn(false);
+        options.setAllowSignUp(false);
+        options.setAllowForgotPassword(false);
         options.setLoginAfterSignUp(false);
 
 
@@ -433,13 +451,14 @@ public class OptionsTest {
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(options.isChangePasswordEnabled(), is(equalTo(parceledOptions.isChangePasswordEnabled())));
         assertThat(options.isClosable(), is(equalTo(parceledOptions.isClosable())));
         assertThat(options.isFullscreen(), is(equalTo(parceledOptions.isFullscreen())));
         assertThat(options.useBrowser(), is(equalTo(parceledOptions.useBrowser())));
         assertThat(options.usePKCE(), is(equalTo(parceledOptions.usePKCE())));
         assertThat(options.usernameStyle(), is(equalTo(parceledOptions.usernameStyle())));
-        assertThat(options.isSignUpEnabled(), is(equalTo(parceledOptions.isSignUpEnabled())));
+        assertThat(options.allowSignIn(), is(equalTo(parceledOptions.allowSignIn())));
+        assertThat(options.allowSignUp(), is(equalTo(parceledOptions.allowSignUp())));
+        assertThat(options.allowForgotPassword(), is(equalTo(parceledOptions.allowForgotPassword())));
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
     }
 

--- a/lib/src/test/java/com/auth0/android/lock/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/OptionsTest.java
@@ -177,17 +177,17 @@ public class OptionsTest {
     }
 
     @Test
-    public void shouldAllowSignIn() {
+    public void shouldAllowLogIn() {
         Options options = new Options();
         options.setAccount(auth0);
-        options.setAllowSignIn(true);
+        options.setAllowLogIn(true);
 
         Parcel parcel = Parcel.obtain();
         options.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(options.allowSignIn(), is(equalTo(parceledOptions.allowSignIn())));
+        assertThat(options.allowLogIn(), is(equalTo(parceledOptions.allowLogIn())));
     }
 
     @Test
@@ -390,7 +390,7 @@ public class OptionsTest {
         assertTrue(options != parceledOptions); //assure correct Parcelable object testing
         assertThat(options.useBrowser(), is(false));
         assertThat(options.usePKCE(), is(false));
-        assertThat(options.allowSignIn(), is(true));
+        assertThat(options.allowLogIn(), is(true));
         assertThat(options.allowSignUp(), is(true));
         assertThat(options.allowForgotPassword(), is(true));
         assertThat(options.loginAfterSignUp(), is(true));
@@ -407,7 +407,7 @@ public class OptionsTest {
         options.setUseBrowser(true);
         options.setUsePKCE(true);
         options.setUsernameStyle(UsernameStyle.EMAIL);
-        options.setAllowSignIn(true);
+        options.setAllowLogIn(true);
         options.setAllowSignUp(true);
         options.setAllowForgotPassword(true);
         options.setClosable(true);
@@ -424,7 +424,7 @@ public class OptionsTest {
         assertThat(options.useBrowser(), is(equalTo(parceledOptions.useBrowser())));
         assertThat(options.usePKCE(), is(equalTo(parceledOptions.usePKCE())));
         assertThat(options.usernameStyle(), is(equalTo(parceledOptions.usernameStyle())));
-        assertThat(options.allowSignIn(), is(equalTo(parceledOptions.allowSignIn())));
+        assertThat(options.allowLogIn(), is(equalTo(parceledOptions.allowLogIn())));
         assertThat(options.allowSignUp(), is(equalTo(parceledOptions.allowSignUp())));
         assertThat(options.allowForgotPassword(), is(equalTo(parceledOptions.allowForgotPassword())));
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
@@ -440,7 +440,7 @@ public class OptionsTest {
         options.setUseBrowser(false);
         options.setUsePKCE(false);
         options.setUsernameStyle(UsernameStyle.USERNAME);
-        options.setAllowSignIn(false);
+        options.setAllowLogIn(false);
         options.setAllowSignUp(false);
         options.setAllowForgotPassword(false);
         options.setLoginAfterSignUp(false);
@@ -456,7 +456,7 @@ public class OptionsTest {
         assertThat(options.useBrowser(), is(equalTo(parceledOptions.useBrowser())));
         assertThat(options.usePKCE(), is(equalTo(parceledOptions.usePKCE())));
         assertThat(options.usernameStyle(), is(equalTo(parceledOptions.usernameStyle())));
-        assertThat(options.allowSignIn(), is(equalTo(parceledOptions.allowSignIn())));
+        assertThat(options.allowLogIn(), is(equalTo(parceledOptions.allowLogIn())));
         assertThat(options.allowSignUp(), is(equalTo(parceledOptions.allowSignUp())));
         assertThat(options.allowForgotPassword(), is(equalTo(parceledOptions.allowForgotPassword())));
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));


### PR DESCRIPTION
User can skip the logIn/signUp forms and show only the *Forgot password* form.
```java
lock = Lock.newBuilder(auth0, callback)
                .initialScreen(InitialScreen.FORGOT_PASSWORD)
                .allowForgotPassword(true)
                .allowSignIn(false)
                .allowSignUp(false)
```

Or show only the *Sign Up* form.

```java
lock = Lock.newBuilder(auth0, callback)
                .allowSignIn(false)
                .allowSignUp(true)
```

or equivalent 

```java
lock = Lock.newBuilder(auth0, callback)
                .allowSignIn(false)
                .initialScreen(InitialScreen.SIGN_UP)
```

Default values for `allow....` are all `true`. In the case of `ForgotPassword`, the database connection needs to have this enabled on the dashboard first.