### PR TITLE
Improve dependencies versioning (externalized versions)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    compileSdkVersion rootProject.compileSdkVersion
+    buildToolsVersion rootProject.buildToolsVersion
 
     defaultConfig {
         applicationId "com.auth0.android.lock.app"
-        minSdkVersion 15
-        targetSdkVersion 24
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
         versionCode 1
         versionName "1.0"
     }
@@ -45,7 +45,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:24.2.1'
-    compile 'com.android.support:design:24.2.1'
+    compile "com.android.support:appcompat-v7:$rootProject.supportLibraryVersion"
+    compile "com.android.support:design:$rootProject.supportLibraryVersion"
     compile project(':lock')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,3 +22,26 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+ext {
+    //android config versions
+    compileSdkVersion = 24
+    buildToolsVersion = "24.0.2"
+    minSdkVersion = 15
+    targetSdkVersion = 24
+    versionCode = 1
+
+    //dependencies
+    supportLibraryVersion = "24.2.1"
+    gsonVersion = "2.6.2"
+    ottoVersion = "1.3.8"
+    auth0Version = "1.0.0"
+
+    //test dependencies
+    jUnitVersion = '4.12'
+    hamcrestVersion = '1.3'
+    robolectricVersion = '3.1.2'
+    mockitoVersion = '1.10.19'
+    okHttpMockWebServerVersion = '3.1.2'
+    awaitilityVersion = '1.7.0'
+}

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -6,12 +6,12 @@ version = semver.stringVersion
 logger.lifecycle("Using version ${version} for ${name}")
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    compileSdkVersion rootProject.compileSdkVersion
+    buildToolsVersion rootProject.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 24
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
         versionCode 1
         versionName semver.stringVersion
     }
@@ -25,20 +25,21 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:percent:24.2.1'
-    compile 'com.android.support:appcompat-v7:24.2.1'
-    compile 'com.android.support:recyclerview-v7:24.2.1'
-    compile 'com.android.support:support-v4:24.2.1'
-    compile 'com.android.support:design:24.2.1'
-    compile 'com.google.code.gson:gson:2.6.2'
-    compile 'com.squareup:otto:1.3.8'
-    compile 'com.auth0.android:auth0:1.0.0'
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.hamcrest:hamcrest-library:1.3'
-    testCompile 'org.robolectric:robolectric:3.1.2'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.1.2'
-    testCompile 'com.jayway.awaitility:awaitility:1.7.0'
+    compile "com.android.support:percent:$rootProject.supportLibraryVersion"
+    compile "com.android.support:appcompat-v7:$rootProject.supportLibraryVersion"
+    compile "com.android.support:recyclerview-v7:$rootProject.supportLibraryVersion"
+    compile "com.android.support:support-v4:$rootProject.supportLibraryVersion"
+    compile "com.android.support:design:$rootProject.supportLibraryVersion"
+    compile "com.google.code.gson:gson:$rootProject.gsonVersion"
+    compile "com.squareup:otto:$rootProject.ottoVersion"
+    compile "com.auth0.android:auth0:$rootProject.auth0Version"
+
+    testCompile "junit:junit:$rootProject.jUnitVersion"
+    testCompile "org.hamcrest:hamcrest-library:$rootProject.hamcrestVersion"
+    testCompile "org.robolectric:robolectric:$rootProject.robolectricVersion"
+    testCompile "org.mockito:mockito-core:$rootProject.mockitoVersion"
+    testCompile "com.squareup.okhttp3:mockwebserver:$rootProject.okHttpMockWebServerVersion"
+    testCompile "com.jayway.awaitility:awaitility:$rootProject.awaitilityVersion"
 }
 
 def defineVersion() {


### PR DESCRIPTION
This Pull Request helps to improve the dependency versioning in the library.

Externalize dependency versions by using gradle extra properties, instead of hardcoding and probably duplicating version numbers.

It also makes version upgrades easy.