### PR TITLE
Hide Theme configuration on the Builder  [Breaking Change]

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -257,7 +257,7 @@ public class Lock {
          * @param theme to use.
          * @return the current Builder instance
          */
-        public Builder withTheme(@NonNull Theme theme) {
+        private Builder withTheme(@NonNull Theme theme) {
             options.withTheme(theme);
             return this;
         }

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -266,7 +266,7 @@ public class PasswordlessLock {
          * @param theme to use.
          * @return the current Builder instance
          */
-        public Builder withTheme(@NonNull Theme theme) {
+        private Builder withTheme(@NonNull Theme theme) {
             options.withTheme(theme);
             return this;
         }

--- a/lib/src/main/java/com/auth0/android/lock/Theme.java
+++ b/lib/src/main/java/com/auth0/android/lock/Theme.java
@@ -179,11 +179,11 @@ public class Theme implements Parcelable {
     };
 
 
-    public static Builder newBuilder() {
+    static Builder newBuilder() {
         return new Theme.Builder();
     }
 
-    public static class Builder {
+    static class Builder {
 
         private int headerTitleRes;
         private int headerLogoRes;


### PR DESCRIPTION
Hides the `builder.withTheme(Theme)` call from both Builders as this feature may change in future releases. [Breaking Change]