### PR TITLE
Handle wrong Client Type error

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -414,11 +414,13 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
 
         @Override
         public void onFailure(final AuthenticationException exception) {
-            Log.e(TAG, "Failed to authenticate the user: " + exception.getDescription());
+            final AuthenticationError authError = loginErrorBuilder.buildFrom(exception);
+            final String message = authError.getMessage(LockActivity.this);
+            Log.e(TAG, "Failed to authenticate the user: " + message, exception);
             handler.post(new Runnable() {
                 @Override
                 public void run() {
-                    showErrorMessage(exception.getDescription());
+                    showErrorMessage(message);
                 }
             });
         }

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -51,6 +51,7 @@ import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.lock.adapters.Country;
 import com.auth0.android.lock.enums.PasswordlessMode;
+import com.auth0.android.lock.errors.AuthenticationError;
 import com.auth0.android.lock.errors.LoginErrorMessageBuilder;
 import com.auth0.android.lock.events.CountryCodeChangeEvent;
 import com.auth0.android.lock.events.FetchApplicationEvent;
@@ -518,11 +519,13 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
 
         @Override
         public void onFailure(final AuthenticationException exception) {
-            Log.e(TAG, "Failed to authenticate the user: " + exception.getDescription());
+            final AuthenticationError authError = loginErrorBuilder.buildFrom(exception);
+            final String message = authError.getMessage(PasswordlessLockActivity.this);;
+            Log.e(TAG, "Failed to authenticate the user: " + message, exception);
             handler.post(new Runnable() {
                 @Override
                 public void run() {
-                    showErrorMessage(exception.getDescription());
+                    showErrorMessage(message);
                 }
             });
         }

--- a/lib/src/main/java/com/auth0/android/lock/errors/LoginErrorMessageBuilder.java
+++ b/lib/src/main/java/com/auth0/android/lock/errors/LoginErrorMessageBuilder.java
@@ -36,11 +36,13 @@ public class LoginErrorMessageBuilder implements ErrorMessageBuilder<Authenticat
     private static final String USERNAME_EXISTS_ERROR = "username_exists";
     private static final String USER_IS_BLOCKED_DESCRIPTION = "user is blocked";
     private static final String TOO_MANY_ATTEMPTS_ERROR = "too_many_attempts";
+    private static final String WRONG_CLIENT_TYPE_ERROR = "Unauthorized";
 
     private static final int userExistsResource = R.string.com_auth0_lock_db_signup_user_already_exists_error_message;
     private static final int unauthorizedResource = R.string.com_auth0_lock_db_login_error_unauthorized_message;
     private static final int invalidMFACodeResource = R.string.com_auth0_lock_db_login_error_invalid_mfa_code_message;
     private static final int tooManyAttemptsResource = R.string.com_auth0_lock_db_too_many_attempts_error_message;
+    private static final int wrongClientTypeResource = R.string.com_auth0_lock_db_login_error_wrong_client_type_message;
 
     private int invalidCredentialsResource;
     private int defaultMessage;
@@ -70,6 +72,8 @@ public class LoginErrorMessageBuilder implements ErrorMessageBuilder<Authenticat
             if (!USER_IS_BLOCKED_DESCRIPTION.equals(exception.getDescription())) {
                 description = exception.getDescription();
             }
+        } else if (WRONG_CLIENT_TYPE_ERROR.equals(exception.getDescription())) {
+            messageRes = wrongClientTypeResource;
         } else if (TOO_MANY_ATTEMPTS_ERROR.equals(exception.getCode())) {
             messageRes = tooManyAttemptsResource;
         } else {

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -124,6 +124,7 @@
     <string name="com_auth0_lock_db_login_error_message">There was an error processing the sign in</string>
     <string name="com_auth0_lock_db_login_error_invalid_credentials_message">Wrong email or password</string>
     <string name="com_auth0_lock_db_login_error_unauthorized_message">User is blocked</string>
+    <string name="com_auth0_lock_db_login_error_wrong_client_type_message">Enable PKCE on your Client\'s Dashboard by setting \'Client Type\' to \'Native\'.</string>
     <string name="com_auth0_lock_db_sign_up_error_message">There was an error processing the sign up</string>
     <string name="com_auth0_lock_db_change_password_message_success">We\'ve just sent you an email to reset your password</string>
     <string name="com_auth0_lock_db_message_change_password_error">Couldn\'t reset your password.</string>

--- a/lib/src/test/java/com/auth0/android/lock/errors/LoginErrorMessageBuilderTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/errors/LoginErrorMessageBuilderTest.java
@@ -102,4 +102,11 @@ public class LoginErrorMessageBuilderTest {
         assertThat(error.getMessageRes(), is(equalTo(R.string.com_auth0_lock_db_too_many_attempts_error_message)));
     }
 
+    @Test
+    public void shouldHaveCustomMessageIfIsWrongClientType() throws Exception {
+        Mockito.when(exception.getDescription()).thenReturn("Unauthorized");
+        final AuthenticationError error = builder.buildFrom(exception);
+        assertThat(error.getMessageRes(), is(equalTo(R.string.com_auth0_lock_db_login_error_wrong_client_type_message)));
+    }
+
 }


### PR DESCRIPTION
This PR shows a user friendly error on top of Lock screen when the `client type` configuration it's not set to `Native`.

<img width="473" alt="screen shot 2016-08-09 at 3 56 51 pm" src="https://cloud.githubusercontent.com/assets/3900123/17529508/e7d6fad4-5e49-11e6-8896-c416c4184ac0.png">
