### PR TITLE
Send LockException if the Theme is invalid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
 android:
   components:
   - tools
-  - build-tools-24.0.2
+  - build-tools-24.0.3
   - android-24
   - extra-google-google_play_services
   - extra-google-m2repository

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion '24.0.3'
 
     defaultConfig {
         applicationId "com.auth0.android.lock.app"

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -7,7 +7,7 @@ logger.lifecycle("Using version ${version} for ${name}")
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion '24.0.3'
 
     defaultConfig {
         minSdkVersion 15

--- a/lib/src/main/java/com/auth0/android/lock/Constants.java
+++ b/lib/src/main/java/com/auth0/android/lock/Constants.java
@@ -32,6 +32,7 @@ abstract class Constants {
     static final String AUTHENTICATION_ACTION = "com.auth0.android.lock.action.Authentication";
     static final String SIGN_UP_ACTION = "com.auth0.android.lock.action.SignUp";
     static final String CANCELED_ACTION = "com.auth0.android.lock.action.Canceled";
+    static final String INVALID_CONFIGURATION_ACTION = "com.auth0.android.lock.action.InvalidConfiguration";
 
     static final String ERROR_EXTRA = "com.auth0.android.lock.extra.Error";
     static final String ID_TOKEN_EXTRA = "com.auth0.android.lock.extra.IdToken";

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -140,6 +140,7 @@ public class Lock {
         filter.addAction(Constants.AUTHENTICATION_ACTION);
         filter.addAction(Constants.SIGN_UP_ACTION);
         filter.addAction(Constants.CANCELED_ACTION);
+        filter.addAction(Constants.INVALID_CONFIGURATION_ACTION);
         LocalBroadcastManager.getInstance(activity).registerReceiver(this.receiver, filter);
     }
 
@@ -161,6 +162,10 @@ public class Lock {
             case Constants.CANCELED_ACTION:
                 Log.v(TAG, "CANCELED action received in our BroadcastReceiver");
                 callback.onEvent(LockEvent.CANCELED, new Intent());
+                break;
+            case Constants.INVALID_CONFIGURATION_ACTION:
+                Log.v(TAG, "INVALID_CONFIGURATION_ACTION action received in our BroadcastReceiver");
+                callback.onError(new LockException(data.getStringExtra(Constants.ERROR_EXTRA)));
                 break;
         }
     }

--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -102,14 +102,7 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (!isLaunchConfigValid()) {
-            Log.d(TAG, "Configuration is not valid and the Activity will finish.");
-            finish();
-            return;
-        }
-        if (!isThemeValid()) {
-            Log.d(TAG, "You need to use a Lock.Theme theme (or descendant) with this Activity.");
-            finish();
+        if (!hasValidLaunchConfig()) {
             return;
         }
 
@@ -132,7 +125,25 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
         lockBus.post(new FetchApplicationEvent());
     }
 
-    private boolean isThemeValid() {
+    private boolean hasValidLaunchConfig() {
+        String errorDescription = null;
+        if (!hasValidOptions()) {
+            errorDescription = "Configuration is not valid and the Activity will finish.";
+        }
+        if (!hasValidTheme()) {
+            errorDescription = "You need to use a Lock.Theme theme (or descendant) with this Activity.";
+        }
+        if (errorDescription == null) {
+            return true;
+        }
+        Intent intent = new Intent(Constants.INVALID_CONFIGURATION_ACTION);
+        intent.putExtra(Constants.ERROR_EXTRA, errorDescription);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+        finish();
+        return false;
+    }
+
+    private boolean hasValidTheme() {
         TypedArray a = getTheme().obtainStyledAttributes(R.styleable.Lock_Theme);
         if (!a.hasValue(R.styleable.Lock_Theme_Auth0_HeaderLogo)) {
             a.recycle();
@@ -141,7 +152,7 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
         return true;
     }
 
-    private boolean isLaunchConfigValid() {
+    private boolean hasValidOptions() {
         options = getIntent().getParcelableExtra(Constants.OPTIONS_EXTRA);
         if (options == null) {
             Log.e(TAG, "Lock Options are missing in the received Intent and LockActivity will not launch. " +

--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -27,6 +27,7 @@ package com.auth0.android.lock;
 
 import android.app.Dialog;
 import android.content.Intent;
+import android.content.res.TypedArray;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -106,6 +107,11 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
             finish();
             return;
         }
+        if (!isThemeValid()) {
+            Log.d(TAG, "You need to use a Lock.Theme theme (or descendant) with this Activity.");
+            finish();
+            return;
+        }
 
         getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
         Bus lockBus = new Bus();
@@ -124,6 +130,15 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
         signUpErrorBuilder = new SignUpErrorMessageBuilder();
 
         lockBus.post(new FetchApplicationEvent());
+    }
+
+    private boolean isThemeValid() {
+        TypedArray a = getTheme().obtainStyledAttributes(R.styleable.Lock_Theme);
+        if (!a.hasValue(R.styleable.Lock_Theme_Auth0_HeaderLogo)) {
+            a.recycle();
+            return false;
+        }
+        return true;
     }
 
     private boolean isLaunchConfigValid() {

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -135,6 +135,7 @@ public class PasswordlessLock {
         IntentFilter filter = new IntentFilter();
         filter.addAction(Constants.AUTHENTICATION_ACTION);
         filter.addAction(Constants.CANCELED_ACTION);
+        filter.addAction(Constants.INVALID_CONFIGURATION_ACTION);
         LocalBroadcastManager.getInstance(activity).registerReceiver(this.receiver, filter);
     }
 
@@ -152,6 +153,10 @@ public class PasswordlessLock {
             case Constants.CANCELED_ACTION:
                 Log.v(TAG, "CANCELED action received in our BroadcastReceiver");
                 callback.onEvent(LockEvent.CANCELED, new Intent());
+                break;
+            case Constants.INVALID_CONFIGURATION_ACTION:
+                Log.v(TAG, "INVALID_CONFIGURATION_ACTION action received in our BroadcastReceiver");
+                callback.onError(new LockException(data.getStringExtra(Constants.ERROR_EXTRA)));
                 break;
         }
     }

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -29,6 +29,7 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.TypedArray;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -131,6 +132,11 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
             finish();
             return;
         }
+        if (!isThemeValid()) {
+            Log.d(TAG, "You need to use a Lock.Theme theme (or descendant) with this Activity.");
+            finish();
+            return;
+        }
 
         getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
         lockBus = new Bus();
@@ -152,6 +158,15 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
             loginErrorBuilder = new LoginErrorMessageBuilder(R.string.com_auth0_lock_passwordless_link_request_error_message, R.string.com_auth0_lock_passwordless_login_error_invalid_credentials_message);
         }
         lockBus.post(new FetchApplicationEvent());
+    }
+
+    private boolean isThemeValid() {
+        TypedArray a = getTheme().obtainStyledAttributes(R.styleable.Lock_Theme);
+        if (!a.hasValue(R.styleable.Lock_Theme_Auth0_HeaderLogo)) {
+            a.recycle();
+            return false;
+        }
+        return true;
     }
 
     private boolean isLaunchConfigValid() {


### PR DESCRIPTION
Send a exception via `lockCallback.onError()` method if the launch configuration is invalid:
* Invalid `Options`
* Invalid `launchMode` in the AndroidManifest
* Theme not extending `Lock.Theme`