### PR TITLE
Always pick defaultDbConnection if available

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/Configuration.java
@@ -175,24 +175,31 @@ public class Configuration {
         if (dbs == null) {
             return null;
         }
-        Set<String> set = new HashSet<>(connections);
-        if (defaultDatabaseName != null) {
-            set.add(defaultDatabaseName);
-        }
-        Connection connection = null;
-        for (Connection db : dbs) {
-            if (db.getName().equals(defaultDatabaseName)) {
-                connection = db;
-                break;
-            } else if (connection == null && shouldSelect(db, set)) {
-                connection = db;
-            }
+
+        Connection defaultDb = getConnectionForName(dbs, defaultDatabaseName);
+        if (defaultDb != null && shouldSelect(defaultDb, connections)) {
+            return defaultDb;
         }
 
-        if (connection == null || (defaultDatabaseName != null && !connection.getName().equals(defaultDatabaseName))) {
+        if (defaultDatabaseName != null) {
             Log.w(TAG, String.format("You've chosen '%s' as your default database name, but it wasn't found in your Auth0 connections configuration.", defaultDatabaseName));
         }
-        return connection;
+
+        for (Connection db : dbs) {
+            if (shouldSelect(db, connections)) {
+                return db;
+            }
+        }
+        return null;
+    }
+
+    private Connection getConnectionForName(List<Connection> connections, String name) {
+        for (Connection c : connections) {
+            if (c.getName().equals(name)) {
+                return c;
+            }
+        }
+        return null;
     }
 
     private Strategy filterStrategy(Strategy strategy, Set<String> connections) {

--- a/lib/src/main/java/com/auth0/android/lock/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/Configuration.java
@@ -181,9 +181,11 @@ public class Configuration {
         }
         Connection connection = null;
         for (Connection db : dbs) {
-            if (db.getName().equals(defaultDatabaseName) || shouldSelect(db, set)) {
+            if (db.getName().equals(defaultDatabaseName)) {
                 connection = db;
                 break;
+            } else if (connection == null && shouldSelect(db, set)) {
+                connection = db;
             }
         }
 

--- a/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
@@ -384,12 +384,15 @@ public class ConfigurationTest extends GsonBaseTest {
     }
 
     @Test
-    public void shouldReturnSpecifiedDBConnection() throws Exception {
-        options.setConnections(Arrays.asList(CUSTOM_DATABASE, USERNAME_PASSWORD_AUTHENTICATION));
-        options.useDatabaseConnection(USERNAME_PASSWORD_AUTHENTICATION);
+    public void shouldReturnSpecifiedDBConnectionWhenMoreThanOneDBConnectionIsAvailable() throws Exception {
+        options.setConnections(Arrays.asList(CUSTOM_DATABASE, USERNAME_PASSWORD_AUTHENTICATION, RESTRICTIVE_DATABASE, UNKNOWN_CONNECTION));
+        options.useDatabaseConnection(RESTRICTIVE_DATABASE);
         configuration = new Configuration(application, options);
-        assertThat(configuration.getDefaultDatabaseConnection(), isConnection(USERNAME_PASSWORD_AUTHENTICATION));
+        assertThat(configuration.getDefaultDatabaseConnection(), isConnection(RESTRICTIVE_DATABASE));
+    }
 
+    @Test
+    public void shouldReturnSpecifiedDBConnection() throws Exception{
         options.setConnections(null);
         options.useDatabaseConnection(CUSTOM_DATABASE);
         configuration = new Configuration(application, options);

--- a/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
@@ -392,11 +392,30 @@ public class ConfigurationTest extends GsonBaseTest {
     }
 
     @Test
-    public void shouldReturnSpecifiedDBConnection() throws Exception{
+    public void shouldReturnSpecifiedDBConnectionIfAvailable() throws Exception{
         options.setConnections(null);
+
         options.useDatabaseConnection(CUSTOM_DATABASE);
         configuration = new Configuration(application, options);
         assertThat(configuration.getDefaultDatabaseConnection(), isConnection(CUSTOM_DATABASE));
+    }
+
+    @Test
+    public void shouldIgnoreSpecifiedDBConnectionIfNotAvailable() throws Exception{
+        options.setConnections(null);
+
+        options.useDatabaseConnection("non-existing-db-connection");
+        configuration = new Configuration(application, options);
+        assertThat(configuration.getDefaultDatabaseConnection(), isConnection(USERNAME_PASSWORD_AUTHENTICATION));
+    }
+
+    @Test
+    public void shouldIgnoreSpecifiedDBConnectionIfFiltered() throws Exception{
+        options.setConnections(Collections.singletonList(USERNAME_PASSWORD_AUTHENTICATION));
+
+        options.useDatabaseConnection("non-existing-db-connection");
+        configuration = new Configuration(application, options);
+        assertThat(configuration.getDefaultDatabaseConnection(), isConnection(USERNAME_PASSWORD_AUTHENTICATION));
     }
 
     @Test


### PR DESCRIPTION
When I configure a `defaultDbConnection` in Lock.Builder I expect that _that one_ it's selected among the others, instead of the first positive match.