### PR TITLE
Check that requested tokens are present on the result.

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/AuthenticationCallback.java
+++ b/lib/src/main/java/com/auth0/android/lock/AuthenticationCallback.java
@@ -27,7 +27,6 @@ package com.auth0.android.lock;
 import android.content.Intent;
 import android.util.Log;
 
-import com.auth0.android.lock.utils.LockException;
 import com.auth0.android.result.Credentials;
 
 
@@ -78,14 +77,7 @@ public abstract class AuthenticationCallback implements LockCallback {
         String refreshToken = data.getStringExtra(Constants.REFRESH_TOKEN_EXTRA);
         Credentials credentials = new Credentials(idToken, accessToken, tokenType, refreshToken);
 
-        if (idToken != null && accessToken != null) {
-            Log.d(TAG, "User authenticated!");
-            onAuthentication(credentials);
-        } else {
-            Log.e(TAG, "Error parsing authentication data: id_token or access_token are missing.");
-            LockException up = new LockException(R.string.com_auth0_lock_social_error_authentication);
-            onError(up);
-            //throw up. haha
-        }
+        Log.d(TAG, "User authenticated!");
+        onAuthentication(credentials);
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/Constants.java
+++ b/lib/src/main/java/com/auth0/android/lock/Constants.java
@@ -33,6 +33,7 @@ abstract class Constants {
     static final String SIGN_UP_ACTION = "com.auth0.android.lock.action.SignUp";
     static final String CANCELED_ACTION = "com.auth0.android.lock.action.Canceled";
 
+    static final String ERROR_EXTRA = "com.auth0.android.lock.extra.Error";
     static final String ID_TOKEN_EXTRA = "com.auth0.android.lock.extra.IdToken";
     static final String ACCESS_TOKEN_EXTRA = "com.auth0.android.lock.extra.AccessToken";
     static final String TOKEN_TYPE_EXTRA = "com.auth0.android.lock.extra.TokenType";

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -43,6 +43,7 @@ import com.auth0.android.lock.enums.SocialButtonStyle;
 import com.auth0.android.lock.enums.UsernameStyle;
 import com.auth0.android.lock.provider.AuthProviderResolver;
 import com.auth0.android.lock.provider.ProviderResolverManager;
+import com.auth0.android.lock.utils.LockException;
 import com.auth0.android.util.Telemetry;
 
 import java.util.ArrayList;
@@ -146,7 +147,11 @@ public class Lock {
         switch (action) {
             case Constants.AUTHENTICATION_ACTION:
                 Log.v(TAG, "AUTHENTICATION action received in our BroadcastReceiver");
-                callback.onEvent(LockEvent.AUTHENTICATION, data);
+                if (data.getExtras().containsKey("error")) {
+                    callback.onError(new LockException(data.getStringExtra("error")));
+                } else {
+                    callback.onEvent(LockEvent.AUTHENTICATION, data);
+                }
                 break;
             case Constants.SIGN_UP_ACTION:
                 Log.v(TAG, "SIGN_UP action received in our BroadcastReceiver");

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -147,8 +147,8 @@ public class Lock {
         switch (action) {
             case Constants.AUTHENTICATION_ACTION:
                 Log.v(TAG, "AUTHENTICATION action received in our BroadcastReceiver");
-                if (data.getExtras().containsKey("error")) {
-                    callback.onError(new LockException(data.getStringExtra("error")));
+                if (data.getExtras().containsKey(Constants.ERROR_EXTRA)) {
+                    callback.onError(new LockException(data.getStringExtra(Constants.ERROR_EXTRA)));
                 } else {
                     callback.onEvent(LockEvent.AUTHENTICATION, data);
                 }

--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -161,11 +161,24 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
     }
 
     private void deliverAuthenticationResult(Credentials credentials) {
+        String requestedScopes = "openid";  //default authentication scope
+        if (options.getAuthenticationParameters().containsKey("scope")) {
+            requestedScopes = (String) options.getAuthenticationParameters().get("scope");
+        }
+
         Intent intent = new Intent(Constants.AUTHENTICATION_ACTION);
-        intent.putExtra(Constants.ID_TOKEN_EXTRA, credentials.getIdToken());
-        intent.putExtra(Constants.ACCESS_TOKEN_EXTRA, credentials.getAccessToken());
-        intent.putExtra(Constants.REFRESH_TOKEN_EXTRA, credentials.getRefreshToken());
-        intent.putExtra(Constants.TOKEN_TYPE_EXTRA, credentials.getType());
+        if (credentials.getAccessToken() == null) {
+            intent.putExtra(Constants.ERROR_EXTRA, "The access_token is missing from the response.");
+        } else if (requestedScopes.contains("openid") && credentials.getIdToken() == null) {
+            intent.putExtra(Constants.ERROR_EXTRA, "The id_token is missing from the response.");
+        } else if (requestedScopes.contains("offline_access") && credentials.getRefreshToken() == null) {
+            intent.putExtra(Constants.ERROR_EXTRA, "The refresh_token is missing from the response.");
+        } else {
+            intent.putExtra(Constants.ID_TOKEN_EXTRA, credentials.getIdToken());
+            intent.putExtra(Constants.ACCESS_TOKEN_EXTRA, credentials.getAccessToken());
+            intent.putExtra(Constants.REFRESH_TOKEN_EXTRA, credentials.getRefreshToken());
+            intent.putExtra(Constants.TOKEN_TYPE_EXTRA, credentials.getType());
+        }
 
         LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
         finish();

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -141,8 +141,8 @@ public class PasswordlessLock {
         switch (action) {
             case Constants.AUTHENTICATION_ACTION:
                 Log.v(TAG, "AUTHENTICATION action received in our BroadcastReceiver");
-                if (data.getExtras().containsKey("error")) {
-                    callback.onError(new LockException(data.getStringExtra("error")));
+                if (data.getExtras().containsKey(Constants.ERROR_EXTRA)) {
+                    callback.onError(new LockException(data.getStringExtra(Constants.ERROR_EXTRA)));
                 } else {
                     callback.onEvent(LockEvent.AUTHENTICATION, data);
                 }

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -41,6 +41,7 @@ import com.auth0.android.lock.LockCallback.LockEvent;
 import com.auth0.android.lock.enums.SocialButtonStyle;
 import com.auth0.android.lock.provider.AuthProviderResolver;
 import com.auth0.android.lock.provider.ProviderResolverManager;
+import com.auth0.android.lock.utils.LockException;
 import com.auth0.android.util.Telemetry;
 
 import java.util.HashMap;
@@ -140,7 +141,11 @@ public class PasswordlessLock {
         switch (action) {
             case Constants.AUTHENTICATION_ACTION:
                 Log.v(TAG, "AUTHENTICATION action received in our BroadcastReceiver");
-                callback.onEvent(LockEvent.AUTHENTICATION, data);
+                if (data.getExtras().containsKey("error")) {
+                    callback.onError(new LockException(data.getStringExtra("error")));
+                } else {
+                    callback.onEvent(LockEvent.AUTHENTICATION, data);
+                }
                 break;
             case Constants.CANCELED_ACTION:
                 Log.v(TAG, "CANCELED action received in our BroadcastReceiver");

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -180,11 +180,24 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
     }
 
     private void deliverAuthenticationResult(Credentials credentials) {
+        String requestedScopes = "openid";  //default authentication scope
+        if (options.getAuthenticationParameters().containsKey("scope")) {
+            requestedScopes = (String) options.getAuthenticationParameters().get("scope");
+        }
+
         Intent intent = new Intent(Constants.AUTHENTICATION_ACTION);
-        intent.putExtra(Constants.ID_TOKEN_EXTRA, credentials.getIdToken());
-        intent.putExtra(Constants.ACCESS_TOKEN_EXTRA, credentials.getAccessToken());
-        intent.putExtra(Constants.REFRESH_TOKEN_EXTRA, credentials.getRefreshToken());
-        intent.putExtra(Constants.TOKEN_TYPE_EXTRA, credentials.getType());
+        if (credentials.getAccessToken() == null) {
+            intent.putExtra(Constants.ERROR_EXTRA, "The access_token is missing from the response.");
+        } else if (requestedScopes.contains("openid") && credentials.getIdToken() == null) {
+            intent.putExtra(Constants.ERROR_EXTRA, "The id_token is missing from the response.");
+        } else if (requestedScopes.contains("offline_access") && credentials.getRefreshToken() == null) {
+            intent.putExtra(Constants.ERROR_EXTRA, "The refresh_token is missing from the response.");
+        } else {
+            intent.putExtra(Constants.ID_TOKEN_EXTRA, credentials.getIdToken());
+            intent.putExtra(Constants.ACCESS_TOKEN_EXTRA, credentials.getAccessToken());
+            intent.putExtra(Constants.REFRESH_TOKEN_EXTRA, credentials.getRefreshToken());
+            intent.putExtra(Constants.TOKEN_TYPE_EXTRA, credentials.getType());
+        }
 
         LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
         finish();

--- a/lib/src/main/java/com/auth0/android/lock/utils/LockException.java
+++ b/lib/src/main/java/com/auth0/android/lock/utils/LockException.java
@@ -24,25 +24,12 @@
 
 package com.auth0.android.lock.utils;
 
-import android.content.Context;
-import android.support.annotation.StringRes;
+import android.support.annotation.NonNull;
 
 
 public class LockException extends Exception {
-    private int message;
 
-    public LockException(@StringRes int message) {
-        super();
-        this.message = message;
-    }
-
-    /**
-     * Gets the error message or description for this LockException
-     *
-     * @param context a valid context
-     * @return the localized error message
-     */
-    public String getErrorMessage(Context context) {
-        return context.getResources().getString(message);
+    public LockException(@NonNull String message) {
+        super(message);
     }
 }

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -23,9 +23,6 @@
   -->
 
 <resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@string/com_auth0_lock_social_*">
-    <!-- Social Authentication -->
-    <string name="com_auth0_lock_social_error_authentication">Error parsing Authentication data</string>
-
     <!-- Social Buttons -->
     <string name="com_auth0_lock_social_log_in">LOG IN WITH %s</string>
     <string name="com_auth0_lock_social_sign_up">SIGN UP WITH %s</string>

--- a/lib/src/test/java/com/auth0/android/lock/AuthenticationCallbackTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/AuthenticationCallbackTest.java
@@ -41,6 +41,7 @@ import static com.auth0.android.lock.utils.AuthenticationCallbackMatcher.hasErro
 import static com.auth0.android.lock.utils.AuthenticationCallbackMatcher.hasNoError;
 import static com.auth0.android.lock.utils.AuthenticationCallbackMatcher.isCanceled;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 
@@ -57,7 +58,7 @@ public class AuthenticationCallbackTest {
 
     @Test
     public void shouldCallOnAuthentication() {
-        Intent data = getValidAuthenticationData();
+        Intent data = getAuthenticationData();
         callback.onEvent(LockEvent.AUTHENTICATION, data);
 
         assertThat(callback, hasAuthentication());
@@ -65,8 +66,8 @@ public class AuthenticationCallbackTest {
     }
 
     @Test
-    public void shouldReturnValidAuthentication() {
-        Intent data = getValidAuthenticationData();
+    public void shouldReturnAuthentication() {
+        Intent data = getAuthenticationData();
         callback.onEvent(LockEvent.AUTHENTICATION, data);
         Credentials credentials = credentialsFromData(data);
 
@@ -75,15 +76,6 @@ public class AuthenticationCallbackTest {
         assertThat(callback.getCredentials().getRefreshToken(), equalTo(credentials.getRefreshToken()));
         assertThat(callback.getCredentials().getType(), equalTo(credentials.getType()));
         assertThat(callback, hasNoError());
-    }
-
-    @Test
-    public void shouldCallOnErrorIfDataIsInvalid() {
-        Intent data = getInvalidAuthenticationData();
-        callback.onEvent(LockEvent.AUTHENTICATION, data);
-
-        assertThat(callback, hasError());
-        assertThat(callback, not(hasAuthentication()));
     }
 
     @Test
@@ -115,17 +107,10 @@ public class AuthenticationCallbackTest {
         assertThat(callback, hasNoError());
     }
 
-    public Intent getValidAuthenticationData() {
+    public Intent getAuthenticationData() {
         Intent i = new Intent(Constants.AUTHENTICATION_ACTION);
         i.putExtra(Constants.ID_TOKEN_EXTRA, "");
         i.putExtra(Constants.ACCESS_TOKEN_EXTRA, "");
-        i.putExtra(Constants.TOKEN_TYPE_EXTRA, "");
-        i.putExtra(Constants.REFRESH_TOKEN_EXTRA, "");
-        return i;
-    }
-
-    public Intent getInvalidAuthenticationData() {
-        Intent i = new Intent(Constants.AUTHENTICATION_ACTION);
         i.putExtra(Constants.TOKEN_TYPE_EXTRA, "");
         i.putExtra(Constants.REFRESH_TOKEN_EXTRA, "");
         return i;

--- a/lib/src/test/java/com/auth0/android/lock/utils/MockLockCallback.java
+++ b/lib/src/test/java/com/auth0/android/lock/utils/MockLockCallback.java
@@ -82,4 +82,8 @@ public class MockLockCallback extends AuthenticationCallback {
     public Credentials getCredentials() {
         return this.credentials;
     }
+
+    public LockException getError() {
+        return error;
+    }
 }


### PR DESCRIPTION
* Remove localized error message when Authentication fails. This was used when calling `AuthenticationCallback` with a `LockException`.
* Check for requested scopes, and validate that the `Credentials` received contains them.
* Fail with `callback.onError(LockException)` when a requested token is missing from the response, even if the response was successful. 