### PR TITLE
Handle Application without Connections

### DIFF
--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
@@ -37,6 +37,7 @@ import com.auth0.android.lock.AuthenticationCallback;
 import com.auth0.android.lock.Lock;
 import com.auth0.android.lock.LockCallback;
 import com.auth0.android.lock.PasswordlessLock;
+import com.auth0.android.lock.enums.InitialScreen;
 import com.auth0.android.lock.utils.LockException;
 import com.auth0.authentication.ParameterBuilder;
 import com.auth0.authentication.result.Credentials;

--- a/lib/src/main/java/com/auth0/android/lock/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/Configuration.java
@@ -69,6 +69,8 @@ public class Configuration {
     private boolean allowSignUp;
     private boolean allowForgotPassword;
     private boolean usernameRequired;
+    private final boolean classicLockAvailable;
+    private final boolean passwordlessLockAvailable;
     @UsernameStyle
     private int usernameStyle;
     @SocialButtonStyle
@@ -91,6 +93,8 @@ public class Configuration {
         this.defaultActiveDirectoryConnection = filteredDefaultADConnection(this.activeDirectoryStrategy);
         this.socialStrategies = filterSocialStrategies(application.getSocialStrategies(), connectionSet);
         this.application = application;
+        this.classicLockAvailable = !socialStrategies.isEmpty() || !enterpriseStrategies.isEmpty() || defaultDatabaseConnection != null;
+        this.passwordlessLockAvailable = !socialStrategies.isEmpty() || !passwordlessStrategies.isEmpty();
         parseLocalOptions(options);
     }
 
@@ -346,4 +350,13 @@ public class Configuration {
     public boolean hasExtraFields() {
         return !extraSignUpFields.isEmpty();
     }
+
+    public boolean isClassicLockAvailable() {
+        return classicLockAvailable;
+    }
+
+    public boolean isPasswordlessLockAvailable() {
+        return passwordlessLockAvailable;
+    }
+
 }

--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -27,7 +27,6 @@ package com.auth0.android.lock;
 
 import android.app.Dialog;
 import android.app.ProgressDialog;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Rect;
 import android.os.Build;
@@ -39,7 +38,6 @@ import android.support.annotation.StringRes;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.content.LocalBroadcastManager;
-import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
@@ -287,20 +285,6 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
         });
     }
 
-    private void showMissingConnectionsDialog() {
-        new AlertDialog.Builder(LockActivity.this)
-                .setCancelable(false)
-                .setMessage(R.string.com_auth0_lock_missing_connections_message)
-                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        LockActivity.this.finish();
-                    }
-                })
-                .create()
-                .show();
-    }
-
     private void fetchProviderAndBeginAuthentication(String connectionName) {
         Log.v(TAG, "Looking for a provider to use with the connection " + connectionName);
         currentProvider = ProviderResolverManager.get().onAuthProviderRequest(this, authProviderCallback, connectionName);
@@ -470,23 +454,17 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
     private BaseCallback<Application> applicationCallback = new BaseCallback<Application>() {
         @Override
         public void onSuccess(Application app) {
-            configuration = new Configuration(app, options);
-            if (configuration.isClassicLockAvailable()) {
-                handler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        lockView.configure(configuration);
-                    }
-                });
-                return;
-            }
-
+            final Configuration successConfig = new Configuration(app, options);
             handler.post(new Runnable() {
                 @Override
                 public void run() {
-                    showMissingConnectionsDialog();
+                    lockView.configure(successConfig);
                 }
             });
+            if (successConfig.isClassicLockAvailable()) {
+                configuration = successConfig;
+            }
+            applicationFetcher = null;
         }
 
         @Override

