### PR TITLE
Send Accept-Language Header (v1)

### DIFF
--- a/core/src/main/java/com/auth0/api/internal/RequestFactory.java
+++ b/core/src/main/java/com/auth0/api/internal/RequestFactory.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.squareup.okhttp.HttpUrl;
 import com.squareup.okhttp.OkHttpClient;
 
+import java.util.Locale;
 import java.util.Map;
 
 public class RequestFactory {
@@ -47,49 +48,78 @@ public class RequestFactory {
     }
 
     public static <T> ParameterizableRequest<T> GET(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper, Class<T> clazz) {
-        return addMetricHeader(new SimpleRequest<>(handler, url, client, mapper, "GET", clazz));
+        final SimpleRequest<T> request = new SimpleRequest<>(handler, url, client, mapper, "GET", clazz);
+        addMetricHeader(request);
+        addLocaleHeader(request);
+        return request;
     }
 
     public static <T> ParameterizableRequest<T> POST(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper, Class<T> clazz) {
-        return addMetricHeader(new SimpleRequest<>(handler, url, client, mapper, "POST", clazz));
+        final SimpleRequest<T> request = new SimpleRequest<>(handler, url, client, mapper, "POST", clazz);
+        addMetricHeader(request);
+        addLocaleHeader(request);
+        return request;
     }
 
     public static ParameterizableRequest<Map<String, Object>> rawPOST(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper) {
         final SimpleRequest<Map<String, Object>> request = new SimpleRequest<>(handler, url, client, mapper, "POST");
         addMetricHeader(request);
+        addLocaleHeader(request);
         return request;
     }
 
     public static ParameterizableRequest<Void> POST(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper) {
-        return addMetricHeader(new VoidRequest(handler, url, client, mapper, "POST"));
+        final VoidRequest request = new VoidRequest(handler, url, client, mapper, "POST");
+        addMetricHeader(request);
+        addLocaleHeader(request);
+        return request;
     }
 
     public static ParameterizableRequest<Void> POST(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper, String jwt) {
-        final AuthorizableRequest<Void> request = new VoidRequest(handler, url, client, mapper, "POST")
-                .setBearer(jwt);
-        return addMetricHeader(request);
+        final AuthorizableRequest<Void> request = new VoidRequest(handler, url, client, mapper, "POST").setBearer(jwt);
+        addMetricHeader(request);
+        addLocaleHeader(request);
+        return request;
     }
 
     public static <T> ParameterizableRequest<T> PUT(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper, Class<T> clazz) {
-        return addMetricHeader(new SimpleRequest<>(handler, url, client, mapper, "PUT", clazz));
+        final SimpleRequest<T> request = new SimpleRequest<>(handler, url, client, mapper, "PUT", clazz);
+        addMetricHeader(request);
+        addLocaleHeader(request);
+        return request;
     }
 
     public static <T> ParameterizableRequest<T> PATCH(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper, Class<T> clazz) {
-        return addMetricHeader(new SimpleRequest<>(handler, url, client, mapper, "GET", clazz));
+        final SimpleRequest<T> request = new SimpleRequest<>(handler, url, client, mapper, "GET", clazz);
+        addMetricHeader(request);
+        addLocaleHeader(request);
+        return request;
     }
 
     public static <T> ParameterizableRequest<T> DELETE(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper, Class<T> clazz) {
-        return addMetricHeader(new SimpleRequest<>(handler, url, client, mapper, "DELETE", clazz));
+        final SimpleRequest<T> request = new SimpleRequest<>(handler, url, client, mapper, "DELETE", clazz);
+        addMetricHeader(request);
+        addLocaleHeader(request);
+        return request;
     }
 
     public static Request<Application> newApplicationInfoRequest(HttpUrl url, OkHttpClient client, Handler handler, ObjectMapper mapper) {
-        return addMetricHeader(new ApplicationInfoRequest(handler, client, url, mapper));
+        final ApplicationInfoRequest request = new ApplicationInfoRequest(handler, client, url, mapper);
+        addMetricHeader(request);
+        addLocaleHeader(request);
+        return request;
     }
 
     private static <T> ParameterizableRequest<T> addMetricHeader(ParameterizableRequest<T> request) {
         if (CLIENT_INFO != null) {
             request.addHeader("Auth0-Client", CLIENT_INFO);
         }
+        return request;
+    }
+
+    private static <T> ParameterizableRequest<T> addLocaleHeader(ParameterizableRequest<T> request) {
+        String language = Locale.getDefault().getLanguage();
+        request.addHeader("Accept-Language", language != null ? language : "en");
         return request;
     }
 }

