### PR TITLE
Country code selection widget fixes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ public class HomeActivity extends Activity {
     super.onDestroy();
     // Your own Activity code
     lock.onDestroy(this);
-    lock = nil;
+    lock = null;
   }
 
   private LockCallback callback = new AuthenticationCallback() {
@@ -169,7 +169,7 @@ public class HomeActivity extends Activity {
     super.onDestroy();
     // Your own Activity code
     lock.onDestroy(this);
-    lock = nil;
+    lock = null;
   }
 
   private LockCallback callback = new AuthenticationCallback() {

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -320,11 +320,11 @@ public class Lock {
         }
 
         /**
-         * Sign In can be enabled/disabled locally, regardless the Dashboard configuration.
+         * Log In can be enabled/disabled locally, regardless the Dashboard configuration.
          *
          * @return the current builder instance
          */
-        public Builder allowSignIn(boolean allow) {
+        public Builder allowLogIn(boolean allow) {
             options.setAllowLogIn(allow);
             return this;
         }

--- a/lib/src/main/java/com/auth0/android/lock/utils/json/Application.java
+++ b/lib/src/main/java/com/auth0/android/lock/utils/json/Application.java
@@ -164,7 +164,7 @@ public class Application {
      *
      * @return hasAllowedOrigins flag
      */
-    public boolean isHasAllowedOrigins() {
+    public boolean hasAllowedOrigins() {
         return hasAllowedOrigins;
     }
 

--- a/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
@@ -87,9 +87,10 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
             Log.v(TAG, "SignUp enabled. Adding the Login/SignUp Mode Switcher");
             modeSelectionView = new ModeSelectionView(getContext(), this);
             modeSelectionView.setId(R.id.com_auth0_lock_form_selector);
+            int verticalModeSelectionMargin = (int) getResources().getDimension(R.dimen.com_auth0_lock_widget_vertical_margin_mode_selection);
             LayoutParams modeSelectionParams = new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
             modeSelectionParams.addRule(ALIGN_PARENT_TOP);
-            modeSelectionParams.setMargins(horizontalMargin, verticalMargin, horizontalMargin, verticalMargin);
+            modeSelectionParams.setMargins(horizontalMargin, verticalModeSelectionMargin, horizontalMargin, 0);
             addView(modeSelectionView, modeSelectionParams);
         }
         formsHolder = new LinearLayout(getContext());

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordlessRequestCodeFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordlessRequestCodeFormView.java
@@ -183,9 +183,6 @@ public class PasswordlessRequestCodeFormView extends FormView implements View.On
      * @param isOpen whether the keyboard is open or close.
      */
     public void onKeyboardStateChanged(boolean isOpen) {
-        if (passwordlessMode == SMS_LINK || passwordlessMode == SMS_CODE) {
-            countryCodeSelector.setVisibility(isOpen ? GONE : VISIBLE);
-        }
         if (listener.shouldShowGotCodeButton()) {
             gotCodeButton.setVisibility(isOpen ? GONE : VISIBLE);
         }

--- a/lib/src/main/res/values-long/dimens.xml
+++ b/lib/src/main/res/values-long/dimens.xml
@@ -37,6 +37,7 @@
     <dimen name="com_auth0_lock_widget_small_margin">3dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_passwordless_sent">24dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_link">26dp</dimen>
+    <dimen name="com_auth0_lock_widget_vertical_margin_mode_selection">16dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_field">8dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_field_with_error">3dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_social">4dp</dimen>

--- a/lib/src/main/res/values/dimens.xml
+++ b/lib/src/main/res/values/dimens.xml
@@ -37,6 +37,7 @@
     <dimen name="com_auth0_lock_widget_small_margin">3dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_passwordless_sent">29dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_link">33dp</dimen>
+    <dimen name="com_auth0_lock_widget_vertical_margin_mode_selection">20dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_field">10dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_field_with_error">5dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_social">6dp</dimen>

--- a/lib/src/main/res/values/styles.xml
+++ b/lib/src/main/res/values/styles.xml
@@ -191,6 +191,9 @@
         <item name="android:hint">@string/com_auth0_lock_hint_search_country</item>
         <item name="android:textSize">@dimen/com_auth0_lock_title_text</item>
         <item name="android:theme">@style/Lock.Theme</item>
+        <item name="android:singleLine">true</item>
+        <item name="android:maxLines">1</item>
+        <item name="android:imeOptions">actionDone</item>
     </style>
 
     <style name="Lock.Theme.Widget.CountryCodeSelector" parent="Lock.Theme.Widget.Field">

--- a/lib/src/test/java/com/auth0/android/lock/utils/json/ApplicationGsonTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/utils/json/ApplicationGsonTest.java
@@ -100,7 +100,7 @@ public class ApplicationGsonTest extends GsonBaseTest {
         assertThat(application.getStrategies().get(0), instanceOf(Strategy.class));
         assertThat(application.getSubscription(), is("dev"));
         assertThat(application.getCallbackURL(), is("http://localhost:3000/"));
-        assertThat(application.isHasAllowedOrigins(), is(true));
+        assertThat(application.hasAllowedOrigins(), is(true));
     }
 
     private Application buildApplicationFrom(Reader json) throws IOException {

--- a/lib/src/test/java/com/auth0/android/lock/utils/json/ApplicationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/utils/json/ApplicationTest.java
@@ -78,7 +78,7 @@ public class ApplicationTest {
         assertThat(application.getAuthorizeURL(), equalTo(AUTHORIZE_URL));
         assertThat(application.getCallbackURL(), equalTo(CALLBACK_URL));
         assertThat(application.getSubscription(), equalTo(SUBSCRIPTION));
-        assertThat(application.isHasAllowedOrigins(), equalTo(HAS_ALLOWED_ORIGINS));
+        assertThat(application.hasAllowedOrigins(), equalTo(HAS_ALLOWED_ORIGINS));
     }
 
     @Test


### PR DESCRIPTION
Introducing **breaking change** in the `Lock.Builder` class: Rename `allowSignIn` to `allowLogIn`. 

Also:
* Disable multiline in country code search field.
* Show country code widget when keyboard is opened.
* Change ModeSelection widget margin.