### PR TITLE
[Breaking Change] Rename builder methods

### DIFF
--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
@@ -36,12 +36,12 @@ import android.widget.LinearLayout;
 import android.widget.RadioGroup;
 
 import com.auth0.android.Auth0;
+import com.auth0.android.lock.AuthButtonSize;
 import com.auth0.android.lock.AuthenticationCallback;
+import com.auth0.android.lock.InitialScreen;
 import com.auth0.android.lock.Lock;
 import com.auth0.android.lock.LockCallback;
 import com.auth0.android.lock.PasswordlessLock;
-import com.auth0.android.lock.InitialScreen;
-import com.auth0.android.lock.SocialButtonStyle;
 import com.auth0.android.lock.UsernameStyle;
 import com.auth0.android.lock.utils.LockException;
 import com.auth0.android.result.Credentials;
@@ -137,9 +137,9 @@ public class DemoActivity extends AppCompatActivity {
         builder.loginAfterSignUp(checkboxLoginAfterSignUp.isChecked());
 
         if (groupSocialStyle.getCheckedRadioButtonId() == R.id.radio_social_style_big) {
-            builder.withSocialButtonStyle(SocialButtonStyle.BIG);
+            builder.withAuthButtonSize(AuthButtonSize.BIG);
         } else if (groupSocialStyle.getCheckedRadioButtonId() == R.id.radio_social_style_small) {
-            builder.withSocialButtonStyle(SocialButtonStyle.SMALL);
+            builder.withAuthButtonSize(AuthButtonSize.SMALL);
         }
 
         if (groupUsernameStyle.getCheckedRadioButtonId() == R.id.radio_username_style_email) {
@@ -160,7 +160,7 @@ public class DemoActivity extends AppCompatActivity {
             builder.initialScreen(InitialScreen.LOG_IN);
         }
 
-        builder.onlyUseConnections(generateConnections());
+        builder.allowedConnections(generateConnections());
         if (checkboxConnectionsDB.isChecked()) {
             if (groupDefaultDB.getCheckedRadioButtonId() == R.id.radio_default_db_policy) {
                 builder.setDefaultDatabaseConnection("with-strength");
@@ -182,9 +182,9 @@ public class DemoActivity extends AppCompatActivity {
         builder.useBrowser(groupWebMode.getCheckedRadioButtonId() == R.id.radio_use_browser);
 
         if (groupSocialStyle.getCheckedRadioButtonId() == R.id.radio_social_style_big) {
-            builder.withSocialButtonStyle(SocialButtonStyle.BIG);
+            builder.withAuthButtonSize(AuthButtonSize.BIG);
         } else if (groupSocialStyle.getCheckedRadioButtonId() == R.id.radio_social_style_small) {
-            builder.withSocialButtonStyle(SocialButtonStyle.SMALL);
+            builder.withAuthButtonSize(AuthButtonSize.SMALL);
         }
 
         if (groupPasswordlessMode.getCheckedRadioButtonId() == R.id.radio_use_link) {
@@ -193,7 +193,7 @@ public class DemoActivity extends AppCompatActivity {
             builder.useCode();
         }
 
-        builder.onlyUseConnections(generateConnections());
+        builder.allowedConnections(generateConnections());
 
         passwordlessLock = builder.build(this);
 

--- a/lib/src/main/java/com/auth0/android/lock/AuthButtonSize.java
+++ b/lib/src/main/java/com/auth0/android/lock/AuthButtonSize.java
@@ -29,13 +29,13 @@ import android.support.annotation.IntDef;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-import static com.auth0.android.lock.SocialButtonStyle.BIG;
-import static com.auth0.android.lock.SocialButtonStyle.SMALL;
-import static com.auth0.android.lock.SocialButtonStyle.UNSPECIFIED;
+import static com.auth0.android.lock.AuthButtonSize.BIG;
+import static com.auth0.android.lock.AuthButtonSize.SMALL;
+import static com.auth0.android.lock.AuthButtonSize.UNSPECIFIED;
 
 @IntDef({UNSPECIFIED, BIG, SMALL})
 @Retention(RetentionPolicy.SOURCE)
-public @interface SocialButtonStyle {
+public @interface AuthButtonSize {
     int UNSPECIFIED = 0;
     int BIG = 1;
     int SMALL = 2;

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -38,9 +38,9 @@ import android.util.Log;
 import com.auth0.android.Auth0;
 import com.auth0.android.authentication.ParameterBuilder;
 import com.auth0.android.lock.LockCallback.LockEvent;
-import com.auth0.android.lock.provider.AuthResolver;
 import com.auth0.android.lock.internal.configuration.Options;
 import com.auth0.android.lock.internal.configuration.Theme;
+import com.auth0.android.lock.provider.AuthResolver;
 import com.auth0.android.lock.utils.CustomField;
 import com.auth0.android.lock.utils.LockException;
 import com.auth0.android.provider.AuthHandler;
@@ -294,7 +294,7 @@ public class Lock {
          * @param connections a non-null List containing the allowed Auth0 Connections.
          * @return the current builder instance
          */
-        public Builder onlyUseConnections(@NonNull List<String> connections) {
+        public Builder allowedConnections(@NonNull List<String> connections) {
             options.setConnections(connections);
             return this;
         }
@@ -312,16 +312,16 @@ public class Lock {
         }
 
         /**
-         * Social Button style to use when Social connections are available. If social
-         * is the only connection type, by default it will use the Big style. If social and db or
-         * enterprise are present and there's only one social connection, the button will use the
-         * Big style. In the rest of the cases, it will use Small style.
+         * Auth Button size to use when Social connections are available. If Social
+         * is the only connection type it will default to the BIG size. If Database or
+         * Enterprise are present and there's only one Social connection, the button will use the
+         * BIG size. In the rest of the cases, it will use SMALL size.
          *
-         * @param style a valid SocialButtonStyle.
+         * @param style a valid AuthButtonSize.
          * @return the current builder instance
          */
-        public Builder withSocialButtonStyle(@SocialButtonStyle int style) {
-            options.setSocialButtonStyle(style);
+        public Builder withAuthButtonSize(@AuthButtonSize int style) {
+            options.setAuthButtonSize(style);
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -276,16 +276,16 @@ public class PasswordlessLock {
         }
 
         /**
-         * Social Button style to use when Social connections are available. If social
-         * is the only connection type, by default it will use the Big style. If social and db or
-         * enterprise are present and there's only one social connection, the button will use the
-         * Big style. In the rest of the cases, it will use Small style.
+         * Auth Button size to use when Social connections are available. If Social
+         * is the only connection type it will default to the BIG size. If Database or
+         * Enterprise are present and there's only one Social connection, the button will use the
+         * BIG size. In the rest of the cases, it will use SMALL size.
          *
-         * @param style a valid SocialButtonStyle.
+         * @param style a valid AuthButtonSize.
          * @return the current builder instance
          */
-        public Builder withSocialButtonStyle(@SocialButtonStyle int style) {
-            options.setSocialButtonStyle(style);
+        public Builder withAuthButtonSize(@AuthButtonSize int style) {
+            options.setAuthButtonSize(style);
             return this;
         }
 
@@ -318,7 +318,7 @@ public class PasswordlessLock {
          * @param connections a non-null List containing the allowed Auth0 Connections.
          * @return the current builder instance
          */
-        public Builder onlyUseConnections(@NonNull List<String> connections) {
+        public Builder allowedConnections(@NonNull List<String> connections) {
             options.setConnections(connections);
             return this;
         }

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
@@ -29,8 +29,8 @@ import android.support.annotation.Nullable;
 import android.support.annotation.StyleRes;
 import android.util.Log;
 
+import com.auth0.android.lock.AuthButtonSize;
 import com.auth0.android.lock.InitialScreen;
-import com.auth0.android.lock.SocialButtonStyle;
 import com.auth0.android.lock.UsernameStyle;
 import com.auth0.android.lock.utils.CustomField;
 import com.auth0.android.lock.views.AuthConfig;
@@ -62,7 +62,7 @@ public class Configuration {
     private boolean mustAcceptTerms;
     @UsernameStyle
     private int usernameStyle;
-    @SocialButtonStyle
+    @AuthButtonSize
     private int socialButtonStyle;
     private boolean loginAfterSignUp;
     @PasswordlessMode
@@ -165,7 +165,7 @@ public class Configuration {
 
     private void parseLocalOptions(Options options) {
         usernameStyle = options.usernameStyle();
-        socialButtonStyle = options.socialButtonStyle();
+        socialButtonStyle = options.authButtonSize();
         loginAfterSignUp = options.loginAfterSignUp();
         mustAcceptTerms = options.mustAcceptTerms();
 
@@ -231,7 +231,7 @@ public class Configuration {
         return initialScreen;
     }
 
-    @SocialButtonStyle
+    @AuthButtonSize
     public int getSocialButtonStyle() {
         return socialButtonStyle;
     }

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -35,8 +35,8 @@ import android.util.Patterns;
 import com.auth0.android.Auth0;
 import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.lock.Auth0Parcelable;
+import com.auth0.android.lock.AuthButtonSize;
 import com.auth0.android.lock.InitialScreen;
-import com.auth0.android.lock.SocialButtonStyle;
 import com.auth0.android.lock.UsernameStyle;
 import com.auth0.android.lock.utils.CustomField;
 
@@ -62,7 +62,7 @@ public class Options implements Parcelable {
     private boolean useBrowser;
     private boolean usePKCE;
     private boolean closable;
-    private int socialButtonStyle;
+    private int authButtonSize;
     private int usernameStyle;
     private boolean useCodePasswordless;
     private boolean allowLogIn;
@@ -111,7 +111,7 @@ public class Options implements Parcelable {
         defaultDatabaseConnection = in.readString();
         usernameStyle = in.readInt();
         initialScreen = in.readInt();
-        socialButtonStyle = in.readInt();
+        authButtonSize = in.readInt();
         theme = in.readParcelable(Theme.class.getClassLoader());
         privacyURL = in.readString();
         termsURL = in.readString();
@@ -174,7 +174,7 @@ public class Options implements Parcelable {
         dest.writeString(defaultDatabaseConnection);
         dest.writeInt(usernameStyle);
         dest.writeInt(initialScreen);
-        dest.writeInt(socialButtonStyle);
+        dest.writeInt(authButtonSize);
         dest.writeParcelable(theme, flags);
         dest.writeString(privacyURL);
         dest.writeString(termsURL);
@@ -280,13 +280,13 @@ public class Options implements Parcelable {
         this.allowLogIn = allowLogIn;
     }
 
-    public void setSocialButtonStyle(@SocialButtonStyle int socialButtonStyle) {
-        this.socialButtonStyle = socialButtonStyle;
+    public void setAuthButtonSize(@AuthButtonSize int authButtonSize) {
+        this.authButtonSize = authButtonSize;
     }
 
-    @SocialButtonStyle
-    public int socialButtonStyle() {
-        return socialButtonStyle;
+    @AuthButtonSize
+    public int authButtonSize() {
+        return authButtonSize;
     }
 
     public boolean allowLogIn() {

--- a/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
@@ -37,10 +37,10 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import com.auth0.android.lock.AuthButtonSize;
 import com.auth0.android.lock.R;
 import com.auth0.android.lock.internal.configuration.AuthMode;
 import com.auth0.android.lock.InitialScreen;
-import com.auth0.android.lock.SocialButtonStyle;
 import com.auth0.android.lock.events.DatabaseSignUpEvent;
 import com.auth0.android.lock.views.interfaces.IdentityListener;
 import com.auth0.android.lock.views.interfaces.LockWidgetForm;
@@ -133,10 +133,10 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
         boolean formContainsFields = showDatabase || showEnterprise;
         boolean singleConnection = lockWidget.getConfiguration().getSocialConnections().size() == 1;
 
-        if (style == SocialButtonStyle.UNSPECIFIED) {
+        if (style == AuthButtonSize.UNSPECIFIED) {
             socialLayout = new SocialView(lockWidget, formContainsFields && !singleConnection);
         } else {
-            socialLayout = new SocialView(lockWidget, style == SocialButtonStyle.SMALL);
+            socialLayout = new SocialView(lockWidget, style == AuthButtonSize.SMALL);
         }
 
         formsHolder.addView(socialLayout);

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordlessFormLayout.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordlessFormLayout.java
@@ -35,10 +35,10 @@ import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import com.auth0.android.lock.AuthButtonSize;
 import com.auth0.android.lock.R;
 import com.auth0.android.lock.adapters.Country;
 import com.auth0.android.lock.internal.configuration.PasswordlessMode;
-import com.auth0.android.lock.SocialButtonStyle;
 import com.auth0.android.lock.views.interfaces.LockWidgetPasswordless;
 
 public class PasswordlessFormLayout extends LinearLayout implements PasswordlessInputCodeFormView.OnCodeResendListener, PasswordlessRequestCodeFormView.OnAlreadyGotCodeListener {
@@ -87,10 +87,10 @@ public class PasswordlessFormLayout extends LinearLayout implements Passwordless
         int style = lockWidget.getConfiguration().getSocialButtonStyle();
         boolean fewConnections = lockWidget.getConfiguration().getSocialConnections().size() <= MAX_SOCIAL_BIG_BUTTONS_WITH_PASSWORDLESS;
 
-        if (style == SocialButtonStyle.UNSPECIFIED) {
+        if (style == AuthButtonSize.UNSPECIFIED) {
             socialLayout = new SocialView(lockWidget, passwordlessAvailable && !fewConnections);
         } else {
-            socialLayout = new SocialView(lockWidget, style == SocialButtonStyle.SMALL);
+            socialLayout = new SocialView(lockWidget, style == AuthButtonSize.SMALL);
         }
 
         addView(socialLayout);

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
@@ -24,9 +24,9 @@
 
 package com.auth0.android.lock.internal.configuration;
 
+import com.auth0.android.lock.AuthButtonSize;
 import com.auth0.android.lock.InitialScreen;
 import com.auth0.android.lock.R;
-import com.auth0.android.lock.SocialButtonStyle;
 import com.auth0.android.lock.UsernameStyle;
 import com.auth0.android.lock.utils.CustomField;
 import com.auth0.android.lock.utils.CustomField.FieldType;
@@ -100,7 +100,7 @@ public class ConfigurationTest extends GsonBaseTest {
         assertThat(configuration.loginAfterSignUp(), is(true));
         assertThat(configuration.getUsernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
         assertThat(configuration.getInitialScreen(), is(equalTo(InitialScreen.LOG_IN)));
-        assertThat(configuration.getSocialButtonStyle(), is(equalTo(SocialButtonStyle.UNSPECIFIED)));
+        assertThat(configuration.getSocialButtonStyle(), is(equalTo(AuthButtonSize.UNSPECIFIED)));
         assertThat(configuration.hasExtraFields(), is(false));
         assertThat(configuration.getPasswordPolicy(), is(PasswordStrength.NONE));
         assertThat(configuration.mustAcceptTerms(), is(false));
@@ -128,7 +128,7 @@ public class ConfigurationTest extends GsonBaseTest {
         options.setAllowForgotPassword(false);
         options.setLoginAfterSignUp(false);
         options.setUsernameStyle(UsernameStyle.USERNAME);
-        options.setSocialButtonStyle(SocialButtonStyle.BIG);
+        options.setAuthButtonSize(AuthButtonSize.BIG);
         configuration = new Configuration(connections, options);
         assertThat(configuration.isUsernameRequired(), is(false));
         assertThat(configuration.allowLogIn(), is(false));
@@ -136,7 +136,7 @@ public class ConfigurationTest extends GsonBaseTest {
         assertThat(configuration.allowForgotPassword(), is(false));
         assertThat(configuration.loginAfterSignUp(), is(false));
         assertThat(configuration.getUsernameStyle(), is(equalTo(UsernameStyle.USERNAME)));
-        assertThat(configuration.getSocialButtonStyle(), is(equalTo(SocialButtonStyle.BIG)));
+        assertThat(configuration.getSocialButtonStyle(), is(equalTo(AuthButtonSize.BIG)));
         assertThat(configuration.hasExtraFields(), is(false));
     }
 

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -5,9 +5,9 @@ import android.os.Parcel;
 import android.support.v7.appcompat.BuildConfig;
 
 import com.auth0.android.Auth0;
+import com.auth0.android.lock.AuthButtonSize;
 import com.auth0.android.lock.InitialScreen;
 import com.auth0.android.lock.R;
-import com.auth0.android.lock.SocialButtonStyle;
 import com.auth0.android.lock.UsernameStyle;
 import com.auth0.android.lock.utils.CustomField;
 import com.auth0.android.lock.utils.CustomField.FieldType;
@@ -142,28 +142,28 @@ public class OptionsTest {
 
     @Test
     public void shouldUseBigSocialButtonStyle() throws Exception {
-        options.setSocialButtonStyle(SocialButtonStyle.BIG);
+        options.setAuthButtonSize(AuthButtonSize.BIG);
 
         Parcel parcel = Parcel.obtain();
         options.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(options.socialButtonStyle(), is(SocialButtonStyle.BIG));
-        assertThat(options.socialButtonStyle(), is(equalTo(parceledOptions.socialButtonStyle())));
+        assertThat(options.authButtonSize(), is(AuthButtonSize.BIG));
+        assertThat(options.authButtonSize(), is(equalTo(parceledOptions.authButtonSize())));
     }
 
     @Test
     public void shouldUseSmallSocialButtonStyle() throws Exception {
-        options.setSocialButtonStyle(SocialButtonStyle.SMALL);
+        options.setAuthButtonSize(AuthButtonSize.SMALL);
 
         Parcel parcel = Parcel.obtain();
         options.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(options.socialButtonStyle(), is(equalTo(SocialButtonStyle.SMALL)));
-        assertThat(options.socialButtonStyle(), is(equalTo(parceledOptions.socialButtonStyle())));
+        assertThat(options.authButtonSize(), is(equalTo(AuthButtonSize.SMALL)));
+        assertThat(options.authButtonSize(), is(equalTo(parceledOptions.authButtonSize())));
     }
 
     @Test
@@ -567,7 +567,7 @@ public class OptionsTest {
         assertThat(options.useCodePasswordless(), is(true));
         assertThat(options.mustAcceptTerms(), is(false));
         assertThat(options.usernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
-        assertThat(options.socialButtonStyle(), is(equalTo(SocialButtonStyle.UNSPECIFIED)));
+        assertThat(options.authButtonSize(), is(equalTo(AuthButtonSize.UNSPECIFIED)));
         assertThat(options.getTheme(), is(notNullValue()));
         assertThat(options.getAuthenticationParameters(), is(notNullValue()));
         assertThat(options.getAuthStyles(), is(notNullValue()));
@@ -585,7 +585,7 @@ public class OptionsTest {
         options.setAllowForgotPassword(true);
         options.setClosable(true);
         options.setMustAcceptTerms(true);
-        options.setSocialButtonStyle(SocialButtonStyle.BIG);
+        options.setAuthButtonSize(AuthButtonSize.BIG);
         options.setLoginAfterSignUp(true);
 
 
@@ -603,7 +603,7 @@ public class OptionsTest {
         assertThat(options.allowLogIn(), is(equalTo(parceledOptions.allowLogIn())));
         assertThat(options.allowSignUp(), is(equalTo(parceledOptions.allowSignUp())));
         assertThat(options.allowForgotPassword(), is(equalTo(parceledOptions.allowForgotPassword())));
-        assertThat(options.socialButtonStyle(), is(equalTo(parceledOptions.socialButtonStyle())));
+        assertThat(options.authButtonSize(), is(equalTo(parceledOptions.authButtonSize())));
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
     }
 
@@ -618,7 +618,7 @@ public class OptionsTest {
         options.setAllowSignUp(false);
         options.setAllowForgotPassword(false);
         options.setMustAcceptTerms(false);
-        options.setSocialButtonStyle(SocialButtonStyle.SMALL);
+        options.setAuthButtonSize(AuthButtonSize.SMALL);
         options.setLoginAfterSignUp(false);
 
 
@@ -636,7 +636,7 @@ public class OptionsTest {
         assertThat(options.allowLogIn(), is(equalTo(parceledOptions.allowLogIn())));
         assertThat(options.allowSignUp(), is(equalTo(parceledOptions.allowSignUp())));
         assertThat(options.allowForgotPassword(), is(equalTo(parceledOptions.allowForgotPassword())));
-        assertThat(options.socialButtonStyle(), is(equalTo(parceledOptions.socialButtonStyle())));
+        assertThat(options.authButtonSize(), is(equalTo(parceledOptions.authButtonSize())));
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
     }
 


### PR DESCRIPTION
Both `Lock.Builder` and `PasswordlessLock.Builder` has been refactored.
* The method `withSocialButtonStyle` has been renamed to `withAuthButtonSize`.
* The method `onlyUseConnections` has been renamed to `allowedConnections`.