--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -333,7 +333,7 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
     @SuppressWarnings("unused")
     @Subscribe
     public void onFetchApplicationRequest(FetchApplicationEvent event) {
-        if (configuration == null && applicationFetcher == null) {
+        if (applicationFetcher == null) {
             applicationFetcher = new ApplicationFetcher(options.getAccount(), new OkHttpClient());
             applicationFetcher.fetch(applicationCallback);
         }
@@ -454,16 +454,13 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
     private BaseCallback<Application> applicationCallback = new BaseCallback<Application>() {
         @Override
         public void onSuccess(Application app) {
-            final Configuration successConfig = new Configuration(app, options);
+            configuration = new Configuration(app, options);
             handler.post(new Runnable() {
                 @Override
                 public void run() {
-                    lockView.configure(successConfig);
+                    lockView.configure(configuration);
                 }
             });
-            if (successConfig.isClassicLockAvailable()) {
-                configuration = successConfig;
-            }
             applicationFetcher = null;
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -212,7 +212,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
         }
 
         boolean launchedForResult = getCallingActivity() != null;
-        if (launchedForResult){
+        if (launchedForResult) {
             Log.e(TAG, "You're not allowed to start Lock with startActivityForResult.");
             return false;
         }
@@ -517,24 +517,18 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
     private BaseCallback<Application> applicationCallback = new BaseCallback<Application>() {
         @Override
         public void onSuccess(Application app) {
-            configuration = new Configuration(app, options);
-            if (configuration.isPasswordlessLockAvailable()) {
-                handler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        lockView.configure(configuration);
-                        reloadRecentPasswordlessData();
-                    }
-                });
-                return;
-            }
-
+            final Configuration successConfig = new Configuration(app, options);
             handler.post(new Runnable() {
                 @Override
                 public void run() {
-                    showMissingConnectionsDialog();
+                    lockView.configure(successConfig);
+                    reloadRecentPasswordlessData();
                 }
             });
+            if (successConfig.isClassicLockAvailable()) {
+                configuration = successConfig;
+            }
+            applicationFetcher = null;
         }
 
         @Override

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -455,7 +455,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
     @SuppressWarnings("unused")
     @Subscribe
     public void onFetchApplicationRequest(FetchApplicationEvent event) {
-        if (configuration == null && applicationFetcher == null) {
+        if (applicationFetcher == null) {
             applicationFetcher = new ApplicationFetcher(options.getAccount(), new OkHttpClient());
             applicationFetcher.fetch(applicationCallback);
         }
@@ -517,17 +517,14 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
     private BaseCallback<Application> applicationCallback = new BaseCallback<Application>() {
         @Override
         public void onSuccess(Application app) {
-            final Configuration successConfig = new Configuration(app, options);
+            configuration = new Configuration(app, options);
             handler.post(new Runnable() {
                 @Override
                 public void run() {
-                    lockView.configure(successConfig);
+                    lockView.configure(configuration);
                     reloadRecentPasswordlessData();
                 }
             });
-            if (successConfig.isClassicLockAvailable()) {
-                configuration = successConfig;
-            }
             applicationFetcher = null;
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -82,7 +82,7 @@ public class ClassicLockView extends LinearLayout implements View.OnClickListene
         setOrientation(VERTICAL);
         if (configuration == null) {
             Log.w(TAG, "Configuration is missing, the view won't init.");
-            showConfigurationMissingLayout();
+            showConfigurationMissingLayout(false);
         } else {
             showContentLayout();
         }
@@ -141,14 +141,14 @@ public class ClassicLockView extends LinearLayout implements View.OnClickListene
         removeView(loadingProgressBar);
         loadingProgressBar = null;
         this.configuration = configuration;
-        if (configuration != null) {
+        if (configuration != null && configuration.isClassicLockAvailable()) {
             init();
-            return;
+        } else {
+            showConfigurationMissingLayout(configuration != null && !configuration.isClassicLockAvailable());
         }
-        showConfigurationMissingLayout();
     }
 
-    private void showConfigurationMissingLayout() {
+    private void showConfigurationMissingLayout(boolean missingConnections) {
         int horizontalMargin = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_horizontal_margin);
         final LinearLayout errorLayout = new LinearLayout(getContext());
         errorLayout.setOrientation(LinearLayout.VERTICAL);
@@ -157,7 +157,7 @@ public class ClassicLockView extends LinearLayout implements View.OnClickListene
         params.gravity = Gravity.CENTER;
 
         TextView errorText = new TextView(getContext());
-        errorText.setText(R.string.com_auth0_lock_configuration_retrieving_error);
+        errorText.setText(missingConnections ? R.string.com_auth0_lock_missing_connections_message : R.string.com_auth0_lock_configuration_retrieving_error);
         errorText.setGravity(Gravity.CENTER);
 
         Button retryButton = new Button(getContext());

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -27,6 +27,7 @@ package com.auth0.android.lock.views;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
@@ -82,7 +83,7 @@ public class ClassicLockView extends LinearLayout implements View.OnClickListene
         setOrientation(VERTICAL);
         if (configuration == null) {
             Log.w(TAG, "Configuration is missing, the view won't init.");
-            showConfigurationMissingLayout(false);
+            showConfigurationMissingLayout(R.string.com_auth0_lock_configuration_retrieving_error);
         } else {
             showContentLayout();
         }
@@ -144,11 +145,17 @@ public class ClassicLockView extends LinearLayout implements View.OnClickListene
         if (configuration != null && configuration.isClassicLockAvailable()) {
             init();
         } else {
-            showConfigurationMissingLayout(configuration != null && !configuration.isClassicLockAvailable());
+            int errorRes = 0;
+            if (configuration == null) {
+                errorRes = R.string.com_auth0_lock_configuration_retrieving_error;
+            } else if (!configuration.isClassicLockAvailable()) {
+                errorRes = R.string.com_auth0_lock_missing_connections_message;
+            }
+            showConfigurationMissingLayout(errorRes);
         }
     }
 
-    private void showConfigurationMissingLayout(boolean missingConnections) {
+    private void showConfigurationMissingLayout(@StringRes int errorMessage) {
         int horizontalMargin = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_horizontal_margin);
         final LinearLayout errorLayout = new LinearLayout(getContext());
         errorLayout.setOrientation(LinearLayout.VERTICAL);
@@ -157,7 +164,7 @@ public class ClassicLockView extends LinearLayout implements View.OnClickListene
         params.gravity = Gravity.CENTER;
 
         TextView errorText = new TextView(getContext());
-        errorText.setText(missingConnections ? R.string.com_auth0_lock_missing_connections_message : R.string.com_auth0_lock_configuration_retrieving_error);
+        errorText.setText(errorMessage);
         errorText.setGravity(Gravity.CENTER);
 
         Button retryButton = new Button(getContext());

--- a/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
@@ -78,7 +78,7 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
         boolean showSocial = !lockWidget.getConfiguration().getSocialStrategies().isEmpty();
         showDatabase = lockWidget.getConfiguration().getDefaultDatabaseConnection() != null;
         showEnterprise = !lockWidget.getConfiguration().getEnterpriseStrategies().isEmpty();
-        boolean showModeSelection = lockWidget.getConfiguration().allowLogIn() && lockWidget.getConfiguration().allowSignUp();
+        boolean showModeSelection = showDatabase && lockWidget.getConfiguration().allowLogIn() && lockWidget.getConfiguration().allowSignUp();
 
         int verticalMargin = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_vertical_margin_field);
         int horizontalMargin = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_horizontal_margin);

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordlessLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordlessLockView.java
@@ -73,7 +73,7 @@ public class PasswordlessLockView extends LinearLayout implements LockWidgetSoci
         setOrientation(VERTICAL);
         if (configuration == null) {
             Log.w(TAG, "Configuration is missing, the view won't init.");
-            showConfigurationMissingLayout();
+            showConfigurationMissingLayout(false);
         } else {
             showContentLayout();
         }
@@ -112,14 +112,14 @@ public class PasswordlessLockView extends LinearLayout implements LockWidgetSoci
         removeView(loadingProgressBar);
         loadingProgressBar = null;
         this.configuration = configuration;
-        if (configuration != null) {
+        if (configuration != null && configuration.isPasswordlessLockAvailable()) {
             init();
-            return;
+        } else {
+            showConfigurationMissingLayout(configuration != null && !configuration.isPasswordlessLockAvailable());
         }
-        showConfigurationMissingLayout();
     }
 
-    private void showConfigurationMissingLayout() {
+    private void showConfigurationMissingLayout(boolean missingConnections) {
         int horizontalMargin = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_horizontal_margin);
         final LinearLayout errorLayout = new LinearLayout(getContext());
         errorLayout.setOrientation(LinearLayout.VERTICAL);
@@ -128,7 +128,7 @@ public class PasswordlessLockView extends LinearLayout implements LockWidgetSoci
         params.gravity = Gravity.CENTER;
 
         TextView errorText = new TextView(getContext());
-        errorText.setText(R.string.com_auth0_lock_configuration_retrieving_error);
+        errorText.setText(missingConnections ? R.string.com_auth0_lock_missing_connections_message : R.string.com_auth0_lock_configuration_retrieving_error);
         errorText.setGravity(Gravity.CENTER);
 
         Button retryButton = new Button(getContext());
@@ -154,7 +154,7 @@ public class PasswordlessLockView extends LinearLayout implements LockWidgetSoci
      * @return true if it was handled, false otherwise
      */
     public boolean onBackPressed() {
-        return formLayout.onBackPressed();
+        return formLayout != null && formLayout.onBackPressed();
     }
 
     /**

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordlessLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordlessLockView.java
@@ -26,6 +26,7 @@ package com.auth0.android.lock.views;
 
 import android.content.Context;
 import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
@@ -73,7 +74,7 @@ public class PasswordlessLockView extends LinearLayout implements LockWidgetSoci
         setOrientation(VERTICAL);
         if (configuration == null) {
             Log.w(TAG, "Configuration is missing, the view won't init.");
-            showConfigurationMissingLayout(false);
+            showConfigurationMissingLayout(R.string.com_auth0_lock_configuration_retrieving_error);
         } else {
             showContentLayout();
         }
@@ -115,11 +116,17 @@ public class PasswordlessLockView extends LinearLayout implements LockWidgetSoci
         if (configuration != null && configuration.isPasswordlessLockAvailable()) {
             init();
         } else {
-            showConfigurationMissingLayout(configuration != null && !configuration.isPasswordlessLockAvailable());
+            int errorRes = 0;
+            if (configuration == null) {
+                errorRes = R.string.com_auth0_lock_configuration_retrieving_error;
+            } else if (!configuration.isPasswordlessLockAvailable()) {
+                errorRes = R.string.com_auth0_lock_missing_connections_message;
+            }
+            showConfigurationMissingLayout(errorRes);
         }
     }
 
-    private void showConfigurationMissingLayout(boolean missingConnections) {
+    private void showConfigurationMissingLayout(@StringRes int errorMessage) {
         int horizontalMargin = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_horizontal_margin);
         final LinearLayout errorLayout = new LinearLayout(getContext());
         errorLayout.setOrientation(LinearLayout.VERTICAL);
@@ -128,7 +135,7 @@ public class PasswordlessLockView extends LinearLayout implements LockWidgetSoci
         params.gravity = Gravity.CENTER;
 
         TextView errorText = new TextView(getContext());
-        errorText.setText(missingConnections ? R.string.com_auth0_lock_missing_connections_message : R.string.com_auth0_lock_configuration_retrieving_error);
+        errorText.setText(errorMessage);
         errorText.setGravity(Gravity.CENTER);
 
         Button retryButton = new Button(getContext());

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -145,6 +145,7 @@
     <string name="com_auth0_lock_title_passwordless_sms">Enter your phone to sign in\n or create an account</string>
 
     <!-- Custom Error Messages -->
+    <string name="com_auth0_lock_missing_connections_message">There isn\'t any connection configured for this Application. Check your dashboard configuration on http://auth0.com</string>
     <string name="com_auth0_lock_configuration_retrieving_error">Error retrieving the Dashboard configuration</string>
     <string name="com_auth0_lock_enterprise_no_connection_message">There was no connection configured for the domain</string>
     <string name="com_auth0_lock_db_login_error_message">There was an error processing the sign in</string>

--- a/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
@@ -81,6 +81,8 @@ public class ConfigurationTest extends GsonBaseTest {
     private static final String RESTRICTIVE_DATABASE = "RestrictiveDatabase";
     private static final String CUSTOM_DATABASE = "CustomDatabase";
     private static final String USERNAME_PASSWORD_AUTHENTICATION = "Username-Password-Authentication";
+    private static final String TWITTER = "twitter";
+    private static final String EMAIL = "email";
     private static final String MY_AD = "MyAD";
     private static final String MY_SECOND_AD = "mySecondAD";
     private static final String UNKNOWN_AD = "UnknownAD";
@@ -141,6 +143,98 @@ public class ConfigurationTest extends GsonBaseTest {
         configuration = new Configuration(application, options);
         assertThat(configuration.allowSignUp(), is(false));
         assertThat(configuration.allowForgotPassword(), is(false));
+    }
+
+    @Test
+    public void shouldNotUseClassicLockIfNoConnectionsAreAvailable() throws Exception {
+        configuration = filteredConfigBy("");
+        assertThat(configuration.isClassicLockAvailable(), is(false));
+    }
+
+    @Test
+    public void shouldNotUseClassicLockIfAllScreensAreDisabled() throws Exception {
+        options.setAllowLogIn(false);
+        options.setAllowSignUp(false);
+        options.setAllowForgotPassword(false);
+        configuration = new Configuration(application, options);
+        assertThat(configuration.isClassicLockAvailable(), is(false));
+    }
+
+    @Test
+    public void shouldUseClassicLockWithEnterpriseConnections() throws Exception {
+        configuration = filteredConfigBy(MY_AD);
+        assertThat(configuration.isClassicLockAvailable(), is(true));
+    }
+
+    @Test
+    public void shouldNotUseClassicLockWithEnterpriseConnectionsAndLogInDisabled() throws Exception {
+        options.setAllowLogIn(false);
+        configuration = filteredConfigBy(MY_AD);
+        assertThat(configuration.isClassicLockAvailable(), is(false));
+    }
+
+    @Test
+    public void shouldUseClassicLockWithSocialConnections() throws Exception {
+        configuration = filteredConfigBy(TWITTER);
+        assertThat(configuration.isClassicLockAvailable(), is(true));
+    }
+
+    @Test
+    public void shouldUseClassicLockWithSocialConnectionsInLogInScreen() throws Exception {
+        options.setAllowLogIn(true);
+        options.setAllowSignUp(false);
+        configuration = filteredConfigBy(TWITTER);
+        assertThat(configuration.isClassicLockAvailable(), is(true));
+    }
+
+    @Test
+    public void shouldUseClassicLockWithSocialConnectionsInSignUpScreen() throws Exception {
+        options.setAllowLogIn(false);
+        options.setAllowSignUp(true);
+        configuration = filteredConfigBy(TWITTER);
+        assertThat(configuration.isClassicLockAvailable(), is(true));
+    }
+
+    @Test
+    public void shouldNotUseClassicLockWithSocialConnectionsAndScreensDisabled() throws Exception {
+        options.setAllowLogIn(false);
+        options.setAllowSignUp(false);
+        configuration = filteredConfigBy(TWITTER);
+        assertThat(configuration.isClassicLockAvailable(), is(false));
+    }
+
+    @Test
+    public void shouldUseClassicLockWithDatabaseConnections() throws Exception {
+        options.useDatabaseConnection(USERNAME_PASSWORD_AUTHENTICATION);
+        configuration = filteredConfigBy(USERNAME_PASSWORD_AUTHENTICATION);
+        assertThat(configuration.isClassicLockAvailable(), is(true));
+    }
+
+    @Test
+    public void shouldNotUsePasswordlessLockWithoutConnections() throws Exception {
+        configuration = filteredConfigBy("");
+        assertThat(configuration.isPasswordlessLockAvailable(), is(false));
+    }
+
+    @Test
+    public void shouldUsePasswordlessLockWithSocialConnections() throws Exception {
+        configuration = filteredConfigBy(TWITTER);
+        assertThat(configuration.isPasswordlessLockAvailable(), is(true));
+    }
+
+    @Test
+    public void shouldUsePasswordlessLockWithPasswordlessConnections() throws Exception {
+        configuration = filteredConfigBy(EMAIL);
+        assertThat(configuration.isPasswordlessLockAvailable(), is(true));
+    }
+
+    @Test
+    public void shouldPasswordlessLockNotBeAffectedByClassicLockScreenFlags() throws Exception {
+        configuration = filteredConfigBy(EMAIL, TWITTER);
+        options.setAllowLogIn(false);
+        options.setAllowSignUp(false);
+        options.setAllowForgotPassword(false);
+        assertThat(configuration.isPasswordlessLockAvailable(), is(true));
     }
 
     @Test


### PR DESCRIPTION
Show a "No connections configured" message with a retry button. (Same layout is used with a different text when the application couldn't be fetched). 

http://recordit.co/ox87sWmQsF
