### PR TITLE
Force init lock [Breaking Change]

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,7 @@ public class HomeActivity extends Activity {
     Auth0 auth0 = new Auth0("YOUR_AUTH0_CLIENT_ID", "YOUR_AUTH0_DOMAIN");
     this.lock = Lock.newBuilder(auth0, callback)
       //Customize Lock
-      .build();
-    lock.onCreate(this);
+      .build(this);
   }
 
   @Override
@@ -189,8 +188,7 @@ public class HomeActivity extends Activity {
     Auth0 auth0 = new Auth0("YOUR_AUTH0_CLIENT_ID", "YOUR_AUTH0_DOMAIN");
     this.lock = PasswordlessLock.newBuilder(auth0, callback)
       //Customize Lock
-      .build();
-    lock.onCreate(this);
+      .build(this);
   }
 
   @Override

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:host="@string/auth0_domain"
+                    android:host="@string/com_auth0_domain"
                     android:pathPrefix="/android/com.auth0.android.lock.app/callback"
                     android:scheme="https" />
             </intent-filter>
@@ -57,7 +57,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:host="@string/auth0_domain"
+                    android:host="@string/com_auth0_domain"
                     android:pathPrefix="/android/com.auth0.android.lock.app/email"
                     android:scheme="https" />
             </intent-filter>

--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
@@ -170,9 +170,7 @@ public class DemoActivity extends AppCompatActivity {
                 builder.setDefaultDatabaseConnection("Username-Password-Authentication");
             }
         }
-        lock = builder.build();
-
-        lock.onCreate(this);
+        lock = builder.build(this);
 
         startActivity(lock.newIntent(this));
     }
@@ -197,8 +195,7 @@ public class DemoActivity extends AppCompatActivity {
 
         builder.onlyUseConnections(generateConnections());
 
-        passwordlessLock = builder.build();
-        passwordlessLock.onCreate(this);
+        passwordlessLock = builder.build(this);
 
         startActivity(passwordlessLock.newIntent(this));
     }

