### PR TITLE
Password Strength Widget

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/Configuration.java
@@ -29,6 +29,7 @@ import android.support.annotation.Nullable;
 import android.util.Log;
 
 import com.auth0.android.lock.enums.InitialScreen;
+import com.auth0.android.lock.enums.PasswordStrength;
 import com.auth0.android.lock.enums.PasswordlessMode;
 import com.auth0.android.lock.enums.SocialButtonStyle;
 import com.auth0.android.lock.enums.UsernameStyle;
@@ -49,6 +50,7 @@ public class Configuration {
     private static final String SHOW_SIGNUP_KEY = "showSignup";
     private static final String SHOW_FORGOT_KEY = "showForgot";
     private static final String REQUIRES_USERNAME_KEY = "requires_username";
+    public static final String PASSWORD_POLICY_KEY = "passwordPolicy";
     private final List<CustomField> extraSignUpFields;
 
     private Connection defaultDatabaseConnection;
@@ -69,6 +71,8 @@ public class Configuration {
     private boolean allowSignUp;
     private boolean allowForgotPassword;
     private boolean usernameRequired;
+    @PasswordStrength
+    private int passwordPolicy;
     private final boolean classicLockAvailable;
     private final boolean passwordlessLockAvailable;
     @UsernameStyle
@@ -250,6 +254,7 @@ public class Configuration {
             allowForgotPassword = getDefaultDatabaseConnection().booleanForKey(SHOW_FORGOT_KEY) && options.allowForgotPassword();
 
             usernameRequired = getDefaultDatabaseConnection().booleanForKey(REQUIRES_USERNAME_KEY);
+            passwordPolicy = parsePasswordPolicy((String) getDefaultDatabaseConnection().getValueForKey(PASSWORD_POLICY_KEY));
 
             initialScreen = options.initialScreen();
             switch (initialScreen) {
@@ -301,6 +306,21 @@ public class Configuration {
         }
     }
 
+    @PasswordStrength
+    private int parsePasswordPolicy(String policyName) {
+        if ("excellent".equalsIgnoreCase(policyName)) {
+            return PasswordStrength.EXCELLENT;
+        } else if ("good".equalsIgnoreCase(policyName)) {
+            return PasswordStrength.GOOD;
+        } else if ("fair".equalsIgnoreCase(policyName)) {
+            return PasswordStrength.FAIR;
+        } else if ("low".equalsIgnoreCase(policyName)) {
+            return PasswordStrength.LOW;
+        } else {
+            return PasswordStrength.NONE;
+        }
+    }
+
     private boolean shouldSelect(Connection connection, Set<String> connections) {
         return connections.isEmpty() || connections.contains(connection.getName());
     }
@@ -347,6 +367,11 @@ public class Configuration {
     @PasswordlessMode
     public int getPasswordlessMode() {
         return passwordlessMode;
+    }
+
+    @PasswordStrength
+    public int getPasswordPolicy() {
+        return passwordPolicy;
     }
 
     public boolean loginAfterSignUp() {

--- a/lib/src/main/java/com/auth0/android/lock/enums/PasswordStrength.java
+++ b/lib/src/main/java/com/auth0/android/lock/enums/PasswordStrength.java
@@ -1,0 +1,22 @@
+package com.auth0.android.lock.enums;
+
+import android.support.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import static com.auth0.android.lock.enums.PasswordStrength.EXCELLENT;
+import static com.auth0.android.lock.enums.PasswordStrength.FAIR;
+import static com.auth0.android.lock.enums.PasswordStrength.GOOD;
+import static com.auth0.android.lock.enums.PasswordStrength.LOW;
+import static com.auth0.android.lock.enums.PasswordStrength.NONE;
+
+@IntDef({NONE, LOW, FAIR, GOOD, EXCELLENT})
+@Retention(RetentionPolicy.SOURCE)
+public @interface PasswordStrength {
+    int NONE = 0;
+    int LOW = 1;
+    int FAIR = 2;
+    int GOOD = 3;
+    int EXCELLENT = 4;
+}

--- a/lib/src/main/java/com/auth0/android/lock/views/CheckableOptionView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/CheckableOptionView.java
@@ -72,6 +72,7 @@ public class CheckableOptionView extends LinearLayout {
         CharSequence text = a.getText(0);
         a.recycle();
         description.setText(text);
+        updateStatus();
     }
 
     public void setChecked(boolean checked) {

--- a/lib/src/main/java/com/auth0/android/lock/views/CheckableOptionView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/CheckableOptionView.java
@@ -25,15 +25,17 @@
 package com.auth0.android.lock.views;
 
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.support.v4.content.ContextCompat;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.auth0.android.lock.R;
 
-public class CheckableOptionView extends View {
+public class CheckableOptionView extends LinearLayout {
 
     private ImageView icon;
     private TextView description;
@@ -43,23 +45,33 @@ public class CheckableOptionView extends View {
 
     public CheckableOptionView(Context context) {
         super(context);
-        init();
+        init(null);
     }
 
     public CheckableOptionView(Context context, AttributeSet attrs) {
         super(context, attrs);
-        init();
+        init(attrs);
     }
 
     public CheckableOptionView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        init();
+        init(attrs);
     }
 
-    private void init() {
-        final View v = inflate(getContext(), R.layout.com_auth0_lock_checkable_option, null);
+    private void init(AttributeSet attrs) {
+        final View v = inflate(getContext(), R.layout.com_auth0_lock_checkable_option, this);
         icon = (ImageView) v.findViewById(R.id.com_auth0_lock_checkable_text_icon);
         description = (TextView) v.findViewById(R.id.com_auth0_lock_checkable_text_description);
+
+        if (attrs == null) {
+            return;
+        }
+
+        int[] set = {android.R.attr.text};
+        TypedArray a = getContext().obtainStyledAttributes(attrs, set);
+        CharSequence text = a.getText(0);
+        a.recycle();
+        description.setText(text);
     }
 
     public void setChecked(boolean checked) {

--- a/lib/src/main/java/com/auth0/android/lock/views/CheckableOptionView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/CheckableOptionView.java
@@ -75,20 +75,6 @@ public class CheckableOptionView extends LinearLayout {
         updateStatus();
     }
 
-    public void setText(String text) {
-        this.description.setText(text);
-    }
-
-    public void setChecked(boolean checked) {
-        this.checked = checked;
-        updateStatus();
-    }
-
-    public void setMandatory(boolean mandatory) {
-        this.mandatory = mandatory;
-        updateStatus();
-    }
-
     private void updateStatus() {
         if (checked) {
             icon.setImageResource(R.drawable.com_auth0_lock_ic_check_success);
@@ -97,5 +83,35 @@ public class CheckableOptionView extends LinearLayout {
         }
         icon.setImageResource(mandatory ? R.drawable.com_auth0_lock_ic_check_error : R.drawable.com_auth0_lock_ic_check_unset);
         description.setTextColor(ContextCompat.getColor(getContext(), mandatory ? R.color.com_auth0_lock_checkable_option_error : R.color.com_auth0_lock_checkable_option_unset));
+    }
+
+    /**
+     * Sets the current text/description for this Option.
+     *
+     * @param text to set.
+     */
+    public void setText(String text) {
+        this.description.setText(text);
+    }
+
+    /**
+     * Updates the current checked state of this Option widget.
+     *
+     * @param checked whether to check or uncheck the Option.
+     */
+    public void setChecked(boolean checked) {
+        this.checked = checked;
+        updateStatus();
+    }
+
+    /**
+     * If this Option is a requirement that must be met, set it to mandatory.
+     * Used for displaying a different image on the side when unchecked.
+     *
+     * @param mandatory whether this Option is required or not.
+     */
+    public void setMandatory(boolean mandatory) {
+        this.mandatory = mandatory;
+        updateStatus();
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/CheckableOptionView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/CheckableOptionView.java
@@ -75,6 +75,10 @@ public class CheckableOptionView extends LinearLayout {
         updateStatus();
     }
 
+    public void setText(String text) {
+        this.description.setText(text);
+    }
+
     public void setChecked(boolean checked) {
         this.checked = checked;
         updateStatus();

--- a/lib/src/main/java/com/auth0/android/lock/views/CheckableOptionView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/CheckableOptionView.java
@@ -1,0 +1,84 @@
+/*
+ * CheckableOptionView.java
+ *
+ * Copyright (c) 2016 Auth0 (http://auth0.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.auth0.android.lock.views;
+
+import android.content.Context;
+import android.support.v4.content.ContextCompat;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.auth0.android.lock.R;
+
+public class CheckableOptionView extends View {
+
+    private ImageView icon;
+    private TextView description;
+
+    private boolean mandatory;
+    private boolean checked;
+
+    public CheckableOptionView(Context context) {
+        super(context);
+        init();
+    }
+
+    public CheckableOptionView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public CheckableOptionView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    private void init() {
+        final View v = inflate(getContext(), R.layout.com_auth0_lock_checkable_option, null);
+        icon = (ImageView) v.findViewById(R.id.com_auth0_lock_checkable_text_icon);
+        description = (TextView) v.findViewById(R.id.com_auth0_lock_checkable_text_description);
+    }
+
+    public void setChecked(boolean checked) {
+        this.checked = checked;
+        updateStatus();
+    }
+
+    public void setMandatory(boolean mandatory) {
+        this.mandatory = mandatory;
+        updateStatus();
+    }
+
+    private void updateStatus() {
+        if (checked) {
+            icon.setImageResource(R.drawable.com_auth0_lock_ic_check_success);
+            description.setTextColor(ContextCompat.getColor(getContext(), R.color.com_auth0_lock_checkable_option_success));
+            return;
+        }
+        icon.setImageResource(mandatory ? R.drawable.com_auth0_lock_ic_check_error : R.drawable.com_auth0_lock_ic_check_unset);
+        description.setTextColor(ContextCompat.getColor(getContext(), mandatory ? R.color.com_auth0_lock_checkable_option_error : R.color.com_auth0_lock_checkable_option_unset));
+    }
+}

--- a/lib/src/main/java/com/auth0/android/lock/views/CheckableOptionView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/CheckableOptionView.java
@@ -82,7 +82,7 @@ public class CheckableOptionView extends LinearLayout {
             return;
         }
         icon.setImageResource(mandatory ? R.drawable.com_auth0_lock_ic_check_error : R.drawable.com_auth0_lock_ic_check_unset);
-        description.setTextColor(ContextCompat.getColor(getContext(), mandatory ? R.color.com_auth0_lock_checkable_option_error : R.color.com_auth0_lock_checkable_option_unset));
+        description.setTextColor(ContextCompat.getColor(getContext(), mandatory ? R.color.com_auth0_lock_checkable_option_error : R.color.com_auth0_lock_normal_text));
     }
 
     /**

--- a/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
@@ -78,7 +78,7 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
         topMessage = (TextView) findViewById(R.id.com_auth0_lock_text);
         domainParser = new EnterpriseConnectionMatcher(lockWidget.getConfiguration().getEnterpriseStrategies());
         usernameInput = (ValidatedUsernameInputView) findViewById(R.id.com_auth0_lock_input_username);
-        passwordInput = (ValidatedInputView) findViewById(R.id.com_auth0_lock_input_password);
+        passwordInput = (ValidatedPasswordInputView) findViewById(R.id.com_auth0_lock_input_password);
         passwordInput.setOnEditorActionListener(this);
 
         emailInput = (ValidatedUsernameInputView) findViewById(R.id.com_auth0_lock_input_username_email);

--- a/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
@@ -49,7 +49,7 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
     private final LockWidgetForm lockWidget;
     private ValidatedUsernameInputView emailInput;
     private ValidatedUsernameInputView usernameInput;
-    private ValidatedInputView passwordInput;
+    private ValidatedPasswordInputView passwordInput;
     private View changePasswordBtn;
     private TextView topMessage;
     private Connection currentConnection;

--- a/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
@@ -49,7 +49,7 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
     private final LockWidgetForm lockWidget;
     private ValidatedUsernameInputView emailInput;
     private ValidatedUsernameInputView usernameInput;
-    private ValidatedPasswordInputView passwordInput;
+    private ValidatedInputView passwordInput;
     private View changePasswordBtn;
     private TextView topMessage;
     private Connection currentConnection;
@@ -78,7 +78,8 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
         topMessage = (TextView) findViewById(R.id.com_auth0_lock_text);
         domainParser = new EnterpriseConnectionMatcher(lockWidget.getConfiguration().getEnterpriseStrategies());
         usernameInput = (ValidatedUsernameInputView) findViewById(R.id.com_auth0_lock_input_username);
-        passwordInput = (ValidatedPasswordInputView) findViewById(R.id.com_auth0_lock_input_password);
+        passwordInput = (ValidatedInputView) findViewById(R.id.com_auth0_lock_input_password);
+        passwordInput.setDataType(ValidatedInputView.DataType.PASSWORD);
         passwordInput.setOnEditorActionListener(this);
 
         emailInput = (ValidatedUsernameInputView) findViewById(R.id.com_auth0_lock_input_username_email);

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
@@ -90,9 +90,11 @@ public class PasswordStrengthView extends LinearLayout {
      */
     private void showPolicy() {
         if (strength == PasswordStrength.NONE) {
+            setEnabled(false);
             setVisibility(GONE);
             return;
         }
+        setEnabled(true);
         setVisibility(VISIBLE);
 
         optionLowercase.setMandatory(strength == PasswordStrength.FAIR);

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
@@ -102,7 +102,7 @@ public class PasswordStrengthView extends LinearLayout {
         optionNumeric.setMandatory(strength == PasswordStrength.FAIR);
 
         titleAtLeast.setVisibility(strength == PasswordStrength.FAIR || strength == PasswordStrength.LOW ? GONE : VISIBLE);
-        String lengthRequirements = getContext().getResources().getString(R.string.password_strength_chars_length);
+        String lengthRequirements = getContext().getResources().getString(R.string.com_auth0_lock_password_strength_chars_length);
         optionLength.setText(String.format(lengthRequirements, getMinimumLength()));
 
         optionLowercase.setVisibility(strength == PasswordStrength.LOW ? GONE : VISIBLE);

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
@@ -1,0 +1,121 @@
+/*
+ * CheckableOptionView.java
+ *
+ * Copyright (c) 2016 Auth0 (http://auth0.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.auth0.android.lock.views;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.auth0.android.lock.R;
+import com.auth0.android.lock.enums.PasswordStrength;
+
+
+public class PasswordStrengthView extends LinearLayout {
+
+    private static final String UPPERCASE_REGEX = "^[AZ]$";
+    private static final String LOWERCASE_REGEX = "^[az]$";
+    private static final String SPECIAL_REGEX = "^[ !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~]$";
+    private static final String NUMERIC_REGEX = "^[09]$";
+
+    @PasswordStrength
+    private int strength;
+
+    private TextView titleMustHave;
+    private TextView titleAtLeast;
+    private CheckableOptionView optionLength;
+    private CheckableOptionView optionIdenticalCharacters;
+    private CheckableOptionView optionLowercase;
+    private CheckableOptionView optionUppercase;
+    private CheckableOptionView optionNumbers;
+    private CheckableOptionView optionSpecialCharacters;
+
+    public PasswordStrengthView(Context context) {
+        super(context);
+        init();
+    }
+
+    private void init() {
+        inflate(getContext(), R.layout.com_auth0_lock_password_strength, this);
+        titleMustHave = (TextView) findViewById(R.id.com_auth0_lock_password_strength_title_must_have);
+        titleAtLeast = (TextView) findViewById(R.id.com_auth0_lock_password_strength_title_at_least);
+
+        optionLength = (CheckableOptionView) findViewById(R.id.com_auth0_lock_password_strength_option_length);
+        optionIdenticalCharacters = (CheckableOptionView) findViewById(R.id.com_auth0_lock_password_strength_option_identical_characters);
+        optionLowercase = (CheckableOptionView) findViewById(R.id.com_auth0_lock_password_strength_option_lowercase);
+        optionUppercase = (CheckableOptionView) findViewById(R.id.com_auth0_lock_password_strength_option_uppercase);
+        optionNumbers = (CheckableOptionView) findViewById(R.id.com_auth0_lock_password_strength_option_numbers);
+        optionSpecialCharacters = (CheckableOptionView) findViewById(R.id.com_auth0_lock_password_strength_option_special_characters);
+    }
+
+    /**
+     * @see "https://auth0.com/docs/connections/database/password-strength"
+     */
+    private void showStrengthPolicy() {
+        setVisibility(strength == PasswordStrength.NONE ? View.GONE : VISIBLE);
+    }
+
+    private boolean hasUppercaseCharacters(@NonNull String input) {
+        return UPPERCASE_REGEX.matches(input);
+    }
+
+    private boolean hasLowercaseCharacters(@NonNull String input) {
+        return LOWERCASE_REGEX.matches(input);
+    }
+
+    private boolean hasNumericCharacters(@NonNull String input) {
+        return NUMERIC_REGEX.matches(input);
+    }
+
+    private boolean hasSpecialCharacters(@NonNull String input) {
+        return SPECIAL_REGEX.matches(input);
+    }
+
+    private boolean hasMinimumLength(@NonNull String input, int length) {
+        return input.length() >= length;
+    }
+
+
+    /**
+     * Sets the current level of Strength that this widget is going to validate.
+     *
+     * @param strength the required strength level.
+     */
+    public void setStrength(@PasswordStrength int strength) {
+        this.strength = strength;
+    }
+
+    /**
+     * Checks that all the requirements are meet.
+     *
+     * @param password the current password to validate
+     * @return whether the given password complies with this password policy or not.
+     */
+    public boolean isValid(String password) {
+        return false;
+    }
+
+}

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
@@ -40,6 +40,7 @@ public class PasswordStrengthView extends LinearLayout {
     private static final String LOWERCASE_REGEX = "^[az]$";
     private static final String SPECIAL_REGEX = "^[ !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~]$";
     private static final String NUMERIC_REGEX = "^[09]$";
+    private static final String IDENTICAL_REGEX = "(.)\\1\\1";
 
     @PasswordStrength
     private int strength;
@@ -74,8 +75,26 @@ public class PasswordStrengthView extends LinearLayout {
     /**
      * @see "https://auth0.com/docs/connections/database/password-strength"
      */
-    private void showStrengthPolicy() {
+    private void showPolicyUI() {
         setVisibility(strength == PasswordStrength.NONE ? View.GONE : VISIBLE);
+
+        switch (strength) {
+            case PasswordStrength.EXCELLENT:
+                break;
+            case PasswordStrength.GOOD:
+                break;
+            case PasswordStrength.FAIR:
+                break;
+            case PasswordStrength.LOW:
+                break;
+            case PasswordStrength.NONE:
+
+                break;
+        }
+    }
+
+    private boolean hasIdenticalCharacters(@NonNull String input) {
+        return IDENTICAL_REGEX.matches(input);
     }
 
     private boolean hasUppercaseCharacters(@NonNull String input) {
@@ -98,6 +117,13 @@ public class PasswordStrengthView extends LinearLayout {
         return input.length() >= length;
     }
 
+    private boolean atLeastThree(boolean a, boolean b, boolean c, boolean d) {
+        boolean one = a && b && (c ^ d);
+        boolean two = b && c && (d ^ a);
+        boolean three = c && d && (a ^ b);
+
+        return one || two || three;
+    }
 
     /**
      * Sets the current level of Strength that this widget is going to validate.
@@ -115,7 +141,34 @@ public class PasswordStrengthView extends LinearLayout {
      * @return whether the given password complies with this password policy or not.
      */
     public boolean isValid(String password) {
-        return false;
+        if (password == null || password.isEmpty()) {
+            return false;
+        }
+
+        boolean length = true;
+        boolean atLeast = true;
+        switch (strength) {
+            case PasswordStrength.EXCELLENT:
+                atLeast = atLeastThree(hasLowercaseCharacters(password), hasUppercaseCharacters(password), hasNumericCharacters(password), hasSpecialCharacters(password))
+                        && !hasIdenticalCharacters(password);
+                length = hasMinimumLength(password, 10);
+                break;
+            case PasswordStrength.GOOD:
+                atLeast = atLeastThree(hasLowercaseCharacters(password), hasUppercaseCharacters(password), hasNumericCharacters(password), hasSpecialCharacters(password));
+                length = hasMinimumLength(password, 8);
+                break;
+            case PasswordStrength.FAIR:
+                atLeast = hasLowercaseCharacters(password) && hasUppercaseCharacters(password) && hasNumericCharacters(password);
+                length = hasMinimumLength(password, 8);
+                break;
+            case PasswordStrength.LOW:
+                length = hasMinimumLength(password, 6);
+                break;
+            case PasswordStrength.NONE:
+                length = hasMinimumLength(password, 1);
+                break;
+        }
+        return length && atLeast;
     }
 
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
@@ -36,14 +36,15 @@ import com.auth0.android.lock.enums.PasswordStrength;
 
 public class PasswordStrengthView extends LinearLayout {
 
+    private static final String TAG = PasswordStrengthView.class.getSimpleName();
+
     private static final String UPPERCASE_REGEX = "^[AZ]$";
     private static final String LOWERCASE_REGEX = "^[az]$";
     private static final String SPECIAL_REGEX = "^[ !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~]$";
     private static final String NUMERIC_REGEX = "^[09]$";
-    private static final String IDENTICAL_REGEX = "(.)\\1\\1";
 
     @PasswordStrength
-    private int strength;
+    private int strength = PasswordStrength.EXCELLENT;
 
     private TextView titleMustHave;
     private TextView titleAtLeast;
@@ -94,7 +95,21 @@ public class PasswordStrengthView extends LinearLayout {
     }
 
     private boolean hasIdenticalCharacters(@NonNull String input) {
-        return IDENTICAL_REGEX.matches(input);
+        int count = 0;
+        char lastChar = 0;
+        for (char c : input.toCharArray()) {
+            if (lastChar == c) {
+                count++;
+            } else {
+                lastChar = c;
+                count = 1;
+            }
+
+            if (count > 2) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean hasUppercaseCharacters(@NonNull String input) {
@@ -146,19 +161,19 @@ public class PasswordStrengthView extends LinearLayout {
         }
 
         boolean length = true;
-        boolean atLeast = true;
+        boolean other = true;
         switch (strength) {
             case PasswordStrength.EXCELLENT:
-                atLeast = atLeastThree(hasLowercaseCharacters(password), hasUppercaseCharacters(password), hasNumericCharacters(password), hasSpecialCharacters(password))
-                        && !hasIdenticalCharacters(password);
+                boolean atLeast = atLeastThree(hasLowercaseCharacters(password), hasUppercaseCharacters(password), hasNumericCharacters(password), hasSpecialCharacters(password));
+                other = hasIdenticalCharacters(password) && atLeast;
                 length = hasMinimumLength(password, 10);
                 break;
             case PasswordStrength.GOOD:
-                atLeast = atLeastThree(hasLowercaseCharacters(password), hasUppercaseCharacters(password), hasNumericCharacters(password), hasSpecialCharacters(password));
+                other = atLeastThree(hasLowercaseCharacters(password), hasUppercaseCharacters(password), hasNumericCharacters(password), hasSpecialCharacters(password));
                 length = hasMinimumLength(password, 8);
                 break;
             case PasswordStrength.FAIR:
-                atLeast = hasLowercaseCharacters(password) && hasUppercaseCharacters(password) && hasNumericCharacters(password);
+                other = hasLowercaseCharacters(password) && hasUppercaseCharacters(password) && hasNumericCharacters(password);
                 length = hasMinimumLength(password, 8);
                 break;
             case PasswordStrength.LOW:
@@ -168,7 +183,7 @@ public class PasswordStrengthView extends LinearLayout {
                 length = hasMinimumLength(password, 1);
                 break;
         }
-        return length && atLeast;
+        return length && other;
     }
 
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
@@ -38,8 +38,14 @@ import java.util.regex.Pattern;
 public class PasswordStrengthView extends LinearLayout {
 
     private static final String TAG = PasswordStrengthView.class.getSimpleName();
+
     private static final int MAX_IDENTICAL_CHARACTERS_IN_A_ROW = 2;
     private static final int MAX_LENGTH = 128;
+    private static final int MIN_LENGTH_EXCELLENT = 10;
+    private static final int MIN_LENGTH_GOOD = 8;
+    private static final int MIN_LENGTH_FAIR = 8;
+    private static final int MIN_LENGTH_LOW = 6;
+    private static final int MIN_LENGTH_NONE = 1;
 
     private final Pattern patternUppercase = Pattern.compile("^.*[A-Z]+.*$");
     private final Pattern patternLowercase = Pattern.compile("^.*[a-z]+.*$");
@@ -55,7 +61,7 @@ public class PasswordStrengthView extends LinearLayout {
     private CheckableOptionView optionIdenticalCharacters;
     private CheckableOptionView optionLowercase;
     private CheckableOptionView optionUppercase;
-    private CheckableOptionView optionNumbers;
+    private CheckableOptionView optionNumeric;
     private CheckableOptionView optionSpecialCharacters;
 
     public PasswordStrengthView(Context context) {
@@ -74,7 +80,7 @@ public class PasswordStrengthView extends LinearLayout {
         optionIdenticalCharacters.setMandatory(true);
         optionLowercase = (CheckableOptionView) findViewById(R.id.com_auth0_lock_password_strength_option_lowercase);
         optionUppercase = (CheckableOptionView) findViewById(R.id.com_auth0_lock_password_strength_option_uppercase);
-        optionNumbers = (CheckableOptionView) findViewById(R.id.com_auth0_lock_password_strength_option_numbers);
+        optionNumeric = (CheckableOptionView) findViewById(R.id.com_auth0_lock_password_strength_option_numeric);
         optionSpecialCharacters = (CheckableOptionView) findViewById(R.id.com_auth0_lock_password_strength_option_special_characters);
         setStrength(PasswordStrength.NONE);
     }
@@ -91,25 +97,10 @@ public class PasswordStrengthView extends LinearLayout {
 
         optionLowercase.setMandatory(strength == PasswordStrength.FAIR);
         optionUppercase.setMandatory(strength == PasswordStrength.FAIR);
-        optionNumbers.setMandatory(strength == PasswordStrength.FAIR);
-
+        optionNumeric.setMandatory(strength == PasswordStrength.FAIR);
 
         optionSpecialCharacters.setVisibility(strength == PasswordStrength.EXCELLENT || strength == PasswordStrength.GOOD ? VISIBLE : GONE);
-        optionSpecialCharacters.setVisibility(strength == PasswordStrength.EXCELLENT ? VISIBLE : GONE);
-
-        switch (strength) {
-            case PasswordStrength.EXCELLENT:
-                break;
-            case PasswordStrength.GOOD:
-                break;
-            case PasswordStrength.FAIR:
-                break;
-            case PasswordStrength.LOW:
-                break;
-            case PasswordStrength.NONE:
-
-                break;
-        }
+        optionIdenticalCharacters.setVisibility(strength == PasswordStrength.EXCELLENT ? VISIBLE : GONE);
     }
 
     private boolean hasIdenticalCharacters(@NonNull String input) {
@@ -146,7 +137,7 @@ public class PasswordStrengthView extends LinearLayout {
 
     private boolean hasNumericCharacters(@NonNull String input) {
         boolean v = patternNumeric.matcher(input).matches();
-        optionNumbers.setChecked(v);
+        optionNumeric.setChecked(v);
         return v;
     }
 
@@ -168,6 +159,10 @@ public class PasswordStrengthView extends LinearLayout {
         boolean three = c && d && (a ^ b);
 
         return one || two || three;
+    }
+
+    private boolean allThree(boolean a, boolean b, boolean c) {
+        return a && b && c;
     }
 
     /**
@@ -197,21 +192,21 @@ public class PasswordStrengthView extends LinearLayout {
             case PasswordStrength.EXCELLENT:
                 boolean atLeast = atLeastThree(hasLowercaseCharacters(password), hasUppercaseCharacters(password), hasNumericCharacters(password), hasSpecialCharacters(password));
                 other = hasIdenticalCharacters(password) && atLeast;
-                length = hasMinimumLength(password, 10);
+                length = hasMinimumLength(password, MIN_LENGTH_EXCELLENT);
                 break;
             case PasswordStrength.GOOD:
                 other = atLeastThree(hasLowercaseCharacters(password), hasUppercaseCharacters(password), hasNumericCharacters(password), hasSpecialCharacters(password));
-                length = hasMinimumLength(password, 8);
+                length = hasMinimumLength(password, MIN_LENGTH_GOOD);
                 break;
             case PasswordStrength.FAIR:
-                other = hasLowercaseCharacters(password) && hasUppercaseCharacters(password) && hasNumericCharacters(password);
-                length = hasMinimumLength(password, 8);
+                other = allThree(hasLowercaseCharacters(password), hasUppercaseCharacters(password), hasNumericCharacters(password));
+                length = hasMinimumLength(password, MIN_LENGTH_FAIR);
                 break;
             case PasswordStrength.LOW:
-                length = hasMinimumLength(password, 6);
+                length = hasMinimumLength(password, MIN_LENGTH_LOW);
                 break;
             case PasswordStrength.NONE:
-                length = hasMinimumLength(password, 1);
+                length = hasMinimumLength(password, MIN_LENGTH_NONE);
                 break;
         }
         return length && other;

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
@@ -82,7 +82,7 @@ public class PasswordStrengthView extends LinearLayout {
         optionUppercase = (CheckableOptionView) findViewById(R.id.com_auth0_lock_password_strength_option_uppercase);
         optionNumeric = (CheckableOptionView) findViewById(R.id.com_auth0_lock_password_strength_option_numeric);
         optionSpecialCharacters = (CheckableOptionView) findViewById(R.id.com_auth0_lock_password_strength_option_special_characters);
-        setStrength(PasswordStrength.NONE);
+        setStrength(PasswordStrength.LOW);
     }
 
     /**
@@ -99,6 +99,13 @@ public class PasswordStrengthView extends LinearLayout {
         optionUppercase.setMandatory(strength == PasswordStrength.FAIR);
         optionNumeric.setMandatory(strength == PasswordStrength.FAIR);
 
+        titleAtLeast.setVisibility(strength == PasswordStrength.FAIR || strength == PasswordStrength.LOW ? GONE : VISIBLE);
+        String lengthRequirements = getContext().getResources().getString(R.string.password_strength_chars_length);
+        optionLength.setText(String.format(lengthRequirements, getMinimumLength()));
+
+        optionLowercase.setVisibility(strength == PasswordStrength.LOW ? GONE : VISIBLE);
+        optionUppercase.setVisibility(strength == PasswordStrength.LOW ? GONE : VISIBLE);
+        optionNumeric.setVisibility(strength == PasswordStrength.LOW ? GONE : VISIBLE);
         optionSpecialCharacters.setVisibility(strength == PasswordStrength.EXCELLENT || strength == PasswordStrength.GOOD ? VISIBLE : GONE);
         optionIdenticalCharacters.setVisibility(strength == PasswordStrength.EXCELLENT ? VISIBLE : GONE);
     }
@@ -165,6 +172,22 @@ public class PasswordStrengthView extends LinearLayout {
         return a && b && c;
     }
 
+    private int getMinimumLength() {
+        switch (strength) {
+            case PasswordStrength.EXCELLENT:
+                return MIN_LENGTH_EXCELLENT;
+            case PasswordStrength.GOOD:
+                return MIN_LENGTH_GOOD;
+            case PasswordStrength.FAIR:
+                return MIN_LENGTH_FAIR;
+            case PasswordStrength.LOW:
+                return MIN_LENGTH_LOW;
+            default:
+            case PasswordStrength.NONE:
+                return MIN_LENGTH_NONE;
+        }
+    }
+
     /**
      * Sets the current level of Strength that this widget is going to validate.
      *
@@ -186,28 +209,21 @@ public class PasswordStrengthView extends LinearLayout {
             return false;
         }
 
-        boolean length = true;
+        boolean length = hasMinimumLength(password, getMinimumLength());
         boolean other = true;
         switch (strength) {
             case PasswordStrength.EXCELLENT:
                 boolean atLeast = atLeastThree(hasLowercaseCharacters(password), hasUppercaseCharacters(password), hasNumericCharacters(password), hasSpecialCharacters(password));
                 other = hasIdenticalCharacters(password) && atLeast;
-                length = hasMinimumLength(password, MIN_LENGTH_EXCELLENT);
                 break;
             case PasswordStrength.GOOD:
                 other = atLeastThree(hasLowercaseCharacters(password), hasUppercaseCharacters(password), hasNumericCharacters(password), hasSpecialCharacters(password));
-                length = hasMinimumLength(password, MIN_LENGTH_GOOD);
                 break;
             case PasswordStrength.FAIR:
                 other = allThree(hasLowercaseCharacters(password), hasUppercaseCharacters(password), hasNumericCharacters(password));
-                length = hasMinimumLength(password, MIN_LENGTH_FAIR);
                 break;
             case PasswordStrength.LOW:
-                length = hasMinimumLength(password, MIN_LENGTH_LOW);
-                break;
             case PasswordStrength.NONE:
-                length = hasMinimumLength(password, MIN_LENGTH_NONE);
-                break;
         }
         return length && other;
     }

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
@@ -82,7 +82,7 @@ public class PasswordStrengthView extends LinearLayout {
         optionUppercase = (CheckableOptionView) findViewById(R.id.com_auth0_lock_password_strength_option_uppercase);
         optionNumeric = (CheckableOptionView) findViewById(R.id.com_auth0_lock_password_strength_option_numeric);
         optionSpecialCharacters = (CheckableOptionView) findViewById(R.id.com_auth0_lock_password_strength_option_special_characters);
-        setStrength(PasswordStrength.EXCELLENT);
+        setStrength(PasswordStrength.NONE);
     }
 
     /**

--- a/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
@@ -55,7 +55,7 @@ public class SignUpFormView extends FormView implements TextView.OnEditorActionL
     private final LockWidgetForm lockWidget;
     private ValidatedInputView usernameInput;
     private ValidatedInputView emailInput;
-    private ValidatedInputView passwordInput;
+    private ValidatedPasswordInputView passwordInput;
     private LinearLayout fieldContainer;
     private boolean displayFewCustomFields;
 
@@ -82,8 +82,8 @@ public class SignUpFormView extends FormView implements TextView.OnEditorActionL
         emailInput.setDataType(ValidatedInputView.DataType.EMAIL);
         emailInput.setIdentityListener(this);
         emailInput.setOnEditorActionListener(this);
-        passwordInput = (ValidatedInputView) findViewById(R.id.com_auth0_lock_input_password);
-        passwordInput.setDataType(ValidatedInputView.DataType.PASSWORD);
+        passwordInput = (ValidatedPasswordInputView) findViewById(R.id.com_auth0_lock_input_password);
+        passwordInput.setPasswordPolicy(configuration.getPasswordPolicy());
         passwordInput.setOnEditorActionListener(this);
 
         usernameInput.setVisibility(configuration.isUsernameRequired() ? View.VISIBLE : View.GONE);

--- a/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
@@ -73,7 +73,7 @@ public class SignUpFormView extends FormView implements TextView.OnEditorActionL
     private void init() {
         Configuration configuration = lockWidget.getConfiguration();
         inflate(getContext(), R.layout.com_auth0_lock_signup_form_view, this);
-        fieldContainer = (LinearLayout) findViewById(R.id.com_auth0_lock_container);
+        fieldContainer = (LinearLayout) findViewById(R.id.com_auth0_lock_custom_fields_container);
 
         usernameInput = (ValidatedInputView) findViewById(R.id.com_auth0_lock_input_username);
         usernameInput.setDataType(ValidatedInputView.DataType.USERNAME);

--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedInputView.java
@@ -30,6 +30,7 @@ import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Handler;
+import android.support.annotation.CallSuper;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.IntDef;
 import android.support.annotation.StringRes;
@@ -41,7 +42,6 @@ import android.text.method.PasswordTransformationMethod;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.util.Patterns;
-import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.ImageView;
@@ -245,6 +245,12 @@ public class ValidatedInputView extends LinearLayout {
         icon.setImageResource(inputIcon);
     }
 
+    /**
+     * Updates the view knowing if the input is valid or not.
+     *
+     * @param isValid if the input is valid or not for this kind of DataType.
+     */
+    @CallSuper
     protected void updateBorder(boolean isValid) {
         ViewGroup parent = ((ViewGroup) input.getParent());
         Drawable bg = parent.getBackground();
@@ -267,6 +273,7 @@ public class ValidatedInputView extends LinearLayout {
     }
 
     @Override
+    @CallSuper
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
 
@@ -291,6 +298,7 @@ public class ValidatedInputView extends LinearLayout {
 
     /**
      * Validates the input data and updates the icon. DataType must be set.
+     * Empty fields are considered valid.
      *
      * @return whether the data is valid or not.
      */
@@ -300,6 +308,12 @@ public class ValidatedInputView extends LinearLayout {
         return isValid;
     }
 
+    /**
+     * Validates the input data and updates the icon. DataType must be set.
+     *
+     * @param validateEmptyFields if an empty input should be considered invalid.
+     * @return whether the data is valid or not.
+     */
     protected boolean validate(boolean validateEmptyFields) {
         boolean isValid = false;
         String value = getText();

--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedInputView.java
@@ -41,6 +41,7 @@ import android.text.method.PasswordTransformationMethod;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.util.Patterns;
+import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.ImageView;
@@ -72,12 +73,12 @@ public class ValidatedInputView extends LinearLayout {
     private static final int MIN_PASSWORD_LENGTH = 6;
     private static final int VALIDATION_DELAY = 500;
 
+    protected LinearLayout rootView;
     private TextView errorDescription;
     private EditText input;
     private ImageView icon;
     private IdentityListener identityListener;
     private int inputIcon;
-    private boolean isShowingError = true;
     private boolean hasValidInput;
 
     @IntDef({USERNAME, EMAIL, USERNAME_OR_EMAIL, NUMBER, PHONE_NUMBER, PASSWORD, MOBILE_PHONE, DATE})
@@ -113,6 +114,7 @@ public class ValidatedInputView extends LinearLayout {
 
     private void init(AttributeSet attrs) {
         inflate(getContext(), R.layout.com_auth0_lock_validated_input_view, this);
+        rootView = (LinearLayout) findViewById(R.id.com_auth0_lock_container);
         errorDescription = (TextView) findViewById(R.id.errorDescription);
         icon = (ImageView) findViewById(R.id.com_auth0_lock_icon);
         input = (EditText) findViewById(R.id.com_auth0_lock_input);
@@ -243,7 +245,7 @@ public class ValidatedInputView extends LinearLayout {
         icon.setImageResource(inputIcon);
     }
 
-    private void updateBorder(boolean isValid) {
+    protected void updateBorder(boolean isValid) {
         ViewGroup parent = ((ViewGroup) input.getParent());
         Drawable bg = parent.getBackground();
         GradientDrawable gd = bg == null ? new GradientDrawable() : (GradientDrawable) bg;
@@ -254,7 +256,6 @@ public class ValidatedInputView extends LinearLayout {
         ViewUtils.setBackground(parent, gd);
 
         errorDescription.setVisibility(isValid ? INVISIBLE : VISIBLE);
-        isShowingError = !isValid;
         requestLayout();
     }
 
@@ -299,7 +300,7 @@ public class ValidatedInputView extends LinearLayout {
         return isValid;
     }
 
-    private boolean validate(boolean validateEmptyFields) {
+    protected boolean validate(boolean validateEmptyFields) {
         boolean isValid = false;
         String value = getText();
         if (!validateEmptyFields && value.isEmpty()) {

--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedInputView.java
@@ -70,7 +70,6 @@ public class ValidatedInputView extends LinearLayout {
     public static final String CODE_REGEX = "^[0-9]{4,12}$";
     public static final String EMAIL_REGEX = Patterns.EMAIL_ADDRESS.pattern();
     private static final String TAG = ValidatedInputView.class.getSimpleName();
-    private static final int MIN_PASSWORD_LENGTH = 6;
     private static final int VALIDATION_DELAY = 500;
 
     protected LinearLayout rootView;
@@ -316,7 +315,7 @@ public class ValidatedInputView extends LinearLayout {
      */
     protected boolean validate(boolean validateEmptyFields) {
         boolean isValid = false;
-        String value = getText();
+        String value = dataType == PASSWORD ? getText() : getText().trim();
         if (!validateEmptyFields && value.isEmpty()) {
             return true;
         }
@@ -326,7 +325,7 @@ public class ValidatedInputView extends LinearLayout {
                 isValid = value.matches(EMAIL_REGEX);
                 break;
             case PASSWORD:
-                isValid = value.length() >= MIN_PASSWORD_LENGTH;
+                isValid = !value.isEmpty();
                 break;
             case USERNAME:
                 isValid = value.matches(USERNAME_REGEX);
@@ -351,12 +350,12 @@ public class ValidatedInputView extends LinearLayout {
     }
 
     /**
-     * Gets the current text from the input field, without spaces at the end.
+     * Gets the current text from the input field.
      *
      * @return the current text
      */
     public String getText() {
-        return input.getText().toString().trim();
+        return input.getText().toString();
     }
 
     /**

--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedPasswordInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedPasswordInputView.java
@@ -51,6 +51,14 @@ public class ValidatedPasswordInputView extends ValidatedInputView {
         return valid;
     }
 
+    @Override
+    protected void updateBorder(boolean isValid) {
+        super.updateBorder(isValid);
+        if (strengthView != null) {
+            strengthView.setVisibility(!isValid || !getText().isEmpty() ? VISIBLE : GONE);
+        }
+    }
+
     /**
      * Sets the Password Strength Policy level for this view.
      *

--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedPasswordInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedPasswordInputView.java
@@ -39,11 +39,12 @@ public class ValidatedPasswordInputView extends ValidatedInputView {
     @Override
     protected boolean validate(boolean validateEmptyFields) {
         String value = getText();
+        //Run strength validation to update ui
+        final boolean valid = strengthView.isValid(value);
         if (!validateEmptyFields && value.isEmpty()) {
             return true;
         }
 
-        final boolean valid = strengthView.isValid(value);
         Log.v(TAG, "Field validation results: Is valid? " + valid);
         return valid;
     }

--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedPasswordInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedPasswordInputView.java
@@ -54,7 +54,7 @@ public class ValidatedPasswordInputView extends ValidatedInputView {
     @Override
     protected void updateBorder(boolean isValid) {
         super.updateBorder(isValid);
-        if (strengthView != null) {
+        if (strengthView != null && strengthView.isEnabled()) {
             strengthView.setVisibility(!isValid || !getText().isEmpty() ? VISIBLE : GONE);
         }
     }

--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedPasswordInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedPasswordInputView.java
@@ -1,65 +1,50 @@
-/*
- * ValidatedPasswordInputView.java
- *
- * Copyright (c) 2016 Auth0 (http://auth0.com)
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
-
 package com.auth0.android.lock.views;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.view.View;
+import android.util.Log;
 
-import com.auth0.android.lock.R;
 
 public class ValidatedPasswordInputView extends ValidatedInputView {
+    private static final String TAG = ValidatedPasswordInputView.class.getSimpleName();
+    private PasswordStrengthView strengthView;
 
     public ValidatedPasswordInputView(Context context) {
         super(context);
-        addStrengthView();
-    }
-
-    public ValidatedPasswordInputView(Context context, AttributeSet attrs) {
-        super(context, attrs);
-        addStrengthView();
+        init();
     }
 
     public ValidatedPasswordInputView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        addStrengthView();
+        init();
     }
 
-
-    private void addStrengthView() {
-        final View inflate = inflate(getContext(), R.layout.com_auth0_lock_password_strength, null);
-        addView(inflate);
+    public ValidatedPasswordInputView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
     }
 
-    /**
-     * Choose the password strength for this input field.
-     *
-     * @param level of password strength
-     */
-    public void setPasswordStrength(int level) {
+    public void init() {
+        strengthView = new PasswordStrengthView(getContext());
+        rootView.addView(strengthView, 0);  //Add it above the field
+    }
 
-        //TODO: complete me
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+        int strengthHeight = ViewUtils.measureViewHeight(strengthView);
+        setMeasuredDimension(getMeasuredWidth(), getMeasuredHeight() + strengthHeight);
+    }
+
+    @Override
+    protected boolean validate(boolean validateEmptyFields) {
+        String value = getText();
+        if (!validateEmptyFields && value.isEmpty()) {
+            return true;
+        }
+
+        final boolean valid = strengthView.isValid(value);
+        Log.v(TAG, "Field validation results: Is valid? " + valid);
+        return valid;
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedPasswordInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedPasswordInputView.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.util.Log;
 
+import com.auth0.android.lock.enums.PasswordStrength;
+
 
 public class ValidatedPasswordInputView extends ValidatedInputView {
     private static final String TAG = ValidatedPasswordInputView.class.getSimpleName();
@@ -47,5 +49,14 @@ public class ValidatedPasswordInputView extends ValidatedInputView {
 
         Log.v(TAG, "Field validation results: Is valid? " + valid);
         return valid;
+    }
+
+    /**
+     * Sets the Password Strength Policy level for this view.
+     *
+     * @param strength the new Policy level.
+     */
+    public void setPasswordPolicy(@PasswordStrength int strength) {
+        strengthView.setStrength(strength);
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedPasswordInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedPasswordInputView.java
@@ -1,0 +1,65 @@
+/*
+ * ValidatedPasswordInputView.java
+ *
+ * Copyright (c) 2016 Auth0 (http://auth0.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.auth0.android.lock.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+
+import com.auth0.android.lock.R;
+
+public class ValidatedPasswordInputView extends ValidatedInputView {
+
+    public ValidatedPasswordInputView(Context context) {
+        super(context);
+        addStrengthView();
+    }
+
+    public ValidatedPasswordInputView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        addStrengthView();
+    }
+
+    public ValidatedPasswordInputView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        addStrengthView();
+    }
+
+
+    private void addStrengthView() {
+        final View inflate = inflate(getContext(), R.layout.com_auth0_lock_password_strength, null);
+        addView(inflate);
+    }
+
+    /**
+     * Choose the password strength for this input field.
+     *
+     * @param level of password strength
+     */
+    public void setPasswordStrength(int level) {
+
+        //TODO: complete me
+    }
+}

--- a/lib/src/main/res/drawable/com_auth0_lock_ic_check_error.xml
+++ b/lib/src/main/res/drawable/com_auth0_lock_ic_check_error.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="12dp"
+    android:viewportHeight="12.0"
+    android:viewportWidth="12.0">
+    <path
+        android:fillColor="#BE4527"
+        android:pathData="M0,6a6,6 0,1 0,12 0a6,6 0,1 0,-12 0z"
+        android:strokeColor="#00000000"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M9,3.604l-0.604,-0.604l-2.396,2.396l-2.396,-2.396l-0.604,0.604l2.396,2.396l-2.396,2.396l0.604,0.604l2.396,-2.396l2.396,2.396l0.604,-0.604l-2.396,-2.396z"
+        android:strokeColor="#00000000"
+        android:strokeWidth="1" />
+</vector>

--- a/lib/src/main/res/drawable/com_auth0_lock_ic_check_success.xml
+++ b/lib/src/main/res/drawable/com_auth0_lock_ic_check_success.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="12dp"
+    android:viewportHeight="12.0"
+    android:viewportWidth="12.0">
+    <path
+        android:fillColor="#80D135"
+        android:pathData="M0,6a6,6 0,1 0,12 0a6,6 0,1 0,-12 0z"
+        android:strokeColor="#00000000"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M4.542,7.734l-1.897,-1.866l-0.646,0.631l2.542,2.501l5.458,-5.369l-0.641,-0.631z"
+        android:strokeColor="#00000000"
+        android:strokeWidth="1" />
+</vector>

--- a/lib/src/main/res/drawable/com_auth0_lock_ic_check_unset.xml
+++ b/lib/src/main/res/drawable/com_auth0_lock_ic_check_unset.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="12dp"
+    android:viewportHeight="12.0"
+    android:viewportWidth="12.0">
+    <path
+        android:fillColor="#D0D2D3"
+        android:pathData="M6,12C9.314,12 12,9.314 12,6C12,2.686 9.314,0 6,0C2.686,0 0,2.686 0,6C0,9.314 2.686,12 6,12Z"
+        android:strokeColor="#00000000"
+        android:strokeWidth="1" />
+</vector>

--- a/lib/src/main/res/layout/com_auth0_lock_checkable_option.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_checkable_option.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ com_auth0_lock_checkable_optionon.xml
+  ~
+  ~ Copyright (c) 2016 Auth0 (http://auth0.com)
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/com_auth0_lock_checkable_text_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:src="@drawable/com_auth0_lock_ic_check_success" />
+
+    <TextView
+        android:id="@+id/com_auth0_lock_checkable_text_description"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        tools:text="Option value or description" />
+</LinearLayout>

--- a/lib/src/main/res/layout/com_auth0_lock_checkable_option.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_checkable_option.xml
@@ -26,6 +26,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/com_auth0_lock_widget_vertical_margin_checkable_option"
+    android:layout_marginTop="@dimen/com_auth0_lock_widget_vertical_margin_checkable_option"
     android:orientation="horizontal">
 
     <ImageView
@@ -37,8 +39,8 @@
 
     <TextView
         android:id="@+id/com_auth0_lock_checkable_text_description"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        style="@style/Lock.Theme.Text.PasswordPolicy"
+        android:layout_marginLeft="@dimen/com_auth0_lock_widget_with_text_horizontal_padding"
         android:gravity="center_vertical"
         tools:text="Option value or description" />
 </LinearLayout>

--- a/lib/src/main/res/layout/com_auth0_lock_login_form_view.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_login_form_view.xml
@@ -49,7 +49,7 @@
         android:visibility="gone"
         lock:Auth0.InputDataType="username" />
 
-    <com.auth0.android.lock.views.ValidatedPasswordInputView
+    <com.auth0.android.lock.views.ValidatedInputView
         android:id="@+id/com_auth0_lock_input_password"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/lib/src/main/res/layout/com_auth0_lock_login_form_view.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_login_form_view.xml
@@ -49,7 +49,7 @@
         android:visibility="gone"
         lock:Auth0.InputDataType="username" />
 
-    <com.auth0.android.lock.views.ValidatedInputView
+    <com.auth0.android.lock.views.ValidatedPasswordInputView
         android:id="@+id/com_auth0_lock_input_password"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/lib/src/main/res/layout/com_auth0_lock_password_strength.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_password_strength.xml
@@ -26,6 +26,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginBottom="@dimen/com_auth0_lock_widget_vertical_margin_field"
+    android:layout_marginTop="@dimen/com_auth0_lock_widget_vertical_margin_password_strength"
     android:orientation="vertical">
 
     <TextView
@@ -35,14 +36,12 @@
 
     <com.auth0.android.lock.views.CheckableOptionView
         android:id="@+id/com_auth0_lock_password_strength_option_length"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        style="@style/Lock.Theme.Text.PasswordPolicy"
         android:text="@string/com_auth0_lock_password_strength_chars_length" />
 
     <com.auth0.android.lock.views.CheckableOptionView
         android:id="@+id/com_auth0_lock_password_strength_option_identical_characters"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        style="@style/Lock.Theme.Text.PasswordPolicy"
         android:text="@string/com_auth0_lock_password_strength_identical_chars" />
 
     <TextView
@@ -53,25 +52,21 @@
 
     <com.auth0.android.lock.views.CheckableOptionView
         android:id="@+id/com_auth0_lock_password_strength_option_lowercase"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        style="@style/Lock.Theme.Text.PasswordPolicy"
         android:text="@string/com_auth0_lock_password_strength_lowercase_letters" />
 
     <com.auth0.android.lock.views.CheckableOptionView
         android:id="@+id/com_auth0_lock_password_strength_option_uppercase"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        style="@style/Lock.Theme.Text.PasswordPolicy"
         android:text="@string/com_auth0_lock_password_strength_uppercase_letters" />
 
     <com.auth0.android.lock.views.CheckableOptionView
         android:id="@+id/com_auth0_lock_password_strength_option_numeric"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        style="@style/Lock.Theme.Text.PasswordPolicy"
         android:text="@string/com_auth0_lock_password_strength_numbers" />
 
     <com.auth0.android.lock.views.CheckableOptionView
         android:id="@+id/com_auth0_lock_password_strength_option_special_characters"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        style="@style/Lock.Theme.Text.PasswordPolicy"
         android:text="@string/com_auth0_lock_password_strength_special_chars" />
 </LinearLayout>

--- a/lib/src/main/res/layout/com_auth0_lock_password_strength.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_password_strength.xml
@@ -65,7 +65,7 @@
         android:text="@string/com_auth0_lock_password_strength_uppercase_letters" />
 
     <com.auth0.android.lock.views.CheckableOptionView
-        android:id="@+id/com_auth0_lock_password_strength_option_numbers"
+        android:id="@+id/com_auth0_lock_password_strength_option_numeric"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/com_auth0_lock_password_strength_numbers" />

--- a/lib/src/main/res/layout/com_auth0_lock_password_strength.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_password_strength.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ com_auth0_lock_password_strength.xmlength.xml
+  ~
+  ~ Copyright (c) 2016 Auth0 (http://auth0.com)
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/com_auth0_lock_password_strength_title_must_have"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/com_auth0_lock_password_strength_title_must_have" />
+
+    <com.auth0.android.lock.views.CheckableOptionView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/com_auth0_lock_password_strength_chars_length" />
+
+    <com.auth0.android.lock.views.CheckableOptionView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/com_auth0_lock_password_strength_identical_chars" />
+
+
+    <TextView
+        android:id="@+id/com_auth0_lock_password_strength_title_at_least"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/com_auth0_lock_password_strength_title_at_least" />
+
+    <com.auth0.android.lock.views.CheckableOptionView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/com_auth0_lock_password_strength_lowercase_letters" />
+
+    <com.auth0.android.lock.views.CheckableOptionView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/com_auth0_lock_password_strength_uppercase_letters" />
+
+    <com.auth0.android.lock.views.CheckableOptionView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/com_auth0_lock_password_strength_numbers" />
+
+    <com.auth0.android.lock.views.CheckableOptionView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/com_auth0_lock_password_strength_special_chars" />
+</LinearLayout>

--- a/lib/src/main/res/layout/com_auth0_lock_password_strength.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_password_strength.xml
@@ -25,12 +25,12 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/com_auth0_lock_widget_vertical_margin_field"
     android:orientation="vertical">
 
     <TextView
         android:id="@+id/com_auth0_lock_password_strength_title_must_have"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        style="@style/Lock.Theme.Text.PasswordPolicy"
         android:text="@string/com_auth0_lock_password_strength_title_must_have" />
 
     <com.auth0.android.lock.views.CheckableOptionView
@@ -45,11 +45,10 @@
         android:layout_height="wrap_content"
         android:text="@string/com_auth0_lock_password_strength_identical_chars" />
 
-
     <TextView
         android:id="@+id/com_auth0_lock_password_strength_title_at_least"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        style="@style/Lock.Theme.Text.PasswordPolicy"
+        android:layout_marginTop="@dimen/com_auth0_lock_widget_vertical_margin_field"
         android:text="@string/com_auth0_lock_password_strength_title_at_least" />
 
     <com.auth0.android.lock.views.CheckableOptionView

--- a/lib/src/main/res/layout/com_auth0_lock_password_strength.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_password_strength.xml
@@ -34,11 +34,13 @@
         android:text="@string/com_auth0_lock_password_strength_title_must_have" />
 
     <com.auth0.android.lock.views.CheckableOptionView
+        android:id="@+id/com_auth0_lock_password_strength_option_length"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/com_auth0_lock_password_strength_chars_length" />
 
     <com.auth0.android.lock.views.CheckableOptionView
+        android:id="@+id/com_auth0_lock_password_strength_option_identical_characters"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/com_auth0_lock_password_strength_identical_chars" />
@@ -51,21 +53,25 @@
         android:text="@string/com_auth0_lock_password_strength_title_at_least" />
 
     <com.auth0.android.lock.views.CheckableOptionView
+        android:id="@+id/com_auth0_lock_password_strength_option_lowercase"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/com_auth0_lock_password_strength_lowercase_letters" />
 
     <com.auth0.android.lock.views.CheckableOptionView
+        android:id="@+id/com_auth0_lock_password_strength_option_uppercase"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/com_auth0_lock_password_strength_uppercase_letters" />
 
     <com.auth0.android.lock.views.CheckableOptionView
+        android:id="@+id/com_auth0_lock_password_strength_option_numbers"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/com_auth0_lock_password_strength_numbers" />
 
     <com.auth0.android.lock.views.CheckableOptionView
+        android:id="@+id/com_auth0_lock_password_strength_option_special_characters"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/com_auth0_lock_password_strength_special_chars" />

--- a/lib/src/main/res/layout/com_auth0_lock_signup_form_view.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_signup_form_view.xml
@@ -41,7 +41,7 @@
         android:layout_height="wrap_content"
         lock:Auth0.InputDataType="email" />
 
-    <com.auth0.android.lock.views.ValidatedInputView
+    <com.auth0.android.lock.views.ValidatedPasswordInputView
         android:id="@+id/com_auth0_lock_input_password"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/lib/src/main/res/layout/com_auth0_lock_signup_form_view.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_signup_form_view.xml
@@ -49,7 +49,7 @@
         lock:Auth0.InputDataType="password" />
 
     <LinearLayout
-        android:id="@+id/com_auth0_lock_container"
+        android:id="@+id/com_auth0_lock_custom_fields_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical" />

--- a/lib/src/main/res/layout/com_auth0_lock_validated_input_view.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_validated_input_view.xml
@@ -25,6 +25,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:lock="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/com_auth0_lock_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">

--- a/lib/src/main/res/values-long/dimens.xml
+++ b/lib/src/main/res/values-long/dimens.xml
@@ -57,6 +57,7 @@
     <dimen name="com_auth0_lock_switcher_text">12sp</dimen>
     <dimen name="com_auth0_lock_field_text">13dp</dimen>
     <dimen name="com_auth0_lock_field_error_text">11sp</dimen>
+    <dimen name="com_auth0_lock_password_policy_text">11sp</dimen>
     <dimen name="com_auth0_lock_list_item_text">16sp</dimen>
     <dimen name="com_auth0_lock_result_message_text">12sp</dimen>
 
@@ -74,4 +75,5 @@
     <dimen name="com_auth0_lock_action_button_vertical_margin">14dp</dimen>
     <dimen name="com_auth0_lock_bottom_banner_vertical_margin">7dp</dimen>
     <dimen name="com_auth0_lock_top_banner_vertical_margin">12dp</dimen>
+    <dimen name="com_auth0_lock_widget_vertical_margin_checkable_option">1.6dp</dimen>
 </resources>

--- a/lib/src/main/res/values-long/dimens.xml
+++ b/lib/src/main/res/values-long/dimens.xml
@@ -39,6 +39,7 @@
     <dimen name="com_auth0_lock_widget_vertical_margin_mode_selection">16dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_field">8dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_field_with_error">3dp</dimen>
+    <dimen name="com_auth0_lock_widget_vertical_margin_password_strength">13dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_social">4dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_passwordless">28dp</dimen>
     <dimen name="com_auth0_lock_widget_horizontal_margin_small">7dp</dimen>

--- a/lib/src/main/res/values/colors.xml
+++ b/lib/src/main/res/values/colors.xml
@@ -85,4 +85,9 @@
     <color name="com_auth0_lock_disabled_text">#4d000000</color>
     <color name="com_auth0_lock_passwordless_link_sent_text">#c8000000</color>
     <color name="com_auth0_lock_hint_text">#999999</color>
+
+    <color name="com_auth0_lock_checkable_option_success">#518C11</color>
+    <color name="com_auth0_lock_checkable_option_unset">#E2000000</color>
+    <color name="com_auth0_lock_checkable_option_error">#5C666F</color>
+
 </resources>

--- a/lib/src/main/res/values/colors.xml
+++ b/lib/src/main/res/values/colors.xml
@@ -88,6 +88,6 @@
 
     <color name="com_auth0_lock_checkable_option_success">#518C11</color>
     <color name="com_auth0_lock_checkable_option_unset">#E2000000</color>
-    <color name="com_auth0_lock_checkable_option_error">#5C666F</color>
+    <color name="com_auth0_lock_checkable_option_error">#FF511A</color>
 
 </resources>

--- a/lib/src/main/res/values/dimens.xml
+++ b/lib/src/main/res/values/dimens.xml
@@ -39,6 +39,7 @@
     <dimen name="com_auth0_lock_widget_vertical_margin_mode_selection">20dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_field">10dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_field_with_error">5dp</dimen>
+    <dimen name="com_auth0_lock_widget_vertical_margin_password_strength">15dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_social">6dp</dimen>
     <dimen name="com_auth0_lock_widget_vertical_margin_passwordless">36dp</dimen>
     <dimen name="com_auth0_lock_widget_horizontal_margin_small">9dp</dimen>

--- a/lib/src/main/res/values/dimens.xml
+++ b/lib/src/main/res/values/dimens.xml
@@ -57,6 +57,7 @@
     <dimen name="com_auth0_lock_switcher_text">13.5sp</dimen>
     <dimen name="com_auth0_lock_field_text">14dp</dimen>
     <dimen name="com_auth0_lock_field_error_text">12sp</dimen>
+    <dimen name="com_auth0_lock_password_policy_text">12sp</dimen>
     <dimen name="com_auth0_lock_list_item_text">17sp</dimen>
     <dimen name="com_auth0_lock_result_message_text">15sp</dimen>
 
@@ -73,5 +74,6 @@
     <dimen name="com_auth0_lock_action_button_vertical_margin">19dp</dimen>
     <dimen name="com_auth0_lock_bottom_banner_vertical_margin">9dp</dimen>
     <dimen name="com_auth0_lock_top_banner_vertical_margin">15dp</dimen>
+    <dimen name="com_auth0_lock_widget_vertical_margin_checkable_option">2.4dp</dimen>
 
 </resources>

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -165,7 +165,7 @@
     <string name="com_auth0_lock_password_strength_uppercase_letters">Upper case letters (A-Z)</string>
     <string name="com_auth0_lock_password_strength_numbers">Numbers (i.e. 0–9)</string>
     <string name="com_auth0_lock_password_strength_special_chars">Special characters (e.g. !@#$%^&amp;* )</string>
-    <string name="com_auth0_lock_password_strength_title_at_least" formatted="false">And contain at least %d of the following %d types of characters:</string>
+    <string name="com_auth0_lock_password_strength_title_at_least">And contain at least 3 of the following 4 types of characters:</string>
     <string name="com_auth0_lock_password_strength_title_must_have">Must have:</string>
 
 </resources>

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -158,4 +158,14 @@
     <string name="com_auth0_lock_title_mfa_input_code">Two Step Verification</string>
     <string name="com_auth0_lock_description_mfa_input_code">Please enter a verification code from\n your code generator application.</string>
 
+    <!-- Password Strength/Policies -->
+    <string name="com_auth0_lock_password_strength_identical_chars" formatted="false">No more than %d identical characters in a row (e.g., "%s" not allowed)</string>
+    <string name="com_auth0_lock_password_strength_chars_length" formatted="false">At least %d characters in length</string>
+    <string name="com_auth0_lock_password_strength_lowercase_letters">Lower case letters (a-z)</string>
+    <string name="com_auth0_lock_password_strength_uppercase_letters">Upper case letters (A-Z)</string>
+    <string name="com_auth0_lock_password_strength_numbers">Numbers (i.e. 0–9)</string>
+    <string name="com_auth0_lock_password_strength_special_chars">Special characters (e.g. !@#$%^&amp;* )</string>
+    <string name="com_auth0_lock_password_strength_title_at_least" formatted="false">And contain at least %d of the following %d types of characters:</string>
+    <string name="com_auth0_lock_password_strength_title_must_have">Must have:</string>
+
 </resources>

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -159,7 +159,7 @@
     <string name="com_auth0_lock_description_mfa_input_code">Please enter a verification code from\n your code generator application.</string>
 
     <!-- Password Strength/Policies -->
-    <string name="com_auth0_lock_password_strength_identical_chars" formatted="false">No more than %d identical characters in a row (e.g., "%s" not allowed)</string>
+    <string name="com_auth0_lock_password_strength_identical_chars">No more than 2 identical characters in a row (e.g., "111" not allowed)</string>
     <string name="com_auth0_lock_password_strength_chars_length" formatted="false">At least %d characters in length</string>
     <string name="com_auth0_lock_password_strength_lowercase_letters">Lower case letters (a-z)</string>
     <string name="com_auth0_lock_password_strength_uppercase_letters">Upper case letters (A-Z)</string>

--- a/lib/src/main/res/values/styles.xml
+++ b/lib/src/main/res/values/styles.xml
@@ -45,6 +45,10 @@
         <item name="android:textColor">@color/com_auth0_lock_text</item>
     </style>
 
+    <style name="Lock.Theme.Text.PasswordPolicy">
+        <item name="android:textSize">@dimen/com_auth0_lock_field_error_text</item>
+    </style>
+
     <style name="Lock.Theme.Text.ValidationError">
         <item name="android:textColor">@color/com_auth0_lock_validation_error_text</item>
         <item name="android:textSize">@dimen/com_auth0_lock_field_error_text</item>

--- a/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
@@ -26,6 +26,7 @@ package com.auth0.android.lock;
 
 import com.auth0.android.lock.CustomField.FieldType;
 import com.auth0.android.lock.enums.InitialScreen;
+import com.auth0.android.lock.enums.PasswordStrength;
 import com.auth0.android.lock.enums.PasswordlessMode;
 import com.auth0.android.lock.enums.SocialButtonStyle;
 import com.auth0.android.lock.enums.UsernameStyle;
@@ -113,6 +114,7 @@ public class ConfigurationTest extends GsonBaseTest {
         assertThat(configuration.getInitialScreen(), is(equalTo(InitialScreen.LOG_IN)));
         assertThat(configuration.getSocialButtonStyle(), is(equalTo(SocialButtonStyle.UNSPECIFIED)));
         assertThat(configuration.hasExtraFields(), is(false));
+        assertThat(configuration.getPasswordPolicy(), is(PasswordStrength.NONE));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/android/lock/utils/json/ConnectionGsonTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/utils/json/ConnectionGsonTest.java
@@ -79,8 +79,8 @@ public class ConnectionGsonTest extends GsonBaseTest {
         assertThat(connection.getName(), is("ad"));
         assertThat(connection.getValues(), is(notNullValue()));
         assertThat(connection.getValues().isEmpty(), is(false));
-        assertThat((String) connection.getValues().get("domain"), is("auth10.com"));
-        assertThat((List<String>) connection.getValues().get("domain_aliases"), IsCollectionContaining.hasItem("auth10.com"));
+        assertThat((String) connection.getValueForKey("domain"), is("auth10.com"));
+        assertThat((List<String>) connection.getValueForKey("domain_aliases"), IsCollectionContaining.hasItem("auth10.com"));
     }
 
     @Test
@@ -90,7 +90,7 @@ public class ConnectionGsonTest extends GsonBaseTest {
         assertThat(connection.getName(), is("twitter"));
         assertThat(connection.getValues(), is(notNullValue()));
         assertThat(connection.getValues().isEmpty(), is(false));
-        assertThat((String) connection.getValues().get("scope"), is("public_profile"));
+        assertThat((String) connection.getValueForKey("scope"), is("public_profile"));
     }
 
     @Test
@@ -100,11 +100,12 @@ public class ConnectionGsonTest extends GsonBaseTest {
         assertThat(connection.getName(), is("Username-Password-Authentication"));
         assertThat(connection.getValues(), is(notNullValue()));
         assertThat(connection.getValues().isEmpty(), is(false));
-        assertThat((String) connection.getValues().get("forgot_password_url"), is("https://login.auth0.com/lo/forgot?wtrealm=urn:auth0:samples:Username-Password-Authentication"));
-        assertThat((String) connection.getValues().get("signup_url"), is("https://login.auth0.com/lo/signup?wtrealm=urn:auth0:samples:Username-Password-Authentication"));
+        assertThat((String) connection.getValueForKey("forgot_password_url"), is("https://login.auth0.com/lo/forgot?wtrealm=urn:auth0:samples:Username-Password-Authentication"));
+        assertThat((String) connection.getValueForKey("signup_url"), is("https://login.auth0.com/lo/signup?wtrealm=urn:auth0:samples:Username-Password-Authentication"));
         assertThat(connection.booleanForKey("showSignup"), is(true));
         assertThat(connection.booleanForKey("showForgot"), is(true));
         assertThat(connection.booleanForKey("requires_username"), is(false));
+        assertThat((String) connection.getValueForKey("passwordPolicy"), is("good"));
     }
 
     private Connection buildConnectionFrom(Reader json) throws IOException {

--- a/lib/src/test/java/com/auth0/android/lock/views/PasswordStrengthViewTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/views/PasswordStrengthViewTest.java
@@ -1,0 +1,192 @@
+package com.auth0.android.lock.views;
+
+import android.app.Activity;
+
+import com.auth0.android.lock.BuildConfig;
+import com.auth0.android.lock.enums.PasswordStrength;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
+public class PasswordStrengthViewTest {
+
+    public static final String PASSWORD_TOO_LONG = "otPtgNsthiK98lw61BEwevHChF87YMNqVZDpvxgAWBESkBL" +
+            "ytrGRrG6JDhZjIyt2HqqxJDeyeKLlKnRG1pnOoA5xaZWKI6zK6tk37BocILDZESio107JZiHWbc4DlIFe0";
+    public static final String PASSWORD_128_LONG = "otPtgNsthiK98lw61BEwevHChF87YMNqVZDpvxgAWBESkBL" +
+            "ytrGRrG6JDhZjIyt2HqqxJDeyeKLlKnRG1pnOoA5xaZWKI6zK6tk37BocILDZESio107JZiHWbc4DlIFe";
+    public static final String PASSWORD_10_LONG = "123KImd$$.";
+    public static final String PASSWORD_8_LONG = "12KImd$.";
+    public static final String PASSWORD_6_LONG = "1Kd$$.";
+    public static final String PASSWORD_1_LONG = "1";
+    public static final String PASSWORD_EMPTY = "";
+
+    public static final String PASSWORD_NUMERIC = "1234567890";
+    public static final String PASSWORD_ALPHA = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    public static final String PASSWORD_ALPHA_LOWER_CASE = "abcdefghijklmnopqrstuvwxyz";
+    public static final String PASSWORD_ALPHA_UPPER_CASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    public static final String PASSWORD_SPECIAL = " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~";
+    public static final String PASSWORD_IDENTICAL = "AAAAaaaa1111$$$$";
+
+    public static final String PASSWORD_NUMERIC_SPECIAL = "12$#5!@321$314#%5667^&";
+    public static final String PASSWORD_ALPHA_NUMERIC = "ab12ab12ab12";
+    public static final String PASSWORD_ALPHA_NUMERIC_SPECIAL = "a!b1@ca2$bc1@bd2j$1j3";
+    public static final String PASSWORD_ALPHA_CASE_NUMERIC_SPECIAL = "a!B1@CA2$bc1@bd2j$1j3E";
+    public static final String PASSWORD_ALPHA_CASE_NUMERIC = "aB1aB1aB1aB1aB1";
+
+    private PasswordStrengthView view;
+
+    @Before
+    public void setUp() throws Exception {
+        Activity context = Robolectric.buildActivity(Activity.class).create().get();
+        view = new PasswordStrengthView(context);
+    }
+
+    @Test
+    public void shouldHandlePasswordStrengthNONE() throws Exception {
+        view.setStrength(PasswordStrength.NONE);
+
+        assertTrue(view.isValid(PASSWORD_NUMERIC));
+        assertTrue(view.isValid(PASSWORD_ALPHA));
+        assertTrue(view.isValid(PASSWORD_ALPHA_LOWER_CASE));
+        assertTrue(view.isValid(PASSWORD_ALPHA_UPPER_CASE));
+        assertTrue(view.isValid(PASSWORD_SPECIAL));
+        assertTrue(view.isValid(PASSWORD_IDENTICAL));
+
+        assertTrue(view.isValid(PASSWORD_NUMERIC_SPECIAL));
+        assertTrue(view.isValid(PASSWORD_ALPHA_NUMERIC));
+        assertTrue(view.isValid(PASSWORD_ALPHA_NUMERIC_SPECIAL));
+        assertTrue(view.isValid(PASSWORD_ALPHA_CASE_NUMERIC_SPECIAL));
+        assertTrue(view.isValid(PASSWORD_ALPHA_CASE_NUMERIC));
+
+        assertTrue(view.isValid(PASSWORD_128_LONG));
+        assertTrue(view.isValid(PASSWORD_10_LONG));
+        assertTrue(view.isValid(PASSWORD_8_LONG));
+        assertTrue(view.isValid(PASSWORD_6_LONG));
+        assertTrue(view.isValid(PASSWORD_1_LONG));
+
+        assertFalse(view.isValid(PASSWORD_EMPTY));
+        assertFalse(view.isValid(PASSWORD_TOO_LONG));
+        assertFalse(view.isValid(null));
+    }
+
+    @Test
+    public void shouldHandlePasswordStrengthLOW() throws Exception {
+        view.setStrength(PasswordStrength.LOW);
+
+        assertTrue(view.isValid(PASSWORD_NUMERIC));
+        assertTrue(view.isValid(PASSWORD_ALPHA));
+        assertTrue(view.isValid(PASSWORD_ALPHA_LOWER_CASE));
+        assertTrue(view.isValid(PASSWORD_ALPHA_UPPER_CASE));
+        assertTrue(view.isValid(PASSWORD_SPECIAL));
+        assertTrue(view.isValid(PASSWORD_IDENTICAL));
+
+        assertTrue(view.isValid(PASSWORD_NUMERIC_SPECIAL));
+        assertTrue(view.isValid(PASSWORD_ALPHA_NUMERIC));
+        assertTrue(view.isValid(PASSWORD_ALPHA_NUMERIC_SPECIAL));
+        assertTrue(view.isValid(PASSWORD_ALPHA_CASE_NUMERIC_SPECIAL));
+        assertTrue(view.isValid(PASSWORD_ALPHA_CASE_NUMERIC));
+
+        assertTrue(view.isValid(PASSWORD_128_LONG));
+        assertTrue(view.isValid(PASSWORD_10_LONG));
+        assertTrue(view.isValid(PASSWORD_8_LONG));
+        assertTrue(view.isValid(PASSWORD_6_LONG));
+        assertFalse(view.isValid(PASSWORD_1_LONG));
+
+        assertFalse(view.isValid(PASSWORD_EMPTY));
+        assertFalse(view.isValid(PASSWORD_TOO_LONG));
+        assertFalse(view.isValid(null));
+    }
+
+    @Test
+    public void shouldHandlePasswordStrengthFAIR() throws Exception {
+        view.setStrength(PasswordStrength.FAIR);
+
+        assertFalse(view.isValid(PASSWORD_NUMERIC));
+        assertFalse(view.isValid(PASSWORD_ALPHA));
+        assertFalse(view.isValid(PASSWORD_ALPHA_LOWER_CASE));
+        assertFalse(view.isValid(PASSWORD_ALPHA_UPPER_CASE));
+        assertFalse(view.isValid(PASSWORD_SPECIAL));
+        assertTrue(view.isValid(PASSWORD_IDENTICAL));
+
+        assertFalse(view.isValid(PASSWORD_NUMERIC_SPECIAL));
+        assertFalse(view.isValid(PASSWORD_ALPHA_NUMERIC));
+        assertFalse(view.isValid(PASSWORD_ALPHA_NUMERIC_SPECIAL));
+        assertTrue(view.isValid(PASSWORD_ALPHA_CASE_NUMERIC_SPECIAL));
+        assertTrue(view.isValid(PASSWORD_ALPHA_CASE_NUMERIC));
+
+        assertTrue(view.isValid(PASSWORD_128_LONG));
+        assertTrue(view.isValid(PASSWORD_10_LONG));
+        assertTrue(view.isValid(PASSWORD_8_LONG));
+        assertFalse(view.isValid(PASSWORD_6_LONG));
+        assertFalse(view.isValid(PASSWORD_1_LONG));
+
+        assertFalse(view.isValid(PASSWORD_EMPTY));
+        assertFalse(view.isValid(PASSWORD_TOO_LONG));
+        assertFalse(view.isValid(null));
+    }
+
+    @Test
+    public void shouldHandlePasswordStrengthGOOD() throws Exception {
+        view.setStrength(PasswordStrength.GOOD);
+
+        assertFalse(view.isValid(PASSWORD_NUMERIC));
+        assertFalse(view.isValid(PASSWORD_ALPHA));
+        assertFalse(view.isValid(PASSWORD_ALPHA_LOWER_CASE));
+        assertFalse(view.isValid(PASSWORD_ALPHA_UPPER_CASE));
+        assertFalse(view.isValid(PASSWORD_SPECIAL));
+        assertTrue(view.isValid(PASSWORD_IDENTICAL));
+
+        assertFalse(view.isValid(PASSWORD_NUMERIC_SPECIAL));
+        assertFalse(view.isValid(PASSWORD_ALPHA_NUMERIC));
+        assertTrue(view.isValid(PASSWORD_ALPHA_NUMERIC_SPECIAL));
+        assertTrue(view.isValid(PASSWORD_ALPHA_CASE_NUMERIC_SPECIAL));
+        assertTrue(view.isValid(PASSWORD_ALPHA_CASE_NUMERIC));
+
+        assertTrue(view.isValid(PASSWORD_128_LONG));
+        assertTrue(view.isValid(PASSWORD_10_LONG));
+        assertTrue(view.isValid(PASSWORD_8_LONG));
+        assertFalse(view.isValid(PASSWORD_6_LONG));
+        assertFalse(view.isValid(PASSWORD_1_LONG));
+
+        assertFalse(view.isValid(PASSWORD_EMPTY));
+        assertFalse(view.isValid(PASSWORD_TOO_LONG));
+        assertFalse(view.isValid(null));
+    }
+
+    @Test
+    public void shouldHandlePasswordStrengthEXCELLENT() throws Exception {
+        view.setStrength(PasswordStrength.EXCELLENT);
+
+        assertFalse(view.isValid(PASSWORD_NUMERIC));
+        assertFalse(view.isValid(PASSWORD_ALPHA));
+        assertFalse(view.isValid(PASSWORD_ALPHA_LOWER_CASE));
+        assertFalse(view.isValid(PASSWORD_ALPHA_UPPER_CASE));
+        assertFalse(view.isValid(PASSWORD_SPECIAL));
+        assertFalse(view.isValid(PASSWORD_IDENTICAL));
+
+        assertFalse(view.isValid(PASSWORD_NUMERIC_SPECIAL));
+        assertFalse(view.isValid(PASSWORD_ALPHA_NUMERIC));
+        assertTrue(view.isValid(PASSWORD_ALPHA_NUMERIC_SPECIAL));
+        assertTrue(view.isValid(PASSWORD_ALPHA_CASE_NUMERIC_SPECIAL));
+        assertTrue(view.isValid(PASSWORD_ALPHA_CASE_NUMERIC));
+
+        assertTrue(view.isValid(PASSWORD_128_LONG));
+        assertTrue(view.isValid(PASSWORD_10_LONG));
+        assertFalse(view.isValid(PASSWORD_8_LONG));
+        assertFalse(view.isValid(PASSWORD_6_LONG));
+        assertFalse(view.isValid(PASSWORD_1_LONG));
+
+        assertFalse(view.isValid(PASSWORD_EMPTY));
+        assertFalse(view.isValid(PASSWORD_TOO_LONG));
+        assertFalse(view.isValid(null));
+    }
+}

--- a/lib/src/test/resources/db_connection.json
+++ b/lib/src/test/resources/db_connection.json
@@ -3,6 +3,7 @@
   "domain": null,
   "forgot_password_url": "https://login.auth0.com/lo/forgot?wtrealm=urn:auth0:samples:Username-Password-Authentication",
   "signup_url": "https://login.auth0.com/lo/signup?wtrealm=urn:auth0:samples:Username-Password-Authentication",
+  "passwordPolicy": "good",
   "showSignup": true,
   "showForgot": true,
   "requires_username": false


### PR DESCRIPTION
This PR adds the Password Strength Widget above the Password Field on the Sign Up form. It gets the default DB `passwordPolicy` name/level setting from the CDN.
It also removes the password length validation for the log in flow (it just checks that it's not empty) and allows white space chars in the password.

<img width="401" alt="screenshot 2016-06-28 17 32 19" src="https://cloud.githubusercontent.com/assets/3900123/16431286/494b7af2-3d56-11e6-8ece-24d15f2bd22e.png">
