### PR TITLE
Fix OAuth connection callback for PasswordlessActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         <!--Auth0 Lock-->
         <activity
             android:name="com.auth0.android.lock.LockActivity"
-            android:label="@string/app_name"
+            android:label="Classic Lock"
             android:launchMode="singleTask"
             android:screenOrientation="portrait"
             android:theme="@style/MyLock.Theme">
@@ -46,7 +46,7 @@
         <!--Auth0 PasswordlessLock-->
         <activity
             android:name="com.auth0.android.lock.PasswordlessLockActivity"
-            android:label="@string/app_name"
+            android:label="Passwordless Lock"
             android:launchMode="singleTask"
             android:screenOrientation="portrait"
             android:theme="@style/MyLock.Theme">
@@ -55,6 +55,11 @@
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="@string/com_auth0_domain"
+                    android:pathPrefix="/android/com.auth0.android.lock.app/callback"
+                    android:scheme="https" />
 
                 <data
                     android:host="@string/com_auth0_domain"


### PR DESCRIPTION
This was just affecting the sample/demo app. The PR adds the missing Data Filter on the manifest for the `PasswordlessActivity`. Now it will prompt the user to chose between resolve the callback with `Classic Lock` or `Passwordless Lock` activities. 