--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
@@ -201,7 +201,7 @@ public class DemoActivity extends AppCompatActivity {
     }
 
     private Auth0 getAccount() {
-        return new Auth0(getString(R.string.auth0_client_id), getString(R.string.auth0_domain));
+        return new Auth0(getString(R.string.com_auth0_client_id), getString(R.string.com_auth0_domain));
     }
 
     private List<String> generateConnections() {

--- a/app/src/main/res/values/auth0.xml
+++ b/app/src/main/res/values/auth0.xml
@@ -23,6 +23,6 @@
   -->
 
 <resources>
-    <string name="auth0_client_id">Owu62gnGsRYhk1v9SfB3c6IUbIJcRIze</string>
-    <string name="auth0_domain">lbalmaceda.auth0.com</string>
+    <string name="com_auth0_client_id">Owu62gnGsRYhk1v9SfB3c6IUbIJcRIze</string>
+    <string name="com_auth0_domain">lbalmaceda.auth0.com</string>
 </resources>

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -85,7 +85,6 @@ public class Lock {
 
     /**
      * Creates a new Lock.Builder instance with the given account and callback.
-     * ¬
      *
      * @param account  details to use against the Auth0 Authentication API.
      * @param callback that will receive the authentication results.
@@ -93,11 +92,21 @@ public class Lock {
      */
     @SuppressWarnings("unused")
     public static Builder newBuilder(@NonNull Auth0 account, @NonNull LockCallback callback) {
-        if (account.getTelemetry() != null) {
-            Log.v(TAG, String.format("Using Telemetry %s (%s) and Library %s", Constants.LIBRARY_NAME, com.auth0.android.lock.BuildConfig.VERSION_NAME, BuildConfig.VERSION_NAME));
-            account.setTelemetry(new Telemetry(Constants.LIBRARY_NAME, com.auth0.android.lock.BuildConfig.VERSION_NAME, BuildConfig.VERSION_NAME));
-        }
         return new Lock.Builder(account, callback);
+    }
+
+    /**
+     * Creates a new Lock.Builder instance with the given callback. The account information
+     * will be retrieved from the String resources file (strings.xml) using
+     * the keys 'com_auth0_client_id' and 'com_auth0_domain'.
+     *
+     * @param callback that will receive the authentication results.
+     * @return a new Lock.Builder instance.
+     */
+    @SuppressWarnings("unused")
+    public static Builder newBuilder(@NonNull LockCallback callback) {
+        //noinspection ConstantConditions
+        return newBuilder(null, callback);
     }
 
     /**
@@ -181,14 +190,23 @@ public class Lock {
          */
         public Lock build(@NonNull Activity activity) {
             if (options.getAccount() == null) {
-                Log.e(TAG, "You need to specify the com.auth0.Auth0 object with the Auth0 Account details.");
-                throw new IllegalStateException("Missing Auth0 account information.");
+                Log.w(TAG, "com.auth0.Auth0 account details not defined. Trying to create it from the String resources.");
+                try {
+                    options.setAccount(new Auth0(activity));
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalStateException("Missing Auth0 account information.", e);
+                }
             }
             if (callback == null) {
                 Log.e(TAG, "You need to specify the callback object to receive the Authentication result.");
                 throw new IllegalStateException("Missing callback.");
             }
             Log.v(TAG, "Lock instance created");
+
+            if (options.getAccount().getTelemetry() != null) {
+                Log.v(TAG, String.format("Using Telemetry %s (%s) and Library %s", Constants.LIBRARY_NAME, com.auth0.android.lock.BuildConfig.VERSION_NAME, BuildConfig.VERSION_NAME));
+                options.getAccount().setTelemetry(new Telemetry(Constants.LIBRARY_NAME, com.auth0.android.lock.BuildConfig.VERSION_NAME, BuildConfig.VERSION_NAME));
+            }
 
             final Lock lock = new Lock(options, callback);
             lock.initialize(activity);

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -114,21 +114,6 @@ public class Lock {
     }
 
     /**
-     * Should be called on the Activity holding the Lock instance's OnCreate method, as it
-     * ensures the correct Lock lifecycle handling.
-     *
-     * @param activity a valid Activity context
-     */
-    @SuppressWarnings("unused")
-    public void onCreate(Activity activity) {
-        IntentFilter filter = new IntentFilter();
-        filter.addAction(Constants.AUTHENTICATION_ACTION);
-        filter.addAction(Constants.SIGN_UP_ACTION);
-        filter.addAction(Constants.CANCELED_ACTION);
-        LocalBroadcastManager.getInstance(activity).registerReceiver(this.receiver, filter);
-    }
-
-    /**
      * Should be called on the Activity holding the Lock instance's OnDestroy method, as it
      * ensures the correct Lock lifecycle handling.
      *
@@ -137,6 +122,14 @@ public class Lock {
     @SuppressWarnings("unused")
     public void onDestroy(Activity activity) {
         LocalBroadcastManager.getInstance(activity).unregisterReceiver(this.receiver);
+    }
+
+    private void initialize(Activity activity) {
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(Constants.AUTHENTICATION_ACTION);
+        filter.addAction(Constants.SIGN_UP_ACTION);
+        filter.addAction(Constants.CANCELED_ACTION);
+        LocalBroadcastManager.getInstance(activity).registerReceiver(this.receiver, filter);
     }
 
     private void processEvent(Intent data) {
@@ -183,9 +176,10 @@ public class Lock {
          * Finishes the construction of the Lock.Options and generates a new Lock instance
          * with those Lock.Options.
          *
+         * @param activity a valid Activity context
          * @return a new Lock instance configured as in the Builder.
          */
-        public Lock build() {
+        public Lock build(@NonNull Activity activity) {
             if (options.getAccount() == null) {
                 Log.e(TAG, "You need to specify the com.auth0.Auth0 object with the Auth0 Account details.");
                 throw new IllegalStateException("Missing Auth0 account information.");
@@ -195,7 +189,10 @@ public class Lock {
                 throw new IllegalStateException("Missing callback.");
             }
             Log.v(TAG, "Lock instance created");
-            return new Lock(options, callback);
+
+            final Lock lock = new Lock(options, callback);
+            lock.initialize(activity);
+            return lock;
         }
 
         /**

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -108,20 +108,6 @@ public class PasswordlessLock {
     }
 
     /**
-     * Should be called on the Activity holding the Lock instance's OnCreate method, as it
-     * ensures the correct Lock lifecycle handling.
-     *
-     * @param activity a valid Activity context
-     */
-    @SuppressWarnings("unused")
-    public void onCreate(Activity activity) {
-        IntentFilter filter = new IntentFilter();
-        filter.addAction(Constants.AUTHENTICATION_ACTION);
-        filter.addAction(Constants.CANCELED_ACTION);
-        LocalBroadcastManager.getInstance(activity).registerReceiver(this.receiver, filter);
-    }
-
-    /**
      * Should be called on the Activity holding the Lock instance's OnDestroy method, as it
      * ensures the correct Lock lifecycle handling.
      *
@@ -130,6 +116,13 @@ public class PasswordlessLock {
     @SuppressWarnings("unused")
     public void onDestroy(Activity activity) {
         LocalBroadcastManager.getInstance(activity).unregisterReceiver(this.receiver);
+    }
+    
+    private void initialize(Activity activity) {
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(Constants.AUTHENTICATION_ACTION);
+        filter.addAction(Constants.CANCELED_ACTION);
+        LocalBroadcastManager.getInstance(activity).registerReceiver(this.receiver, filter);
     }
 
     private void processEvent(Intent data) {
@@ -172,9 +165,10 @@ public class PasswordlessLock {
          * Finishes the construction of the Lock.Options and generates a new Lock instance
          * with those Lock.Options.
          *
+         * @param activity a valid Activity context
          * @return a new Lock instance configured as in the Builder.
          */
-        public PasswordlessLock build() {
+        public PasswordlessLock build(@NonNull Activity activity) {
             if (options.getAccount() == null) {
                 Log.e(TAG, "You need to specify the com.auth0.Auth0 object with the Auth0 Account details.");
                 throw new IllegalStateException("Missing Auth0 account information.");
@@ -184,7 +178,9 @@ public class PasswordlessLock {
                 throw new IllegalStateException("Missing callback.");
             }
             Log.v(TAG, "PasswordlessLock instance created");
-            return new PasswordlessLock(options, callback);
+            final PasswordlessLock lock = new PasswordlessLock(options, callback);
+            lock.initialize(activity);
+            return lock;
         }
 
         /**

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -87,11 +87,21 @@ public class PasswordlessLock {
      */
     @SuppressWarnings("unused")
     public static Builder newBuilder(@NonNull Auth0 account, @NonNull LockCallback callback) {
-        if (account.getTelemetry() != null) {
-            Log.v(TAG, String.format("Using Telemetry %s (%s) and Library %s", Constants.LIBRARY_NAME, com.auth0.android.lock.BuildConfig.VERSION_NAME, BuildConfig.VERSION_NAME));
-            account.setTelemetry(new Telemetry(Constants.LIBRARY_NAME, com.auth0.android.lock.BuildConfig.VERSION_NAME, BuildConfig.VERSION_NAME));
-        }
         return new PasswordlessLock.Builder(account, callback);
+    }
+
+    /**
+     * Creates a new Lock.Builder instance with the given callback. The account information
+     * will be retrieved from the String resources file (strings.xml) using
+     * the keys 'com_auth0_client_id' and 'com_auth0_domain'.
+     *
+     * @param callback that will receive the authentication results.
+     * @return a new Lock.Builder instance.
+     */
+    @SuppressWarnings("unused")
+    public static Builder newBuilder(@NonNull LockCallback callback) {
+        //noinspection ConstantConditions
+        return newBuilder(null, callback);
     }
 
     /**
@@ -170,14 +180,24 @@ public class PasswordlessLock {
          */
         public PasswordlessLock build(@NonNull Activity activity) {
             if (options.getAccount() == null) {
-                Log.e(TAG, "You need to specify the com.auth0.Auth0 object with the Auth0 Account details.");
-                throw new IllegalStateException("Missing Auth0 account information.");
+                Log.w(TAG, "com.auth0.Auth0 account details not defined. Trying to create it from the String resources.");
+                try {
+                    options.setAccount(new Auth0(activity));
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalStateException("Missing Auth0 account information.", e);
+                }
             }
             if (callback == null) {
                 Log.e(TAG, "You need to specify the callback object to receive the Authentication result.");
                 throw new IllegalStateException("Missing callback.");
             }
             Log.v(TAG, "PasswordlessLock instance created");
+
+            if (options.getAccount().getTelemetry() != null) {
+                Log.v(TAG, String.format("Using Telemetry %s (%s) and Library %s", Constants.LIBRARY_NAME, com.auth0.android.lock.BuildConfig.VERSION_NAME, BuildConfig.VERSION_NAME));
+                options.getAccount().setTelemetry(new Telemetry(Constants.LIBRARY_NAME, com.auth0.android.lock.BuildConfig.VERSION_NAME, BuildConfig.VERSION_NAME));
+            }
+
             final PasswordlessLock lock = new PasswordlessLock(options, callback);
             lock.initialize(activity);
             return lock;


### PR DESCRIPTION
* Remove `Lock.onCreate` and `PasswordlessLock.onCreate` methods. Now you initialize the instance in the `Lock.Builder.build(Activity)` method. [Breaking Change]
* Update the README to reflect the `onCreate` removal.
* Add new builder initializer method `public static Builder newBuilder(@NonNull LockCallback callback)` passing only the callback. The `Auth0` account will be generated using the strings defined in the `strings.xml` resource file (or any other file inside the android resources). If the accounts details can't be found, an exception will be thrown. 