### PR TITLE
Use first available connection name when authenticating with OAuth

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/Configuration.java
@@ -50,7 +50,7 @@ public class Configuration {
     private static final String SHOW_SIGNUP_KEY = "showSignup";
     private static final String SHOW_FORGOT_KEY = "showForgot";
     private static final String REQUIRES_USERNAME_KEY = "requires_username";
-    public static final String PASSWORD_POLICY_KEY = "passwordPolicy";
+    private static final String PASSWORD_POLICY_KEY = "passwordPolicy";
     private final List<CustomField> extraSignUpFields;
 
     private Connection defaultDatabaseConnection;

--- a/lib/src/main/java/com/auth0/android/lock/utils/json/Strategy.java
+++ b/lib/src/main/java/com/auth0/android/lock/utils/json/Strategy.java
@@ -25,7 +25,7 @@
 package com.auth0.android.lock.utils.json;
 
 
-import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.auth0.android.lock.utils.Strategies;
 
@@ -75,13 +75,16 @@ public class Strategy {
     }
 
     /**
-     * Returns the name of the first connection found in this strategy. When no connections available,
-     * it will default to the strategy name.
+     * Returns the name of the first connection found in this strategy. When no connections are available,
+     * it will return the strategy name if this is a social connection or return null in any other case.
      *
-     * @return the first connection found or the strategy name if no connections are available.
+     * @return the first connection found or null if no connections available.
      */
-    @NonNull
+    @Nullable
     public String getDefaultConnectionName() {
-        return !connections.isEmpty() ? connections.get(0).getName() : this.name;
+        if (!connections.isEmpty()) {
+            return connections.get(0).getName();
+        }
+        return strategyMetadata.getType() == Strategies.Type.SOCIAL ? this.name : null;
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/utils/json/Strategy.java
+++ b/lib/src/main/java/com/auth0/android/lock/utils/json/Strategy.java
@@ -25,6 +25,8 @@
 package com.auth0.android.lock.utils.json;
 
 
+import android.support.annotation.NonNull;
+
 import com.auth0.android.lock.utils.Strategies;
 
 import java.util.ArrayList;
@@ -70,5 +72,16 @@ public class Strategy {
         return Strategies.ActiveDirectory.getName().equals(name)
                 || Strategies.ADFS.getName().equals(name)
                 || Strategies.Waad.getName().equals(name);
+    }
+
+    /**
+     * Returns the name of the first connection found in this strategy. When no connections available,
+     * it will default to the strategy name.
+     *
+     * @return the first connection found or the strategy name if no connections are available.
+     */
+    @NonNull
+    public String getDefaultConnectionName() {
+        return !connections.isEmpty() ? connections.get(0).getName() : this.name;
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/SocialViewAdapter.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/SocialViewAdapter.java
@@ -109,7 +109,7 @@ class SocialViewAdapter extends RecyclerView.Adapter<SocialViewAdapter.ViewHolde
         public void onClick(View view) {
             if (callback != null) {
                 Strategy strategy = strategyList.get(getAdapterPosition());
-                callback.onConnectionClicked(strategy.getName());       //returns the name of the first connection element
+                callback.onConnectionClicked(strategy.getDefaultConnectionName());
             } else {
                 Log.w(TAG, "No callback was configured");
             }

--- a/lib/src/test/java/com/auth0/android/lock/utils/json/StrategyTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/utils/json/StrategyTest.java
@@ -24,19 +24,18 @@
 
 package com.auth0.android.lock.utils.json;
 
-import com.auth0.android.lock.utils.json.Connection;
-import com.auth0.android.lock.utils.json.Strategy;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -51,6 +50,26 @@ public class StrategyTest {
         Map<String, Object> values = new HashMap<>();
         values.put("name", "default");
         connection = new Connection(values);
+    }
+
+    @Test
+    public void shouldReturnTheFirstConnectionName() throws Exception {
+        Map<String, Object> firstValues = new HashMap<>();
+        firstValues.put("name", "firstConnection");
+        Connection firstConnection = new Connection(firstValues);
+        Map<String, Object> secondValues = new HashMap<>();
+        secondValues.put("name", "secondConnection");
+        Connection secondConnection = new Connection(secondValues);
+        Strategy strategy = new Strategy("facebook", Arrays.asList(firstConnection, secondConnection));
+        assertThat(strategy.getDefaultConnectionName(), is("firstConnection"));
+        assertThat(strategy.getConnections().get(0), is(equalTo(firstConnection)));
+    }
+
+    @Test
+    public void shouldReturnStrategyNameWhenNoConnections() throws Exception {
+        Strategy strategy = new Strategy("facebook", Collections.<Connection>emptyList());
+        assertThat(strategy.getDefaultConnectionName(), is("facebook"));
+        assertThat(strategy.getConnections().isEmpty(), is(true));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/android/lock/utils/json/StrategyTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/utils/json/StrategyTest.java
@@ -37,6 +37,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 @RunWith(RobolectricGradleTestRunner.class)
@@ -66,9 +67,30 @@ public class StrategyTest {
     }
 
     @Test
-    public void shouldReturnStrategyNameWhenNoConnections() throws Exception {
+    public void shouldReturnStrategyNameWhenNoConnectionsAndTypeSocial() throws Exception {
         Strategy strategy = new Strategy("facebook", Collections.<Connection>emptyList());
         assertThat(strategy.getDefaultConnectionName(), is("facebook"));
+        assertThat(strategy.getConnections().isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldReturnNullWhenNoConnectionsAndTypeEnterprise() throws Exception {
+        Strategy strategy = new Strategy("adfs", Collections.<Connection>emptyList());
+        assertThat(strategy.getDefaultConnectionName(), is(nullValue()));
+        assertThat(strategy.getConnections().isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldReturnNullWhenNoConnectionsAndTypeDatabase() throws Exception {
+        Strategy strategy = new Strategy("auth0", Collections.<Connection>emptyList());
+        assertThat(strategy.getDefaultConnectionName(), is(nullValue()));
+        assertThat(strategy.getConnections().isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldReturnNullWhenNoConnectionsAndTypePasswordless() throws Exception {
+        Strategy strategy = new Strategy("sms", Collections.<Connection>emptyList());
+        assertThat(strategy.getDefaultConnectionName(), is(nullValue()));
         assertThat(strategy.getConnections().isEmpty(), is(true));
     }
 


### PR DESCRIPTION
OAuth authentication was sending the Strategy name as the connection name parameter. This PR changes that to the first Connection name that it founds inside the Strategy, or the Strategy name if no connections were available for that Strategy.