### PR TITLE
Allow to specify the Social Button Style

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/Configuration.java
@@ -30,6 +30,7 @@ import android.util.Log;
 
 import com.auth0.android.lock.enums.InitialScreen;
 import com.auth0.android.lock.enums.PasswordlessMode;
+import com.auth0.android.lock.enums.SocialButtonStyle;
 import com.auth0.android.lock.enums.UsernameStyle;
 import com.auth0.android.lock.utils.Application;
 import com.auth0.android.lock.utils.Connection;
@@ -70,6 +71,8 @@ public class Configuration {
     private boolean usernameRequired;
     @UsernameStyle
     private int usernameStyle;
+    @SocialButtonStyle
+    private int socialButtonStyle;
     private boolean loginAfterSignUp;
     @PasswordlessMode
     private int passwordlessMode;
@@ -222,6 +225,7 @@ public class Configuration {
 
     private void parseLocalOptions(Options options) {
         usernameStyle = options.usernameStyle();
+        socialButtonStyle = options.socialButtonStyle();
         loginAfterSignUp = options.loginAfterSignUp();
 
         final boolean dbAvailable = getDefaultDatabaseConnection() != null;
@@ -318,6 +322,11 @@ public class Configuration {
     @InitialScreen
     public int getInitialScreen() {
         return initialScreen;
+    }
+
+    @SocialButtonStyle
+    public int getSocialButtonStyle() {
+        return socialButtonStyle;
     }
 
     @UsernameStyle

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -37,6 +37,7 @@ import android.util.Log;
 import com.auth0.Auth0;
 import com.auth0.android.lock.LockCallback.LockEvent;
 import com.auth0.android.lock.enums.InitialScreen;
+import com.auth0.android.lock.enums.SocialButtonStyle;
 import com.auth0.android.lock.enums.UsernameStyle;
 import com.auth0.android.lock.provider.AuthProviderResolver;
 import com.auth0.android.lock.provider.ProviderResolverManager;
@@ -290,6 +291,20 @@ public class Lock {
          */
         public Builder withUsernameStyle(@UsernameStyle int style) {
             options.setUsernameStyle(style);
+            return this;
+        }
+
+        /**
+         * Social Button style to use when Social connections are available. If social
+         * is the only connection type, by default it will use the Big style. If social and db or
+         * enterprise are present and there's only one social connection, the button will use the
+         * Big style. In the rest of the cases, it will use Small style.
+         *
+         * @param style a valid SocialButtonStyle.
+         * @return the current builder instance
+         */
+        public Builder withSocialButtonStyle(@SocialButtonStyle int style) {
+            options.setSocialButtonStyle(style);
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/Options.java
@@ -32,6 +32,7 @@ import android.support.annotation.NonNull;
 
 import com.auth0.Auth0;
 import com.auth0.android.lock.enums.InitialScreen;
+import com.auth0.android.lock.enums.SocialButtonStyle;
 import com.auth0.android.lock.enums.UsernameStyle;
 import com.auth0.authentication.AuthenticationAPIClient;
 
@@ -52,6 +53,7 @@ class Options implements Parcelable {
     private boolean usePKCE;
     private boolean closable;
     private boolean fullscreen;
+    private int socialButtonStyle;
     private int usernameStyle;
     private boolean useCodePasswordless;
     private boolean allowLogIn;
@@ -92,6 +94,7 @@ class Options implements Parcelable {
         defaultDatabaseConnection = in.readString();
         usernameStyle = in.readInt();
         initialScreen = in.readInt();
+        socialButtonStyle = in.readInt();
         if (in.readByte() == HAS_DATA) {
             connections = new ArrayList<>();
             in.readList(connections, String.class.getClassLoader());
@@ -139,6 +142,7 @@ class Options implements Parcelable {
         dest.writeString(defaultDatabaseConnection);
         dest.writeInt(usernameStyle);
         dest.writeInt(initialScreen);
+        dest.writeInt(socialButtonStyle);
         if (connections == null) {
             dest.writeByte((byte) (WITHOUT_DATA));
         } else {
@@ -232,6 +236,15 @@ class Options implements Parcelable {
 
     public void setAllowLogIn(boolean allowLogIn) {
         this.allowLogIn = allowLogIn;
+    }
+
+    public void setSocialButtonStyle(@SocialButtonStyle int socialButtonStyle) {
+        this.socialButtonStyle = socialButtonStyle;
+    }
+
+    @SocialButtonStyle
+    public int socialButtonStyle() {
+        return socialButtonStyle;
     }
 
     public boolean allowLogIn() {

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -36,6 +36,7 @@ import android.util.Log;
 
 import com.auth0.Auth0;
 import com.auth0.android.lock.LockCallback.LockEvent;
+import com.auth0.android.lock.enums.SocialButtonStyle;
 import com.auth0.android.lock.provider.AuthProviderResolver;
 import com.auth0.android.lock.provider.ProviderResolverManager;
 import com.auth0.authentication.ParameterBuilder;
@@ -266,6 +267,20 @@ public class PasswordlessLock {
          */
         public Builder fullscreen(boolean fullscreen) {
             options.setFullscreen(fullscreen);
+            return this;
+        }
+
+        /**
+         * Social Button style to use when Social connections are available. If social
+         * is the only connection type, by default it will use the Big style. If social and db or
+         * enterprise are present and there's only one social connection, the button will use the
+         * Big style. In the rest of the cases, it will use Small style.
+         *
+         * @param style a valid SocialButtonStyle.
+         * @return the current builder instance
+         */
+        public Builder withSocialButtonStyle(@SocialButtonStyle int style) {
+            options.setSocialButtonStyle(style);
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/enums/SocialButtonStyle.java
+++ b/lib/src/main/java/com/auth0/android/lock/enums/SocialButtonStyle.java
@@ -1,0 +1,42 @@
+/*
+ * SocialButtonStyle.java
+ *
+ * Copyright (c) 2016 Auth0 (http://auth0.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.auth0.android.lock.enums;
+
+import android.support.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import static com.auth0.android.lock.enums.SocialButtonStyle.BIG;
+import static com.auth0.android.lock.enums.SocialButtonStyle.SMALL;
+import static com.auth0.android.lock.enums.SocialButtonStyle.UNSPECIFIED;
+
+@IntDef({UNSPECIFIED, BIG, SMALL})
+@Retention(RetentionPolicy.SOURCE)
+public @interface SocialButtonStyle {
+    int UNSPECIFIED = 0;
+    int BIG = 1;
+    int SMALL = 2;
+}

--- a/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
@@ -39,6 +39,7 @@ import android.widget.TextView;
 
 import com.auth0.android.lock.R;
 import com.auth0.android.lock.enums.InitialScreen;
+import com.auth0.android.lock.enums.SocialButtonStyle;
 import com.auth0.android.lock.events.DatabaseSignUpEvent;
 import com.auth0.android.lock.views.interfaces.LockWidgetForm;
 
@@ -102,7 +103,7 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
         addView(formsHolder, holderParams);
 
         if (showSocial) {
-            addSocialLayout(showDatabase || showEnterprise);
+            addSocialLayout();
             if (showDatabase || showEnterprise) {
                 addSeparator();
             }
@@ -125,8 +126,17 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
         }
     }
 
-    private void addSocialLayout(boolean smallButtons) {
-        socialLayout = new SocialView(lockWidget, smallButtons);
+    private void addSocialLayout() {
+        int style = lockWidget.getConfiguration().getSocialButtonStyle();
+        boolean formContainsFields = showDatabase || showEnterprise;
+        boolean singleConnection = lockWidget.getConfiguration().getSocialStrategies().size() == 1;
+
+        if (style == SocialButtonStyle.UNSPECIFIED) {
+            socialLayout = new SocialView(lockWidget, formContainsFields && !singleConnection);
+        } else {
+            socialLayout = new SocialView(lockWidget, style == SocialButtonStyle.SMALL);
+        }
+
         formsHolder.addView(socialLayout);
     }
 

--- a/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
@@ -27,6 +27,7 @@ package com.auth0.android.lock;
 import com.auth0.android.lock.CustomField.FieldType;
 import com.auth0.android.lock.enums.InitialScreen;
 import com.auth0.android.lock.enums.PasswordlessMode;
+import com.auth0.android.lock.enums.SocialButtonStyle;
 import com.auth0.android.lock.enums.UsernameStyle;
 import com.auth0.android.lock.utils.Application;
 import com.auth0.android.lock.utils.Connection;
@@ -107,6 +108,7 @@ public class ConfigurationTest {
         assertThat(configuration.loginAfterSignUp(), is(true));
         assertThat(configuration.getUsernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
         assertThat(configuration.getInitialScreen(), is(equalTo(InitialScreen.LOG_IN)));
+        assertThat(configuration.getSocialButtonStyle(), is(equalTo(SocialButtonStyle.UNSPECIFIED)));
         assertThat(configuration.hasExtraFields(), is(false));
     }
 
@@ -118,6 +120,7 @@ public class ConfigurationTest {
         options.setAllowForgotPassword(false);
         options.setLoginAfterSignUp(false);
         options.setUsernameStyle(UsernameStyle.USERNAME);
+        options.setSocialButtonStyle(SocialButtonStyle.BIG);
         configuration = new Configuration(application, options);
         assertThat(configuration.isUsernameRequired(), is(false));
         assertThat(configuration.allowLogIn(), is(false));
@@ -125,6 +128,7 @@ public class ConfigurationTest {
         assertThat(configuration.allowForgotPassword(), is(false));
         assertThat(configuration.loginAfterSignUp(), is(false));
         assertThat(configuration.getUsernameStyle(), is(equalTo(UsernameStyle.USERNAME)));
+        assertThat(configuration.getSocialButtonStyle(), is(equalTo(SocialButtonStyle.BIG)));
         assertThat(configuration.hasExtraFields(), is(false));
     }
 

--- a/lib/src/test/java/com/auth0/android/lock/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/OptionsTest.java
@@ -7,6 +7,7 @@ import android.support.v7.appcompat.BuildConfig;
 import com.auth0.Auth0;
 import com.auth0.android.lock.CustomField.FieldType;
 import com.auth0.android.lock.enums.InitialScreen;
+import com.auth0.android.lock.enums.SocialButtonStyle;
 import com.auth0.android.lock.enums.UsernameStyle;
 
 import org.junit.Before;
@@ -78,6 +79,33 @@ public class OptionsTest {
         assertThat(options.useBrowser(), is(equalTo(parceledOptions.useBrowser())));
     }
 
+    @Test
+    public void shouldUseBigSocialButtonStyle() {
+        Options options = new Options();
+        options.setAccount(auth0);
+        options.setSocialButtonStyle(SocialButtonStyle.BIG);
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.socialButtonStyle(), is(equalTo(parceledOptions.socialButtonStyle())));
+    }
+
+    @Test
+    public void shouldUseSmallSocialButtonStyle() {
+        Options options = new Options();
+        options.setAccount(auth0);
+        options.setSocialButtonStyle(SocialButtonStyle.SMALL);
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.socialButtonStyle(), is(equalTo(parceledOptions.socialButtonStyle())));
+    }
 
     @Test
     public void shouldUsePKCE() {
@@ -438,6 +466,8 @@ public class OptionsTest {
         assertThat(options.allowForgotPassword(), is(true));
         assertThat(options.loginAfterSignUp(), is(true));
         assertThat(options.useCodePasswordless(), is(true));
+        assertThat(options.usernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
+        assertThat(options.socialButtonStyle(), is(equalTo(SocialButtonStyle.UNSPECIFIED)));
     }
 
 
@@ -455,6 +485,7 @@ public class OptionsTest {
         options.setAllowSignUp(true);
         options.setAllowForgotPassword(true);
         options.setClosable(true);
+        options.setSocialButtonStyle(SocialButtonStyle.BIG);
         options.setLoginAfterSignUp(true);
 
 
@@ -472,6 +503,7 @@ public class OptionsTest {
         assertThat(options.allowLogIn(), is(equalTo(parceledOptions.allowLogIn())));
         assertThat(options.allowSignUp(), is(equalTo(parceledOptions.allowSignUp())));
         assertThat(options.allowForgotPassword(), is(equalTo(parceledOptions.allowForgotPassword())));
+        assertThat(options.socialButtonStyle(), is(equalTo(parceledOptions.socialButtonStyle())));
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
     }
 
@@ -489,6 +521,7 @@ public class OptionsTest {
         options.setAllowLogIn(false);
         options.setAllowSignUp(false);
         options.setAllowForgotPassword(false);
+        options.setSocialButtonStyle(SocialButtonStyle.SMALL);
         options.setLoginAfterSignUp(false);
 
 
@@ -506,6 +539,7 @@ public class OptionsTest {
         assertThat(options.allowLogIn(), is(equalTo(parceledOptions.allowLogIn())));
         assertThat(options.allowSignUp(), is(equalTo(parceledOptions.allowSignUp())));
         assertThat(options.allowForgotPassword(), is(equalTo(parceledOptions.allowForgotPassword())));
+        assertThat(options.socialButtonStyle(), is(equalTo(parceledOptions.socialButtonStyle())));
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
     }
 


### PR DESCRIPTION
The user can customize the Social Button Style in the `Lock.Builder` by calling `.withSocialButtonStyle(int)`. Possible values are: **BIG** and **SMALL**.

If the value is not specified it will:
* If Social is the only connection _type_, the buttons will get the style BIG.
* If Social and DB/Enterprise connection _types_ are present and there is only 1 Social connection, the button will get the style BIG.
* If Social and DB/Enterprise connection _types_ are present and there are many Social connections, the buttons will get the style SMALL.