### PR TITLE
Filter social strategies by connection name

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/Configuration.java
@@ -224,12 +224,13 @@ public class Configuration {
     }
 
     private List<Strategy> filterSocialStrategies(List<Strategy> strategies, Set<String> connections) {
-        if (strategies == null || connections.isEmpty()) {
-            return strategies;
+        if (strategies == null) {
+            return null;
         }
         List<Strategy> filtered = new ArrayList<>(strategies.size());
         for (Strategy strategy : strategies) {
-            if (connections.contains(strategy.getName())) {
+            final boolean allowed = connections.isEmpty() || connections.contains(strategy.getDefaultConnectionName());
+            if (allowed && strategy.getDefaultConnectionName() != null) {
                 filtered.add(strategy);
             }
         }

--- a/lib/src/main/java/com/auth0/android/lock/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/Configuration.java
@@ -229,9 +229,11 @@ public class Configuration {
         }
         List<Strategy> filtered = new ArrayList<>(strategies.size());
         for (Strategy strategy : strategies) {
-            final boolean allowed = connections.isEmpty() || connections.contains(strategy.getDefaultConnectionName());
-            if (allowed && strategy.getDefaultConnectionName() != null) {
-                filtered.add(strategy);
+            for (Connection connection : strategy.getConnections()) {
+                if (connections.isEmpty() || connections.contains(connection.getName())) {
+                    filtered.add(strategy);
+                    break;
+                }
             }
         }
         return filtered;

--- a/lib/src/main/java/com/auth0/android/lock/utils/json/Strategy.java
+++ b/lib/src/main/java/com/auth0/android/lock/utils/json/Strategy.java
@@ -76,8 +76,8 @@ public class Strategy {
     }
 
     /**
-     * Returns the name of the first connection found in this strategy. When no connections are available,
-     * it will return the strategy name if this is a social connection or return null in any other case.
+     * Returns the name of the first connection found in this strategy. When no connections
+     * are available it will return null.
      *
      * @return the first connection found or null if no connections available.
      */
@@ -86,6 +86,6 @@ public class Strategy {
         if (!connections.isEmpty()) {
             return connections.get(0).getName();
         }
-        return strategyMetadata.getType() == Strategies.Type.SOCIAL ? this.name : null;
+        return null;
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/utils/json/Strategy.java
+++ b/lib/src/main/java/com/auth0/android/lock/utils/json/Strategy.java
@@ -83,9 +83,6 @@ public class Strategy {
      */
     @Nullable
     public String getDefaultConnectionName() {
-        if (!connections.isEmpty()) {
-            return connections.get(0).getName();
-        }
-        return null;
+        return !connections.isEmpty() ? connections.get(0).getName() : null;
     }
 }

--- a/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
@@ -505,6 +505,14 @@ public class ConfigurationTest extends GsonBaseTest {
     }
 
     @Test
+    public void shouldNotReturnDuplicatedSocialStrategies() throws Exception {
+        configuration = filteredConfigBy("twitter", "twitter-dev");
+        final List<Strategy> strategies = configuration.getSocialStrategies();
+        assertThat(strategies, hasItems(isStrategy(Twitter)));
+        assertThat(strategies, hasSize(1));
+    }
+
+    @Test
     public void shouldReturnUnfilteredSocialStrategiesWithConnections() throws Exception {
         configuration = unfilteredConfig();
         final List<Strategy> strategies = configuration.getSocialStrategies();

--- a/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/ConfigurationTest.java
@@ -55,6 +55,7 @@ import static com.auth0.android.lock.utils.Strategies.Facebook;
 import static com.auth0.android.lock.utils.Strategies.GoogleApps;
 import static com.auth0.android.lock.utils.Strategies.GooglePlus;
 import static com.auth0.android.lock.utils.Strategies.Instagram;
+import static com.auth0.android.lock.utils.Strategies.Linkedin;
 import static com.auth0.android.lock.utils.Strategies.SMS;
 import static com.auth0.android.lock.utils.Strategies.Twitter;
 import static com.auth0.android.lock.utils.Strategies.Yahoo;
@@ -66,6 +67,8 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -502,10 +505,19 @@ public class ConfigurationTest extends GsonBaseTest {
     }
 
     @Test
-    public void shouldReturnUnfilteredSocialStrategies() throws Exception {
+    public void shouldReturnUnfilteredSocialStrategiesWithConnections() throws Exception {
         configuration = unfilteredConfig();
         final List<Strategy> strategies = configuration.getSocialStrategies();
-        assertThat(strategies, containsInAnyOrder(isStrategy(Facebook), isStrategy(Twitter), isStrategy(Instagram), isStrategy(GooglePlus)));
+        assertThat(strategies, hasItems(isStrategy(Facebook), isStrategy(Twitter), isStrategy(Instagram), isStrategy(GooglePlus)));
+        assertThat(strategies, not(hasItem(isStrategy(Linkedin))));
+    }
+
+    @Test
+    public void shouldNotReturnFilteredSocialStrategiesWithoutConnections() throws Exception {
+        configuration = filteredConfigBy(Facebook.getName(), Linkedin.getName());
+        final List<Strategy> strategies = configuration.getSocialStrategies();
+        assertThat(strategies, hasItem(isStrategy(Facebook)));
+        assertThat(strategies, not(hasItem(isStrategy(Linkedin))));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/android/lock/utils/json/StrategyTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/utils/json/StrategyTest.java
@@ -67,9 +67,9 @@ public class StrategyTest {
     }
 
     @Test
-    public void shouldReturnStrategyNameWhenNoConnectionsAndTypeSocial() throws Exception {
+    public void shouldReturnNullStrategyNameWhenNoConnectionsAndTypeSocial() throws Exception {
         Strategy strategy = new Strategy("facebook", Collections.<Connection>emptyList());
-        assertThat(strategy.getDefaultConnectionName(), is("facebook"));
+        assertThat(strategy.getDefaultConnectionName(), is(nullValue()));
         assertThat(strategy.getConnections().isEmpty(), is(true));
     }
 

--- a/lib/src/test/resources/appinfo.json
+++ b/lib/src/test/resources/appinfo.json
@@ -99,6 +99,9 @@
                    "name": "twitter",
                    "connections": [{
                                    "name": "twitter"
+                                   },
+                                   {
+                                     "name": "twitter-dev"
                                    }]
                    }, {
                    "name": "linkedin",

--- a/lib/src/test/resources/appinfo.json
+++ b/lib/src/test/resources/appinfo.json
@@ -100,5 +100,8 @@
                    "connections": [{
                                    "name": "twitter"
                                    }]
+                   }, {
+                   "name": "linkedin",
+                   "connections": []
                    }]
 }


### PR DESCRIPTION
Filter social connections comparing their name instead of the strategy name. Ignore those strategies without connections.