### PR TITLE
Request the user to accept Terms&Policy before Sign Up

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/Configuration.java
@@ -71,6 +71,7 @@ public class Configuration {
     private boolean allowSignUp;
     private boolean allowForgotPassword;
     private boolean usernameRequired;
+    private boolean mustAcceptTerms;
     @PasswordStrength
     private int passwordPolicy;
     private final boolean classicLockAvailable;
@@ -249,6 +250,7 @@ public class Configuration {
         usernameStyle = options.usernameStyle();
         socialButtonStyle = options.socialButtonStyle();
         loginAfterSignUp = options.loginAfterSignUp();
+        mustAcceptTerms = options.mustAcceptTerms();
 
         final boolean socialAvailable = !getSocialStrategies().isEmpty();
         final boolean dbAvailable = getDefaultDatabaseConnection() != null;
@@ -412,5 +414,9 @@ public class Configuration {
     @NonNull
     public String getPrivacyURL() {
         return privacyURL;
+    }
+
+    public boolean mustAcceptTerms() {
+        return mustAcceptTerms;
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -430,6 +430,18 @@ public class Lock {
             return this;
         }
 
+        /**
+         * Prompts the user to accept the Privacy Policy and Terms of Service before signing up.
+         * The default value is false.
+         *
+         * @param mustAcceptTerms whether the user needs to accept the terms before sign up or not.
+         * @return the current builder instance
+         */
+        public Builder setMustAcceptTerms(boolean mustAcceptTerms) {
+            options.setMustAcceptTerms(mustAcceptTerms);
+            return this;
+        }
+
         private List<CustomField> removeDuplicatedKeys(List<CustomField> customFields) {
             int originalSize = customFields.size();
             final List<CustomField> withoutDuplicates = new ArrayList<>();

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -33,7 +33,6 @@ import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
-import android.util.Patterns;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.authentication.ParameterBuilder;
@@ -406,11 +405,7 @@ public class Lock {
          * @return the current builder instance
          */
         public Builder setPrivacyURL(@NonNull String url) {
-            if (Patterns.WEB_URL.matcher(url).matches()) {
-                options.setPrivacyURL(url);
-            } else {
-                Log.w(TAG, "The given Privacy Policy URL doesn't have a valid URL format. Will default to 'https://auth0.com/privacy'.");
-            }
+            options.setPrivacyURL(url);
             return this;
         }
 
@@ -422,11 +417,7 @@ public class Lock {
          * @return the current builder instance
          */
         public Builder setTermsURL(@NonNull String url) {
-            if (Patterns.WEB_URL.matcher(url).matches()) {
-                options.setTermsURL(url);
-            } else {
-                Log.w(TAG, "The given Terms of Service URL doesn't have a valid URL format. Will default to 'https://auth0.com/terms'.");
-            }
+            options.setTermsURL(url);
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/Options.java
@@ -60,6 +60,7 @@ class Options implements Parcelable {
     private boolean allowSignUp;
     private boolean allowForgotPassword;
     private boolean loginAfterSignUp;
+    private boolean mustAcceptTerms;
     private String defaultDatabaseConnection;
     private List<String> connections;
     private List<String> enterpriseConnectionsUsingWebForm;
@@ -94,6 +95,7 @@ class Options implements Parcelable {
         allowSignUp = in.readByte() != WITHOUT_DATA;
         allowForgotPassword = in.readByte() != WITHOUT_DATA;
         loginAfterSignUp = in.readByte() != WITHOUT_DATA;
+        mustAcceptTerms = in.readByte() != WITHOUT_DATA;
         useCodePasswordless = in.readByte() != WITHOUT_DATA;
         defaultDatabaseConnection = in.readString();
         usernameStyle = in.readInt();
@@ -144,6 +146,7 @@ class Options implements Parcelable {
         dest.writeByte((byte) (allowSignUp ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (allowForgotPassword ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (loginAfterSignUp ? HAS_DATA : WITHOUT_DATA));
+        dest.writeByte((byte) (mustAcceptTerms ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (useCodePasswordless ? HAS_DATA : WITHOUT_DATA));
         dest.writeString(defaultDatabaseConnection);
         dest.writeInt(usernameStyle);
@@ -371,5 +374,13 @@ class Options implements Parcelable {
 
     public String getTermsURL() {
         return termsURL;
+    }
+
+    public void setMustAcceptTerms(boolean mustAcceptTerms) {
+        this.mustAcceptTerms = mustAcceptTerms;
+    }
+
+    public boolean mustAcceptTerms() {
+        return mustAcceptTerms;
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/Options.java
@@ -356,20 +356,22 @@ class Options implements Parcelable {
         return initialScreen;
     }
 
-    public void setPrivacyURL(@NonNull String url) {
-        if (Patterns.WEB_URL.matcher(url).matches()) {
-            this.privacyURL = url;
+    public void setPrivacyURL(@NonNull String url) throws IllegalArgumentException {
+        if (!Patterns.WEB_URL.matcher(url).matches()) {
+            throw new IllegalArgumentException("The given Policy Privacy URL doesn't have a valid URL format: " + url);
         }
+        this.privacyURL = url;
     }
 
     public String getPrivacyURL() {
         return privacyURL;
     }
 
-    public void setTermsURL(@NonNull String url) {
-        if (Patterns.WEB_URL.matcher(url).matches()) {
-            this.termsURL = url;
+    public void setTermsURL(@NonNull String url) throws IllegalArgumentException {
+        if (!Patterns.WEB_URL.matcher(url).matches()) {
+            throw new IllegalArgumentException("The given Terms of Service URL doesn't have a valid URL format: " + url);
         }
+        this.termsURL = url;
     }
 
     public String getTermsURL() {

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -92,6 +92,9 @@
     <string name="com_auth0_lock_action_forgot_password">Don\'t remember your password?</string>
     <string name="com_auth0_lock_action_login_with_corporate">Please enter your corporate credentials at %s</string>
     <string name="com_auth0_lock_action_retry">Retry</string>
+    <string name="com_auth0_lock_action_accept">Accept</string>
+    <string name="com_auth0_lock_action_cancel">Cancel</string>
+    <string name="com_auth0_lock_action_ok">OK</string>
     <string name="com_auth0_lock_single_sign_on_enabled">Single Sign On Enabled</string>
     <string name="com_auth0_lock_forms_separator">OR</string>
     <string name="com_auth0_lock_passwordless_sms_forms_separator">Otherwise, enter your phone to sign in or create an account</string>

--- a/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
@@ -115,6 +115,7 @@ public class ConfigurationTest extends GsonBaseTest {
         assertThat(configuration.getSocialButtonStyle(), is(equalTo(SocialButtonStyle.UNSPECIFIED)));
         assertThat(configuration.hasExtraFields(), is(false));
         assertThat(configuration.getPasswordPolicy(), is(PasswordStrength.NONE));
+        assertThat(configuration.mustAcceptTerms(), is(false));
     }
 
     @Test
@@ -572,6 +573,13 @@ public class ConfigurationTest extends GsonBaseTest {
         configuration = new Configuration(application, options);
         assertThat(configuration.getTermsURL(), is(notNullValue()));
         assertThat(configuration.getTermsURL(), is(equalTo("https://google.com/terms")));
+    }
+
+    @Test
+    public void shouldHaveMustAcceptTermsEnabled() throws Exception {
+        options.setMustAcceptTerms(true);
+        configuration = new Configuration(application, options);
+        assertThat(configuration.mustAcceptTerms(), is(true));
     }
 
     private Configuration unfilteredConfig() {

--- a/lib/src/test/java/com/auth0/android/lock/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/OptionsTest.java
@@ -11,7 +11,9 @@ import com.auth0.android.lock.enums.SocialButtonStyle;
 import com.auth0.android.lock.enums.UsernameStyle;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
@@ -44,6 +46,9 @@ public class OptionsTest {
     private static final String SCOPE_OPENID_OFFLINE_ACCESS = "openid offline_access";
 
     private Options options;
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {
@@ -89,21 +94,15 @@ public class OptionsTest {
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(options.getPrivacyURL(), is(notNullValue()));
+        assertThat(options.getPrivacyURL(), is("https://valid.url/privacy"));
         assertThat(options.getPrivacyURL(), is(equalTo(parceledOptions.getPrivacyURL())));
     }
 
     @Test
-    public void shouldNotSetPrivacyPolicyURLWhenInvalidURL() throws Exception {
+    public void shouldThrowWhenSettingPrivacyPolicyURLWithInvalidURL() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("The given Policy Privacy URL doesn't have a valid URL format: an-invalid/url");
         options.setPrivacyURL("an-invalid/url");
-
-        Parcel parcel = Parcel.obtain();
-        options.writeToParcel(parcel, 0);
-        parcel.setDataPosition(0);
-
-        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(options.getPrivacyURL(), is(nullValue()));
-        assertThat(parceledOptions.getPrivacyURL(), is(nullValue()));
     }
 
     @Test
@@ -115,21 +114,15 @@ public class OptionsTest {
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(options.getTermsURL(), is(notNullValue()));
+        assertThat(options.getTermsURL(), is("https://valid.url/terms"));
         assertThat(options.getTermsURL(), is(equalTo(parceledOptions.getTermsURL())));
     }
 
     @Test
-    public void shouldNotSetTermsOfServiceURLWhenInvalidURL() throws Exception {
+    public void shouldThrowWhenSettingTermsOfServiceURLWithInvalidURL() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("The given Terms of Service URL doesn't have a valid URL format: an-invalid/url");
         options.setTermsURL("an-invalid/url");
-
-        Parcel parcel = Parcel.obtain();
-        options.writeToParcel(parcel, 0);
-        parcel.setDataPosition(0);
-
-        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(options.getTermsURL(), is(nullValue()));
-        assertThat(parceledOptions.getTermsURL(), is(nullValue()));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/android/lock/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/OptionsTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -42,15 +43,17 @@ public class OptionsTest {
     private static final String DEVICE_KEY = "device";
     private static final String SCOPE_OPENID_OFFLINE_ACCESS = "openid offline_access";
 
-    private Auth0 auth0;
+    private Options options;
 
     @Before
     public void setUp() throws Exception {
-        auth0 = new Auth0(CLIENT_ID, DOMAIN, CONFIG_DOMAIN);
+        options = new Options();
+        options.setAccount(new Auth0(CLIENT_ID, DOMAIN, CONFIG_DOMAIN));
     }
 
     @Test
-    public void shouldSetAccount() {
+    public void shouldSetAccount() throws Exception {
+        Auth0 auth0 = new Auth0(CLIENT_ID, DOMAIN, CONFIG_DOMAIN);
         Options options = new Options();
         options.setAccount(auth0);
 
@@ -65,9 +68,20 @@ public class OptionsTest {
     }
 
     @Test
-    public void shouldSetPrivacyPolicyURL() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldSetMustAcceptTerms() throws Exception {
+        options.setMustAcceptTerms(true);
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.mustAcceptTerms(), is(true));
+        assertThat(options.mustAcceptTerms(), is(equalTo(parceledOptions.mustAcceptTerms())));
+    }
+
+    @Test
+    public void shouldSetPrivacyPolicyURL() throws Exception {
         options.setPrivacyURL("https://valid.url/privacy");
 
         Parcel parcel = Parcel.obtain();
@@ -75,13 +89,12 @@ public class OptionsTest {
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.getPrivacyURL(), is(notNullValue()));
         assertThat(options.getPrivacyURL(), is(equalTo(parceledOptions.getPrivacyURL())));
     }
 
     @Test
-    public void shouldNotSetPrivacyPolicyURLWhenInvalidURL() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldNotSetPrivacyPolicyURLWhenInvalidURL() throws Exception {
         options.setPrivacyURL("an-invalid/url");
 
         Parcel parcel = Parcel.obtain();
@@ -94,9 +107,7 @@ public class OptionsTest {
     }
 
     @Test
-    public void shouldSetTermsOfServiceURL() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldSetTermsOfServiceURL() throws Exception {
         options.setTermsURL("https://valid.url/terms");
 
         Parcel parcel = Parcel.obtain();
@@ -104,13 +115,12 @@ public class OptionsTest {
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.getTermsURL(), is(notNullValue()));
         assertThat(options.getTermsURL(), is(equalTo(parceledOptions.getTermsURL())));
     }
 
     @Test
-    public void shouldNotSetTermsOfServiceURLWhenInvalidURL() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldNotSetTermsOfServiceURLWhenInvalidURL() throws Exception {
         options.setTermsURL("an-invalid/url");
 
         Parcel parcel = Parcel.obtain();
@@ -123,9 +133,7 @@ public class OptionsTest {
     }
 
     @Test
-    public void shouldUseBrowser() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldUseBrowser() throws Exception {
         options.setUseBrowser(true);
 
         Parcel parcel = Parcel.obtain();
@@ -133,13 +141,12 @@ public class OptionsTest {
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.useBrowser(), is(true));
         assertThat(options.useBrowser(), is(equalTo(parceledOptions.useBrowser())));
     }
 
     @Test
-    public void shouldUseBigSocialButtonStyle() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldUseBigSocialButtonStyle() throws Exception {
         options.setSocialButtonStyle(SocialButtonStyle.BIG);
 
         Parcel parcel = Parcel.obtain();
@@ -147,13 +154,12 @@ public class OptionsTest {
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.socialButtonStyle(), is(SocialButtonStyle.BIG));
         assertThat(options.socialButtonStyle(), is(equalTo(parceledOptions.socialButtonStyle())));
     }
 
     @Test
-    public void shouldUseSmallSocialButtonStyle() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldUseSmallSocialButtonStyle() throws Exception {
         options.setSocialButtonStyle(SocialButtonStyle.SMALL);
 
         Parcel parcel = Parcel.obtain();
@@ -161,27 +167,24 @@ public class OptionsTest {
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.socialButtonStyle(), is(equalTo(SocialButtonStyle.SMALL)));
         assertThat(options.socialButtonStyle(), is(equalTo(parceledOptions.socialButtonStyle())));
     }
 
     @Test
-    public void shouldHavePKCEEnabledByDefault() {
-        Options options = new Options();
-        options.setAccount(auth0);
-
+    public void shouldHavePKCEEnabledByDefault() throws Exception {
         Parcel parcel = Parcel.obtain();
         options.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.usePKCE(), is(parceledOptions.usePKCE()));
         assertThat(options.usePKCE(), is(true));
         assertThat(parceledOptions.usePKCE(), is(true));
     }
 
     @Test
-    public void shouldEnablePKCE() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldEnablePKCE() throws Exception {
         options.setUsePKCE(true);
 
         Parcel parcel = Parcel.obtain();
@@ -189,14 +192,13 @@ public class OptionsTest {
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.usePKCE(), is(parceledOptions.usePKCE()));
         assertThat(options.usePKCE(), is(true));
         assertThat(parceledOptions.usePKCE(), is(true));
     }
 
     @Test
-    public void shouldDisablePKCE() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldDisablePKCE() throws Exception {
         options.setUsePKCE(false);
 
         Parcel parcel = Parcel.obtain();
@@ -204,14 +206,13 @@ public class OptionsTest {
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.usePKCE(), is(parceledOptions.usePKCE()));
         assertThat(options.usePKCE(), is(false));
         assertThat(parceledOptions.usePKCE(), is(false));
     }
 
     @Test
-    public void shouldBeClosable() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldBeClosable() throws Exception {
         options.setClosable(true);
 
         Parcel parcel = Parcel.obtain();
@@ -220,12 +221,11 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options.isClosable(), is(equalTo(parceledOptions.isClosable())));
+        assertThat(options.isClosable(), is(true));
     }
 
     @Test
-    public void shouldNotLoginAfterSignUp() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldNotLoginAfterSignUp() throws Exception {
         options.setLoginAfterSignUp(false);
 
         Parcel parcel = Parcel.obtain();
@@ -234,12 +234,11 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
+        assertThat(options.loginAfterSignUp(), is(false));
     }
 
     @Test
-    public void shouldChangeInitialScreenToLogIn() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldChangeInitialScreenToLogIn() throws Exception {
         options.setInitialScreen(InitialScreen.LOG_IN);
 
         Parcel parcel = Parcel.obtain();
@@ -248,12 +247,11 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options.initialScreen(), is(equalTo(parceledOptions.initialScreen())));
+        assertThat(options.initialScreen(), is(InitialScreen.LOG_IN));
     }
 
     @Test
-    public void shouldChangeInitialScreenToSignUp() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldChangeInitialScreenToSignUp() throws Exception {
         options.setInitialScreen(InitialScreen.SIGN_UP);
 
         Parcel parcel = Parcel.obtain();
@@ -262,12 +260,11 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options.initialScreen(), is(equalTo(parceledOptions.initialScreen())));
+        assertThat(options.initialScreen(), is(InitialScreen.SIGN_UP));
     }
 
     @Test
-    public void shouldChangeInitialScreenToForgotPassword() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldChangeInitialScreenToForgotPassword() throws Exception {
         options.setInitialScreen(InitialScreen.FORGOT_PASSWORD);
 
         Parcel parcel = Parcel.obtain();
@@ -276,12 +273,11 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options.initialScreen(), is(equalTo(parceledOptions.initialScreen())));
+        assertThat(options.initialScreen(), is(InitialScreen.FORGOT_PASSWORD));
     }
 
     @Test
-    public void shouldUseEmailUsernameStyle() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldUseEmailUsernameStyle() throws Exception {
         options.setUsernameStyle(UsernameStyle.EMAIL);
 
         Parcel parcel = Parcel.obtain();
@@ -290,12 +286,11 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options.usernameStyle(), is(equalTo(parceledOptions.usernameStyle())));
+        assertThat(options.usernameStyle(), is(UsernameStyle.EMAIL));
     }
 
     @Test
-    public void shouldUseUsernameUsernameStyle() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldUseUsernameUsernameStyle() throws Exception {
         options.setUsernameStyle(UsernameStyle.USERNAME);
 
         Parcel parcel = Parcel.obtain();
@@ -304,12 +299,11 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options.usernameStyle(), is(equalTo(parceledOptions.usernameStyle())));
+        assertThat(options.usernameStyle(), is(UsernameStyle.USERNAME));
     }
 
     @Test
-    public void shouldUseDefaultUsernameStyle() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldUseDefaultUsernameStyle() throws Exception {
         options.setUsernameStyle(UsernameStyle.DEFAULT);
 
         Parcel parcel = Parcel.obtain();
@@ -318,12 +312,11 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options.usernameStyle(), is(equalTo(parceledOptions.usernameStyle())));
+        assertThat(options.usernameStyle(), is(UsernameStyle.DEFAULT));
     }
 
     @Test
-    public void shouldAllowLogIn() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldAllowLogIn() throws Exception {
         options.setAllowLogIn(true);
 
         Parcel parcel = Parcel.obtain();
@@ -332,12 +325,11 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options.allowLogIn(), is(equalTo(parceledOptions.allowLogIn())));
+        assertThat(options.allowLogIn(), is(true));
     }
 
     @Test
-    public void shouldAllowSignUp() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldAllowSignUp() throws Exception {
         options.setAllowSignUp(true);
 
         Parcel parcel = Parcel.obtain();
@@ -346,12 +338,11 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options.allowSignUp(), is(equalTo(parceledOptions.allowSignUp())));
+        assertThat(options.allowSignUp(), is(true));
     }
 
     @Test
-    public void shouldAllowForgotPassword() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldAllowForgotPassword() throws Exception {
         options.setAllowForgotPassword(true);
 
         Parcel parcel = Parcel.obtain();
@@ -360,12 +351,11 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options.allowForgotPassword(), is(equalTo(parceledOptions.allowForgotPassword())));
+        assertThat(options.allowForgotPassword(), is(true));
     }
 
     @Test
-    public void shouldUsePasswordlessCode() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldUsePasswordlessCode() throws Exception {
         options.setUseCodePasswordless(false);
 
         Parcel parcel = Parcel.obtain();
@@ -374,26 +364,23 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options.useCodePasswordless(), is(equalTo(parceledOptions.useCodePasswordless())));
+        assertThat(options.useCodePasswordless(), is(false));
     }
 
     @Test
-    public void shouldHavePasswordlessCodeByDefault() {
-        Options options = new Options();
-        options.setAccount(auth0);
-
+    public void shouldHavePasswordlessCodeByDefault() throws Exception {
         Parcel parcel = Parcel.obtain();
         options.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.useCodePasswordless(), is(equalTo(parceledOptions.useCodePasswordless())));
         assertThat(options.useCodePasswordless(), is(true));
         assertThat(parceledOptions.useCodePasswordless(), is(true));
     }
 
     @Test
-    public void shouldSetDefaultDatabaseConnection() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldSetDefaultDatabaseConnection() throws Exception {
         options.useDatabaseConnection("default_db_connection");
 
         Parcel parcel = Parcel.obtain();
@@ -402,13 +389,11 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options.getDefaultDatabaseConnection(), is(equalTo(parceledOptions.getDefaultDatabaseConnection())));
+        assertThat(options.getDefaultDatabaseConnection(), is("default_db_connection"));
     }
 
     @Test
     public void shouldSetDefaultTheme() {
-        Options options = new Options();
-        options.setAccount(auth0);
-
         Parcel parcel = Parcel.obtain();
         options.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
@@ -420,9 +405,7 @@ public class OptionsTest {
 
 
     @Test
-    public void shouldSetCustomTheme() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldSetCustomTheme() throws Exception {
         Theme theme = Theme.newBuilder()
                 .withHeaderTitle(R.string.com_auth0_lock_header_title)
                 .withHeaderLogo(R.drawable.com_auth0_lock_header_logo)
@@ -447,9 +430,7 @@ public class OptionsTest {
     }
 
     @Test
-    public void shouldSetConnections() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldSetConnections() throws Exception {
         options.setConnections(createConnections("twitter", "facebook"));
 
         Parcel parcel = Parcel.obtain();
@@ -457,14 +438,13 @@ public class OptionsTest {
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.getConnections(), is(containsInAnyOrder("twitter", "facebook")));
         assertThat(options.getConnections(), is(equalTo(parceledOptions.getConnections())));
     }
 
 
     @Test
-    public void shouldSetEnterpriseConnectionsUsingWebForm() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldSetEnterpriseConnectionsUsingWebForm() throws Exception {
         options.setEnterpriseConnectionsUsingWebForm(createEnterpriseConnectionsUsingWebForm("myAD"));
 
         Parcel parcel = Parcel.obtain();
@@ -472,13 +452,12 @@ public class OptionsTest {
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.getEnterpriseConnectionsUsingWebForm(), containsInAnyOrder("myAD"));
         assertThat(options.getEnterpriseConnectionsUsingWebForm(), is(equalTo(parceledOptions.getEnterpriseConnectionsUsingWebForm())));
     }
 
     @Test
-    public void shouldSetAuthenticationParameters() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldSetAuthenticationParameters() throws Exception {
         options.setAuthenticationParameters(createAuthenticationParameters(654123));
 
         Parcel parcel = Parcel.obtain();
@@ -490,9 +469,7 @@ public class OptionsTest {
     }
 
     @Test
-    public void shouldSetCustomFields() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldSetCustomFields() throws Exception {
         options.setCustomFields(createCustomFields());
 
         Parcel parcel = Parcel.obtain();
@@ -509,10 +486,7 @@ public class OptionsTest {
     }
 
     @Test
-    public void shouldGetEmptyCustomFieldsIfNotSet() {
-        Options options = new Options();
-        options.setAccount(auth0);
-
+    public void shouldGetEmptyCustomFieldsIfNotSet() throws Exception {
         Parcel parcel = Parcel.obtain();
         options.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
@@ -525,9 +499,7 @@ public class OptionsTest {
     }
 
     @Test
-    public void shouldSetDeviceParameterIfUsingOfflineAccessScope() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldSetDeviceParameterIfUsingOfflineAccessScope() throws Exception {
         HashMap<String, Object> params = new HashMap<>();
         params.put(SCOPE_KEY, SCOPE_OPENID_OFFLINE_ACCESS);
         options.setAuthenticationParameters(params);
@@ -544,9 +516,7 @@ public class OptionsTest {
     }
 
     @Test
-    public void shouldNotOverrideDeviceParameterIfAlreadySet() {
-        Options options = new Options();
-        options.setAccount(auth0);
+    public void shouldNotOverrideDeviceParameterIfAlreadySet() throws Exception {
         HashMap<String, Object> params = new HashMap<>();
         params.put(SCOPE_KEY, SCOPE_OPENID_OFFLINE_ACCESS);
         params.put(DEVICE_KEY, "my_device 2016");
@@ -564,10 +534,7 @@ public class OptionsTest {
     }
 
     @Test
-    public void shouldSetDefaultValues() {
-        Options options = new Options();
-        options.setAccount(auth0);
-
+    public void shouldSetDefaultValues() throws Exception {
         Parcel parcel = Parcel.obtain();
         options.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
@@ -581,6 +548,7 @@ public class OptionsTest {
         assertThat(options.allowForgotPassword(), is(true));
         assertThat(options.loginAfterSignUp(), is(true));
         assertThat(options.useCodePasswordless(), is(true));
+        assertThat(options.mustAcceptTerms(), is(false));
         assertThat(options.usernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
         assertThat(options.socialButtonStyle(), is(equalTo(SocialButtonStyle.UNSPECIFIED)));
         assertThat(options.getTheme(), is(notNullValue()));
@@ -589,9 +557,6 @@ public class OptionsTest {
 
     @Test
     public void shouldSetAllTrueFields() throws Exception {
-        Options options = new Options();
-        options.setAccount(auth0);
-
         options.setUseBrowser(true);
         options.setUsePKCE(true);
         options.setUsernameStyle(UsernameStyle.EMAIL);
@@ -600,6 +565,7 @@ public class OptionsTest {
         options.setAllowSignUp(true);
         options.setAllowForgotPassword(true);
         options.setClosable(true);
+        options.setMustAcceptTerms(true);
         options.setSocialButtonStyle(SocialButtonStyle.BIG);
         options.setLoginAfterSignUp(true);
 
@@ -609,6 +575,7 @@ public class OptionsTest {
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.mustAcceptTerms(), is(equalTo(parceledOptions.mustAcceptTerms())));
         assertThat(options.isClosable(), is(equalTo(parceledOptions.isClosable())));
         assertThat(options.useBrowser(), is(equalTo(parceledOptions.useBrowser())));
         assertThat(options.usePKCE(), is(equalTo(parceledOptions.usePKCE())));
@@ -623,9 +590,6 @@ public class OptionsTest {
 
     @Test
     public void shouldSetAllFalseFields() throws Exception {
-        Options options = new Options();
-        options.setAccount(auth0);
-
         options.setClosable(false);
         options.setUseBrowser(false);
         options.setUsePKCE(false);
@@ -634,6 +598,7 @@ public class OptionsTest {
         options.setAllowLogIn(false);
         options.setAllowSignUp(false);
         options.setAllowForgotPassword(false);
+        options.setMustAcceptTerms(false);
         options.setSocialButtonStyle(SocialButtonStyle.SMALL);
         options.setLoginAfterSignUp(false);
 
@@ -643,6 +608,7 @@ public class OptionsTest {
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.mustAcceptTerms(), is(equalTo(parceledOptions.mustAcceptTerms())));
         assertThat(options.isClosable(), is(equalTo(parceledOptions.isClosable())));
         assertThat(options.useBrowser(), is(equalTo(parceledOptions.useBrowser())));
         assertThat(options.usePKCE(), is(equalTo(parceledOptions.usePKCE())));


### PR DESCRIPTION
This affects database connections only. The dev must set the option on the builder first:

```java
Lock lock = new Lock.Builder(account)
// ...
.setMustAcceptTerms(true)
.build();
```

When he completes the fields with valid data and press the submit button, a dialog will prompt asking for acceptance.