### PR TITLE
Add Service Terms and Privacy Policy dialog

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/Configuration.java
@@ -84,6 +84,8 @@ public class Configuration {
     private int passwordlessMode;
     @InitialScreen
     private int initialScreen;
+    private String termsURL;
+    private String privacyURL;
 
     public Configuration(Application application, Options options) {
         List<String> connections = options.getConnections();
@@ -304,6 +306,9 @@ public class Configuration {
         } else {
             passwordlessMode = PasswordlessMode.DISABLED;
         }
+
+        this.termsURL = options.getTermsURL() == null ? "https://auth0.com/terms" : options.getTermsURL();
+        this.privacyURL = options.getPrivacyURL() == null ? "https://auth0.com/privacy" : options.getPrivacyURL();
     }
 
     @PasswordStrength
@@ -390,4 +395,13 @@ public class Configuration {
         return passwordlessLockAvailable;
     }
 
+    @NonNull
+    public String getTermsURL() {
+        return termsURL;
+    }
+
+    @NonNull
+    public String getPrivacyURL() {
+        return privacyURL;
+    }
 }

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -33,6 +33,7 @@ import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
+import android.util.Patterns;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.authentication.ParameterBuilder;
@@ -394,6 +395,38 @@ public class Lock {
         public Builder withSignUpFields(List<CustomField> customFields) {
             final List<CustomField> withoutDuplicates = removeDuplicatedKeys(customFields);
             options.setCustomFields(withoutDuplicates);
+            return this;
+        }
+
+        /**
+         * Choose a custom Privacy Policy URL to access when the user clicks the link on the Sign Up form.
+         * The default value is 'https://auth0.com/privacy'
+         *
+         * @param url a valid url to use.
+         * @return the current builder instance
+         */
+        public Builder setPrivacyURL(@NonNull String url) {
+            if (Patterns.WEB_URL.matcher(url).matches()) {
+                options.setPrivacyURL(url);
+            } else {
+                Log.w(TAG, "The given Privacy Policy URL doesn't have a valid URL format. Will default to 'https://auth0.com/privacy'.");
+            }
+            return this;
+        }
+
+        /**
+         * Choose a custom Terms of Service URL to access when the user clicks the link on the Sign Up form.
+         * The default value is 'https://auth0.com/terms'
+         *
+         * @param url a valid url to use.
+         * @return the current builder instance
+         */
+        public Builder setTermsURL(@NonNull String url) {
+            if (Patterns.WEB_URL.matcher(url).matches()) {
+                options.setTermsURL(url);
+            } else {
+                Log.w(TAG, "The given Terms of Service URL doesn't have a valid URL format. Will default to 'https://auth0.com/terms'.");
+            }
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/Options.java
@@ -29,6 +29,7 @@ import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
+import android.util.Patterns;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.authentication.AuthenticationAPIClient;
@@ -66,6 +67,8 @@ class Options implements Parcelable {
     private List<CustomField> customFields;
     private int initialScreen;
     private Theme theme;
+    private String privacyURL;
+    private String termsURL;
 
     public Options() {
         usernameStyle = UsernameStyle.DEFAULT;
@@ -96,6 +99,8 @@ class Options implements Parcelable {
         initialScreen = in.readInt();
         socialButtonStyle = in.readInt();
         theme = in.readParcelable(Theme.class.getClassLoader());
+        privacyURL = in.readString();
+        termsURL = in.readString();
         if (in.readByte() == HAS_DATA) {
             connections = new ArrayList<>();
             in.readList(connections, String.class.getClassLoader());
@@ -144,6 +149,8 @@ class Options implements Parcelable {
         dest.writeInt(initialScreen);
         dest.writeInt(socialButtonStyle);
         dest.writeParcelable(theme, flags);
+        dest.writeString(privacyURL);
+        dest.writeString(termsURL);
         if (connections == null) {
             dest.writeByte((byte) (WITHOUT_DATA));
         } else {
@@ -343,5 +350,25 @@ class Options implements Parcelable {
     @InitialScreen
     public int initialScreen() {
         return initialScreen;
+    }
+
+    public void setPrivacyURL(@NonNull String url) {
+        if (Patterns.WEB_URL.matcher(url).matches()) {
+            this.privacyURL = url;
+        }
+    }
+
+    public String getPrivacyURL() {
+        return privacyURL;
+    }
+
+    public void setTermsURL(@NonNull String url) {
+        if (Patterns.WEB_URL.matcher(url).matches()) {
+            this.termsURL = url;
+        }
+    }
+
+    public String getTermsURL() {
+        return termsURL;
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -28,6 +28,9 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
+import android.support.v7.app.AlertDialog;
+import android.text.Html;
+import android.text.method.LinkMovementMethod;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
@@ -108,6 +111,12 @@ public class ClassicLockView extends LinearLayout implements View.OnClickListene
         addView(formLayout, formLayoutParams);
 
         bottomBanner = inflate(getContext(), R.layout.com_auth0_lock_terms_layout, null);
+        bottomBanner.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                showSignUpTermsDialog();
+            }
+        });
         bottomBanner.setVisibility(GONE);
         addView(bottomBanner, wrapHeightParams);
 
@@ -243,6 +252,20 @@ public class ClassicLockView extends LinearLayout implements View.OnClickListene
 
     private void showSignUpTerms(boolean show) {
         bottomBanner.setVisibility(show ? VISIBLE : GONE);
+    }
+
+    private void showSignUpTermsDialog() {
+        final String content = String.format(getResources().getString(R.string.com_auth0_lock_sign_up_terms_dialog_message), configuration.getTermsURL(), configuration.getPrivacyURL());
+        final AlertDialog dialog = new AlertDialog.Builder(getContext())
+                .setTitle(getResources().getString(R.string.com_auth0_lock_sign_up_terms_dialog_title))
+                .setPositiveButton(android.R.string.ok, null)
+                .setMessage(Html.fromHtml(content))
+                .show();
+
+        final TextView message = (TextView) dialog.findViewById(android.R.id.message);
+        if (message != null) {
+            message.setMovementMethod(LinkMovementMethod.getInstance());
+        }
     }
 
     @Override

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -138,7 +138,11 @@
     <string name="com_auth0_lock_sign_up_terms">By signing up, you agree to our terms of\n service and privacy policy</string>
     <string name="com_auth0_lock_title_passwordless_email">Enter your email address to sign in\n or create an account</string>
     <string name="com_auth0_lock_title_passwordless_sms">Enter your phone to sign in\n or create an account</string>
-
+    <string name="com_auth0_lock_sign_up_terms_dialog_title">Terms &amp; Policy</string>
+    <string name="com_auth0_lock_sign_up_terms_dialog_message" formatted="false"><![CDATA[
+    By signing up, you agree to our <a href=\'%s\'>terms of service</a> and <a href=\'%s\'>privacy policy</a>
+    ]]></string>
+    
     <!-- Custom Error Messages -->
     <string name="com_auth0_lock_missing_connections_message">There isn\'t any connection configured for this Application. Check your dashboard configuration on http://auth0.com</string>
     <string name="com_auth0_lock_configuration_retrieving_error">Error retrieving the Dashboard configuration</string>
@@ -168,5 +172,4 @@
     <string name="com_auth0_lock_password_strength_special_chars">Special characters (e.g. !@#$%^&amp;* )</string>
     <string name="com_auth0_lock_password_strength_title_at_least">And contain at least 3 of the following 4 types of characters:</string>
     <string name="com_auth0_lock_password_strength_title_must_have">Must have:</string>
-
 </resources>

--- a/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
@@ -522,6 +522,36 @@ public class ConfigurationTest extends GsonBaseTest {
         assertThat(configuration.shouldUseNativeAuthentication(connection, new ArrayList<String>()), is(false));
     }
 
+    @Test
+    public void shouldHaveDefaultPrivacyPolicyURL() throws Exception {
+        configuration = unfilteredConfig();
+        assertThat(configuration.getPrivacyURL(), is(notNullValue()));
+        assertThat(configuration.getPrivacyURL(), is(equalTo("https://auth0.com/privacy")));
+    }
+
+    @Test
+    public void shouldHaveCustomPrivacyPolicyURL() throws Exception {
+        options.setPrivacyURL("https://google.com/privacy");
+        configuration = new Configuration(application, options);
+        assertThat(configuration.getPrivacyURL(), is(notNullValue()));
+        assertThat(configuration.getPrivacyURL(), is(equalTo("https://google.com/privacy")));
+    }
+
+    @Test
+    public void shouldHaveDefaultTermsOfServiceURL() throws Exception {
+        configuration = unfilteredConfig();
+        assertThat(configuration.getTermsURL(), is(notNullValue()));
+        assertThat(configuration.getTermsURL(), is(equalTo("https://auth0.com/terms")));
+    }
+
+    @Test
+    public void shouldHaveCustomTermsOfServiceURL() throws Exception {
+        options.setTermsURL("https://google.com/terms");
+        configuration = new Configuration(application, options);
+        assertThat(configuration.getTermsURL(), is(notNullValue()));
+        assertThat(configuration.getTermsURL(), is(equalTo("https://google.com/terms")));
+    }
+
     private Configuration unfilteredConfig() {
         return new Configuration(application, options);
     }

--- a/lib/src/test/java/com/auth0/android/lock/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/OptionsTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -61,6 +62,64 @@ public class OptionsTest {
         assertThat(options.getAccount().getClientId(), is(equalTo(parceledOptions.getAccount().getClientId())));
         assertThat(options.getAccount().getConfigurationUrl(), is(equalTo(parceledOptions.getAccount().getConfigurationUrl())));
         assertThat(options.getAccount().getDomainUrl(), is(equalTo(parceledOptions.getAccount().getDomainUrl())));
+    }
+
+    @Test
+    public void shouldSetPrivacyPolicyURL() {
+        Options options = new Options();
+        options.setAccount(auth0);
+        options.setPrivacyURL("https://valid.url/privacy");
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.getPrivacyURL(), is(equalTo(parceledOptions.getPrivacyURL())));
+    }
+
+    @Test
+    public void shouldNotSetPrivacyPolicyURLWhenInvalidURL() {
+        Options options = new Options();
+        options.setAccount(auth0);
+        options.setPrivacyURL("an-invalid/url");
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.getPrivacyURL(), is(nullValue()));
+        assertThat(parceledOptions.getPrivacyURL(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldSetTermsOfServiceURL() {
+        Options options = new Options();
+        options.setAccount(auth0);
+        options.setTermsURL("https://valid.url/terms");
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.getTermsURL(), is(equalTo(parceledOptions.getTermsURL())));
+    }
+
+    @Test
+    public void shouldNotSetTermsOfServiceURLWhenInvalidURL() {
+        Options options = new Options();
+        options.setAccount(auth0);
+        options.setTermsURL("an-invalid/url");
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.getTermsURL(), is(nullValue()));
+        assertThat(parceledOptions.getTermsURL(), is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
When clicking the Sign Up terms banner at the bottom of the form, the user will be prompted with a dialog. Clicking the links takes the user to the https://auth0.com/terms and https://auth0.com/privacy urls. These can be changed in the `Lock.Builder` instance (Classic Lock only) by calling the methods `setTermsURL()` and `setPrivacyURL()`.

> This is for DB Connections only. 

<img width="399" alt="screen shot 2016-07-25 at 4 21 19 pm" src="https://cloud.githubusercontent.com/assets/3900123/17114097/dd6e5834-5283-11e6-8b70-f9f532791127.png">