--- a/core/src/main/java/com/auth0/api/internal/RequestFactory.java
+++ b/core/src/main/java/com/auth0/api/internal/RequestFactory.java
@@ -41,7 +41,8 @@ public class RequestFactory {
 
     private static String CLIENT_INFO;
 
-    private RequestFactory() {}
+    private RequestFactory() {
+    }
 
     public static void setClientInfo(String clientInfo) {
         CLIENT_INFO = clientInfo;
@@ -119,7 +120,7 @@ public class RequestFactory {
 
     private static <T> ParameterizableRequest<T> addLocaleHeader(ParameterizableRequest<T> request) {
         String language = Locale.getDefault().toString();
-        request.addHeader("Accept-Language", language != null ? language : "en");
+        request.addHeader("Accept-Language", !language.isEmpty() ? language : "en");
         return request;
     }
 }

--- a/core/src/main/java/com/auth0/api/internal/RequestFactory.java
+++ b/core/src/main/java/com/auth0/api/internal/RequestFactory.java
@@ -118,7 +118,7 @@ public class RequestFactory {
     }
 
     private static <T> ParameterizableRequest<T> addLocaleHeader(ParameterizableRequest<T> request) {
-        String language = Locale.getDefault().getLanguage();
+        String language = Locale.getDefault().toString();
         request.addHeader("Accept-Language", language != null ? language : "en");
         return request;
     }

--- a/core/src/test/java/com/auth0/api/authentication/AuthenticationAPIClientTest.java
+++ b/core/src/test/java/com/auth0/api/authentication/AuthenticationAPIClientTest.java
@@ -179,7 +179,7 @@ public class AuthenticationAPIClientTest {
         assertThat(callback, hasPayloadOfType(Token.class));
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -232,7 +232,7 @@ public class AuthenticationAPIClientTest {
         assertThat(callback, hasPayloadOfType(UserProfile.class));
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/tokeninfo"));
     }
 
@@ -247,7 +247,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/oauth/access_token"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -269,7 +269,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -292,7 +292,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -313,7 +313,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -334,7 +334,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -357,7 +357,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -379,7 +379,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -399,7 +399,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/change_password"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -419,7 +419,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/dbconnections/change_password"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -439,7 +439,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -460,7 +460,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -481,7 +481,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -502,7 +502,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/unlink"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -529,7 +529,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -550,7 +550,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -571,7 +571,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -592,7 +592,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -613,7 +613,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -636,7 +636,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
-        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLocale()));
         assertThat(request.getPath(), equalTo("/oauth/token"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -654,8 +654,8 @@ public class AuthenticationAPIClientTest {
         });
     }
 
-    private String defaultLanguage() {
-        String language = Locale.getDefault().getLanguage();
+    private String defaultLocale() {
+        String language = Locale.getDefault().toString();
         return language != null ? language : "en";
     }
 }

--- a/core/src/test/java/com/auth0/api/authentication/AuthenticationAPIClientTest.java
+++ b/core/src/test/java/com/auth0/api/authentication/AuthenticationAPIClientTest.java
@@ -656,6 +656,6 @@ public class AuthenticationAPIClientTest {
 
     private String defaultLocale() {
         String language = Locale.getDefault().toString();
-        return language != null ? language : "en";
+        return !language.isEmpty() ? language : "en";
     }
 }

--- a/core/src/test/java/com/auth0/api/authentication/AuthenticationAPIClientTest.java
+++ b/core/src/test/java/com/auth0/api/authentication/AuthenticationAPIClientTest.java
@@ -51,6 +51,7 @@ import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import static com.auth0.util.AuthenticationAPI.CODE;
@@ -178,6 +179,7 @@ public class AuthenticationAPIClientTest {
         assertThat(callback, hasPayloadOfType(Token.class));
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -230,6 +232,7 @@ public class AuthenticationAPIClientTest {
         assertThat(callback, hasPayloadOfType(UserProfile.class));
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/tokeninfo"));
     }
 
@@ -244,6 +247,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/oauth/access_token"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -265,6 +269,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -287,6 +292,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/oauth/ro"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -307,6 +313,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -327,6 +334,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -349,6 +357,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -370,6 +379,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/signup"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -389,6 +399,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/change_password"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -408,6 +419,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/dbconnections/change_password"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -427,6 +439,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -447,6 +460,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -467,6 +481,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/delegation"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -487,6 +502,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/unlink"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -513,6 +529,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -533,6 +550,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -553,6 +571,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -573,6 +592,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -593,6 +613,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/passwordless/start"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -615,6 +636,7 @@ public class AuthenticationAPIClientTest {
                 .start(callback);
 
         final RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getHeader("Accept-Language"), equalTo(defaultLanguage()));
         assertThat(request.getPath(), equalTo("/oauth/token"));
 
         Map<String, String> body = bodyFromRequest(request);
@@ -630,5 +652,10 @@ public class AuthenticationAPIClientTest {
     private Map<String, String> bodyFromRequest(RecordedRequest request) throws java.io.IOException {
         return new ObjectMapper().readValue(request.getBody().inputStream(), new TypeReference<Map<String, String>>() {
         });
+    }
+
+    private String defaultLanguage() {
+        String language = Locale.getDefault().getLanguage();
+        return language != null ? language : "en";
     }
 }


### PR DESCRIPTION
Defaults to language "en" if the default language wasn't available/found.