### PR TITLE
Non-empty username validation for custom/imported connections

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Connection.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Connection.java
@@ -158,9 +158,14 @@ public class Connection implements BaseConnection, DatabaseConnection, OAuthConn
 
     private void parseUsernameLength() {
         Map<String, Object> validations = valueForKey("validation", Map.class);
-        if (validations == null || !validations.containsKey("username")) {
+        if (validations == null) {
             minUsernameLength = MIN_USERNAME_LENGTH;
             maxUsernameLength = MAX_USERNAME_LENGTH;
+            return;
+        }
+        if (!validations.containsKey("username")){
+            minUsernameLength = UNUSED_USERNAME_LENGTH;
+            maxUsernameLength = UNUSED_USERNAME_LENGTH;
             return;
         }
         final Map<String, Object> usernameValidation = (Map<String, Object>) validations.get("username");

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Connection.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Connection.java
@@ -169,8 +169,8 @@ public class Connection implements BaseConnection, DatabaseConnection, OAuthConn
             return;
         }
         final Map<String, Object> usernameValidation = (Map<String, Object>) validations.get("username");
-        minUsernameLength = intValue(usernameValidation.get("min"), MIN_USERNAME_LENGTH);
-        maxUsernameLength = intValue(usernameValidation.get("max"), MAX_USERNAME_LENGTH);
+        minUsernameLength = intValue(usernameValidation.get("min"), 0);
+        maxUsernameLength = intValue(usernameValidation.get("max"), 0);
         if (minUsernameLength < MIN_USERNAME_LENGTH || minUsernameLength > maxUsernameLength) {
             minUsernameLength = MIN_USERNAME_LENGTH;
             maxUsernameLength = MAX_USERNAME_LENGTH;

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Connection.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Connection.java
@@ -164,23 +164,19 @@ public class Connection implements BaseConnection, DatabaseConnection, OAuthConn
 
     private void parseUsernameLength() {
         Map<String, Object> validations = valueForKey("validation", Map.class);
-        if (validations == null) {
-            minUsernameLength = MIN_USERNAME_LENGTH;
-            maxUsernameLength = MAX_USERNAME_LENGTH;
-            return;
-        }
-        if (!validations.containsKey("username")) {
+        if (validations == null || !validations.containsKey("username")) {
             isCustomDatabase = true;
-            minUsernameLength = MIN_USERNAME_LENGTH;
+            minUsernameLength = 1;
             maxUsernameLength = Integer.MAX_VALUE;
             return;
         }
+
         final Map<String, Object> usernameValidation = (Map<String, Object>) validations.get("username");
         minUsernameLength = intValue(usernameValidation.get("min"), 0);
         maxUsernameLength = intValue(usernameValidation.get("max"), 0);
-        if (minUsernameLength < MIN_USERNAME_LENGTH || minUsernameLength > maxUsernameLength) {
-            minUsernameLength = MIN_USERNAME_LENGTH;
-            maxUsernameLength = MAX_USERNAME_LENGTH;
+        if (minUsernameLength < 1 || maxUsernameLength < 1 || minUsernameLength > maxUsernameLength) {
+            minUsernameLength = 1;
+            maxUsernameLength = Integer.MAX_VALUE;
         }
     }
 

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Connection.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Connection.java
@@ -17,6 +17,7 @@ public class Connection implements BaseConnection, DatabaseConnection, OAuthConn
     private Map<String, Object> values;
     private int minUsernameLength;
     private int maxUsernameLength;
+    private boolean isCustomDatabase;
 
     private Connection(@NonNull String strategy, Map<String, Object> values) {
         checkArgument(values != null && values.size() > 0, "Must have at least one value");
@@ -125,6 +126,11 @@ public class Connection implements BaseConnection, DatabaseConnection, OAuthConn
     }
 
     @Override
+    public boolean isCustomDatabase() {
+        return isCustomDatabase;
+    }
+
+    @Override
     public boolean isActiveFlowEnabled() {
         return "ad".equals(getStrategy()) || "adfs".equals(getStrategy()) || "waad".equals(getStrategy());
     }
@@ -163,9 +169,10 @@ public class Connection implements BaseConnection, DatabaseConnection, OAuthConn
             maxUsernameLength = MAX_USERNAME_LENGTH;
             return;
         }
-        if (!validations.containsKey("username")){
-            minUsernameLength = UNUSED_USERNAME_LENGTH;
-            maxUsernameLength = UNUSED_USERNAME_LENGTH;
+        if (!validations.containsKey("username")) {
+            isCustomDatabase = true;
+            minUsernameLength = MIN_USERNAME_LENGTH;
+            maxUsernameLength = Integer.MAX_VALUE;
             return;
         }
         final Map<String, Object> usernameValidation = (Map<String, Object>) validations.get("username");

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/DatabaseConnection.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/DatabaseConnection.java
@@ -2,7 +2,6 @@ package com.auth0.android.lock.internal.configuration;
 
 public interface DatabaseConnection extends BaseConnection {
 
-    int UNUSED_USERNAME_LENGTH = -1;
     int MIN_USERNAME_LENGTH = 1;
     int MAX_USERNAME_LENGTH = 15;
 
@@ -48,4 +47,11 @@ public interface DatabaseConnection extends BaseConnection {
      * @return the maximum username length.
      */
     int getMaxUsernameLength();
+
+    /**
+     * Whether this connection is a Custom/Imported Database.
+     *
+     * @return true if this connection is a Custom/Imported Database.
+     */
+    boolean isCustomDatabase();
 }

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/DatabaseConnection.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/DatabaseConnection.java
@@ -2,6 +2,7 @@ package com.auth0.android.lock.internal.configuration;
 
 public interface DatabaseConnection extends BaseConnection {
 
+    int UNUSED_USERNAME_LENGTH = -1;
     int MIN_USERNAME_LENGTH = 1;
     int MAX_USERNAME_LENGTH = 15;
 

--- a/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
@@ -92,7 +92,7 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
         emailInput.configureFrom(configuration.getDatabaseConnection());
         emailInput.setUsernameStyle(configuration.getUsernameStyle());
         emailInput.setIdentityListener(this);
-        usernameInput.setDataType(DataType.USERNAME);
+        usernameInput.setDataType(DataType.NON_EMPTY_USERNAME);
 
         fallbackToDatabase = configuration.getDatabaseConnection() != null;
         changePasswordEnabled = fallbackToDatabase && configuration.allowForgotPassword();

--- a/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
@@ -40,6 +40,7 @@ import com.auth0.android.lock.events.DatabaseLoginEvent;
 import com.auth0.android.lock.events.LockMessageEvent;
 import com.auth0.android.lock.events.OAuthLoginEvent;
 import com.auth0.android.lock.internal.configuration.AuthMode;
+import com.auth0.android.lock.internal.configuration.Configuration;
 import com.auth0.android.lock.internal.configuration.OAuthConnection;
 import com.auth0.android.lock.utils.EnterpriseConnectionMatcher;
 import com.auth0.android.lock.views.interfaces.IdentityListener;
@@ -80,19 +81,21 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
         changePasswordBtn = findViewById(R.id.com_auth0_lock_change_password_btn);
         enterpriseBtn = (SocialButton) findViewById(R.id.com_auth0_lock_enterprise_button);
         topMessage = (TextView) findViewById(R.id.com_auth0_lock_text);
-        domainParser = new EnterpriseConnectionMatcher(lockWidget.getConfiguration().getEnterpriseConnections());
+        Configuration configuration = lockWidget.getConfiguration();
+        domainParser = new EnterpriseConnectionMatcher(configuration.getEnterpriseConnections());
         usernameInput = (ValidatedUsernameInputView) findViewById(R.id.com_auth0_lock_input_username);
         passwordInput = (ValidatedInputView) findViewById(R.id.com_auth0_lock_input_password);
         passwordInput.setDataType(DataType.PASSWORD);
         passwordInput.setOnEditorActionListener(this);
 
         emailInput = (ValidatedUsernameInputView) findViewById(R.id.com_auth0_lock_input_username_email);
-        emailInput.chooseDataType(lockWidget.getConfiguration());
+        emailInput.configureFrom(configuration.getDatabaseConnection());
+        emailInput.setUsernameStyle(configuration.getUsernameStyle());
         emailInput.setIdentityListener(this);
         usernameInput.setDataType(DataType.USERNAME);
 
-        fallbackToDatabase = lockWidget.getConfiguration().getDatabaseConnection() != null;
-        changePasswordEnabled = fallbackToDatabase && lockWidget.getConfiguration().allowForgotPassword();
+        fallbackToDatabase = configuration.getDatabaseConnection() != null;
+        changePasswordEnabled = fallbackToDatabase && configuration.allowForgotPassword();
         changePasswordBtn.setVisibility(changePasswordEnabled ? VISIBLE : GONE);
         changePasswordBtn.setOnClickListener(new OnClickListener() {
             @Override
@@ -100,11 +103,11 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
                 lockWidget.showChangePasswordForm(true);
             }
         });
-        boolean socialAvailable = !lockWidget.getConfiguration().getSocialConnections().isEmpty();
-        boolean singleEnterprise = lockWidget.getConfiguration().getEnterpriseConnections().size() == 1;
+        boolean socialAvailable = !configuration.getSocialConnections().isEmpty();
+        boolean singleEnterprise = configuration.getEnterpriseConnections().size() == 1;
         if (!fallbackToDatabase && !socialAvailable && singleEnterprise) {
             Log.v(TAG, "Only one enterprise connection was found.");
-            setupSingleConnectionUI(lockWidget.getConfiguration().getEnterpriseConnections().get(0));
+            setupSingleConnectionUI(configuration.getEnterpriseConnections().get(0));
         } else {
             Log.v(TAG, "Multiple enterprise/database connections found.");
             setupMultipleConnectionUI();

--- a/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
@@ -84,6 +84,7 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
         Configuration configuration = lockWidget.getConfiguration();
         domainParser = new EnterpriseConnectionMatcher(configuration.getEnterpriseConnections());
         usernameInput = (ValidatedUsernameInputView) findViewById(R.id.com_auth0_lock_input_username);
+        usernameInput.setDataType(DataType.NON_EMPTY_USERNAME);
         passwordInput = (ValidatedInputView) findViewById(R.id.com_auth0_lock_input_password);
         passwordInput.setDataType(DataType.PASSWORD);
         passwordInput.setOnEditorActionListener(this);
@@ -92,7 +93,6 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
         emailInput.configureFrom(configuration.getDatabaseConnection());
         emailInput.setUsernameStyle(configuration.getUsernameStyle());
         emailInput.setIdentityListener(this);
-        usernameInput.setDataType(DataType.NON_EMPTY_USERNAME);
 
         fallbackToDatabase = configuration.getDatabaseConnection() != null;
         changePasswordEnabled = fallbackToDatabase && configuration.allowForgotPassword();

--- a/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
@@ -37,6 +37,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.auth0.android.lock.R;
+import com.auth0.android.lock.UsernameStyle;
 import com.auth0.android.lock.events.DatabaseSignUpEvent;
 import com.auth0.android.lock.internal.configuration.Configuration;
 import com.auth0.android.lock.utils.CustomField;
@@ -53,7 +54,7 @@ public class SignUpFormView extends FormView implements TextView.OnEditorActionL
     public static final int MAX_FEW_CUSTOM_FIELDS = 2;
 
     private final LockWidgetForm lockWidget;
-    private ValidatedInputView usernameInput;
+    private ValidatedUsernameInputView usernameInput;
     private ValidatedInputView emailInput;
     private ValidatedPasswordInputView passwordInput;
     private LinearLayout fieldContainer;
@@ -75,8 +76,9 @@ public class SignUpFormView extends FormView implements TextView.OnEditorActionL
         inflate(getContext(), R.layout.com_auth0_lock_signup_form_view, this);
         fieldContainer = (LinearLayout) findViewById(R.id.com_auth0_lock_custom_fields_container);
 
-        usernameInput = (ValidatedInputView) findViewById(R.id.com_auth0_lock_input_username);
-        usernameInput.setDataType(ValidatedInputView.DataType.USERNAME);
+        usernameInput = (ValidatedUsernameInputView) findViewById(R.id.com_auth0_lock_input_username);
+        usernameInput.configureFrom(configuration.getDatabaseConnection());
+        usernameInput.setUsernameStyle(UsernameStyle.USERNAME);
         usernameInput.setOnEditorActionListener(this);
         emailInput = (ValidatedInputView) findViewById(R.id.com_auth0_lock_input_email);
         emailInput.setDataType(ValidatedInputView.DataType.EMAIL);

--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedInputView.java
@@ -225,7 +225,7 @@ public class ValidatedInputView extends LinearLayout {
                 input.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
                 inputIcon = R.drawable.com_auth0_lock_ic_username;
                 hint = getResources().getString(R.string.com_auth0_lock_hint_username);
-                error = getResources().getString(R.string.com_auth0_lock_input_error_empty);
+                error = getResources().getString(R.string.com_auth0_lock_input_error_username_empty);
                 break;
             case USERNAME:
                 input.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);

--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedInputView.java
@@ -295,6 +295,7 @@ public class ValidatedInputView extends LinearLayout {
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
 
+        errorDescription.measure(widthMeasureSpec, heightMeasureSpec);
         int errorDescriptionHeight = ViewUtils.measureViewHeight(errorDescription);
         int inputHeight = ViewUtils.measureViewHeight(input);
         ViewGroup iconHolder = (ViewGroup) icon.getParent();

--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedUsernameInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedUsernameInputView.java
@@ -105,14 +105,14 @@ public class ValidatedUsernameInputView extends ValidatedInputView {
             return true;
         }
         boolean validUsernameLength = value.length() >= minUsernameLength && value.length() <= maxUsernameLength;
-        boolean validUsername = validUsernameLength && !isCustomDatabase ? value.matches(USERNAME_REGEX) : validUsernameLength;
 
         if (getDataType() == DataType.USERNAME) {
-            return validUsername;
+            return validUsernameLength && !isCustomDatabase ? value.matches(USERNAME_REGEX) : validUsernameLength;
         }
         if (getDataType() == DataType.USERNAME_OR_EMAIL) {
+            //This case is only used in the LogInFormView, avoid validating against username regex
             final boolean validEmail = value.matches(EMAIL_REGEX);
-            return validEmail || validUsername;
+            return validEmail || validUsernameLength;
         }
         return super.validate(validateEmptyFields);
     }

--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedUsernameInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedUsernameInputView.java
@@ -36,6 +36,7 @@ import static com.auth0.android.lock.UsernameStyle.EMAIL;
 import static com.auth0.android.lock.UsernameStyle.USERNAME;
 import static com.auth0.android.lock.internal.configuration.DatabaseConnection.MAX_USERNAME_LENGTH;
 import static com.auth0.android.lock.internal.configuration.DatabaseConnection.MIN_USERNAME_LENGTH;
+import static com.auth0.android.lock.internal.configuration.DatabaseConnection.UNUSED_USERNAME_LENGTH;
 
 public class ValidatedUsernameInputView extends ValidatedInputView {
 
@@ -69,7 +70,10 @@ public class ValidatedUsernameInputView extends ValidatedInputView {
             setDataType(DataType.EMAIL);
         } else if (configuration.getUsernameStyle() == USERNAME) {
             setDataType(DataType.USERNAME);
-            final String error = String.format(getResources().getString(R.string.com_auth0_lock_input_error_username), minUsernameLength, maxUsernameLength);
+            String error = getResources().getString(R.string.com_auth0_lock_input_error_username, minUsernameLength, maxUsernameLength);
+            if (minUsernameLength == UNUSED_USERNAME_LENGTH || maxUsernameLength == UNUSED_USERNAME_LENGTH) {
+                error = getResources().getString(R.string.com_auth0_lock_input_error_username_empty);
+            }
             setErrorDescription(error);
         } else if (configuration.getUsernameStyle() == DEFAULT) {
             setDataType(DataType.USERNAME_OR_EMAIL);
@@ -82,7 +86,13 @@ public class ValidatedUsernameInputView extends ValidatedInputView {
         if (!validateEmptyFields && value.isEmpty()) {
             return true;
         }
-        final boolean validUsername = value.matches(USERNAME_REGEX) && value.length() >= minUsernameLength && value.length() <= maxUsernameLength;
+        boolean validUsername;
+        if (minUsernameLength == UNUSED_USERNAME_LENGTH || maxUsernameLength == UNUSED_USERNAME_LENGTH) {
+            validUsername = !value.isEmpty();
+        } else {
+            validUsername = value.matches(USERNAME_REGEX) && value.length() >= minUsernameLength && value.length() <= maxUsernameLength;
+        }
+
         if (getDataType() == DataType.USERNAME) {
             return validUsername;
         }

--- a/lib/src/main/res/layout/com_auth0_lock_signup_form_view.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_signup_form_view.xml
@@ -28,7 +28,7 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <com.auth0.android.lock.views.ValidatedInputView
+    <com.auth0.android.lock.views.ValidatedUsernameInputView
         android:id="@+id/com_auth0_lock_input_username"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@
     <string name="com_auth0_lock_input_error_password">Invalid Password</string>
     <string name="com_auth0_lock_input_error_username_email">Invalid Username or Email Address</string>
     <string name="com_auth0_lock_input_error_username" formatted="false">Invalid Username. Can only contain between %d to %d alphanumeric characters and \'_\'.</string>
+    <string name="com_auth0_lock_input_error_username_empty" formatted="false">Invalid Username</string>
     <string name="com_auth0_lock_input_error_code">Invalid Code</string>
     <string name="com_auth0_lock_input_error_phone_number">Invalid Phone Number</string>
     <string name="com_auth0_lock_input_error_empty">The value cannot be empty</string>

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/DatabaseConnectionTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/DatabaseConnectionTest.java
@@ -153,17 +153,16 @@ public class DatabaseConnectionTest {
     }
 
     @Test
-    public void shouldGetDefaultMinMaxUsernameLengthIfMissingUsernameValidation() throws Exception {
+    public void shouldOnlyGetMinUsernameLengthIfMissingUsernameValidation() throws Exception {
         Map<String, Object> values = new HashMap<>();
         values.put("name", "Username-Password-Authentication");
         Map<String, Object> validation = new HashMap<>();
         values.put("validation", validation);
         DatabaseConnection connection = connectionFor(values);
 
-        assertThat(connection.getMinUsernameLength(), is(1));
-        assertThat(connection.getMaxUsernameLength(), is(15));
+        assertThat(connection.getMinUsernameLength(), is(-1));
+        assertThat(connection.getMaxUsernameLength(), is(-1));
     }
-
 
     @Test
     public void shouldGetDefaultMinMaxUsernameLengthIfMissingValidation() throws Exception {

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/DatabaseConnectionTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/DatabaseConnectionTest.java
@@ -145,7 +145,7 @@ public class DatabaseConnectionTest {
         Map<String, Object> validation = new HashMap<>();
         values.put("validation", validation);
         Map<String, Object> usernameValidation = new HashMap<>();
-        usernameValidation.put("username", usernameValidation);
+        validation.put("username", usernameValidation);
         DatabaseConnection connection = connectionFor(values);
 
         assertThat(connection.getMinUsernameLength(), is(1));
@@ -183,7 +183,7 @@ public class DatabaseConnectionTest {
         Map<String, Object> usernameValidation = new HashMap<>();
         usernameValidation.put("min", 60);
         usernameValidation.put("max", 10);
-        values.put("username", usernameValidation);
+        validation.put("username", usernameValidation);
         DatabaseConnection connection = connectionFor(values);
 
         assertThat(connection.getMinUsernameLength(), is(1));
@@ -198,7 +198,7 @@ public class DatabaseConnectionTest {
         values.put("validation", validation);
         Map<String, Object> usernameValidation = new HashMap<>();
         usernameValidation.put("min", 10);
-        values.put("username", usernameValidation);
+        validation.put("username", usernameValidation);
         DatabaseConnection connection = connectionFor(values);
 
         assertThat(connection.getMinUsernameLength(), is(1));
@@ -213,7 +213,7 @@ public class DatabaseConnectionTest {
         values.put("validation", validation);
         Map<String, Object> usernameValidation = new HashMap<>();
         usernameValidation.put("max", 60);
-        values.put("username", usernameValidation);
+        validation.put("username", usernameValidation);
         DatabaseConnection connection = connectionFor(values);
 
         assertThat(connection.getMinUsernameLength(), is(1));

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/DatabaseConnectionTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/DatabaseConnectionTest.java
@@ -153,15 +153,15 @@ public class DatabaseConnectionTest {
     }
 
     @Test
-    public void shouldOnlyGetMinUsernameLengthIfMissingUsernameValidation() throws Exception {
+    public void shouldGetInfiniteMinMaxUsernameLengthIfMissingUsernameValidation() throws Exception {
         Map<String, Object> values = new HashMap<>();
         values.put("name", "Username-Password-Authentication");
         Map<String, Object> validation = new HashMap<>();
         values.put("validation", validation);
         DatabaseConnection connection = connectionFor(values);
 
-        assertThat(connection.getMinUsernameLength(), is(-1));
-        assertThat(connection.getMaxUsernameLength(), is(-1));
+        assertThat(connection.getMinUsernameLength(), is(1));
+        assertThat(connection.getMaxUsernameLength(), is(Integer.MAX_VALUE));
     }
 
     @Test
@@ -218,6 +218,30 @@ public class DatabaseConnectionTest {
 
         assertThat(connection.getMinUsernameLength(), is(1));
         assertThat(connection.getMaxUsernameLength(), is(15));
+    }
+
+    @Test
+    public void shouldBeCustomDatabaseIfMissingUsernameValidation() throws Exception {
+        Map<String, Object> values = new HashMap<>();
+        values.put("name", "Username-Password-Authentication");
+        Map<String, Object> validation = new HashMap<>();
+        values.put("validation", validation);
+        DatabaseConnection connection = connectionFor(values);
+
+        assertTrue(connection.isCustomDatabase());
+    }
+
+    @Test
+    public void shouldNotBeCustomDatabaseIfContainsUsernameValidation() throws Exception {
+        Map<String, Object> values = new HashMap<>();
+        values.put("name", "Username-Password-Authentication");
+        Map<String, Object> validation = new HashMap<>();
+        values.put("validation", validation);
+        Map<String, Object> username = new HashMap<>();
+        validation.put("username", username);
+        DatabaseConnection connection = connectionFor(values);
+
+        assertFalse(connection.isCustomDatabase());
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/DatabaseConnectionTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/DatabaseConnectionTest.java
@@ -139,7 +139,7 @@ public class DatabaseConnectionTest {
     }
 
     @Test
-    public void shouldGetDefaultMinMaxUsernameLengthIfMissing() throws Exception {
+    public void shouldGetNonEmptyMinMaxUsernameLengthIfMissingMinMaxValues() throws Exception {
         Map<String, Object> values = new HashMap<>();
         values.put("name", "Username-Password-Authentication");
         Map<String, Object> validation = new HashMap<>();
@@ -149,11 +149,11 @@ public class DatabaseConnectionTest {
         DatabaseConnection connection = connectionFor(values);
 
         assertThat(connection.getMinUsernameLength(), is(1));
-        assertThat(connection.getMaxUsernameLength(), is(15));
+        assertThat(connection.getMaxUsernameLength(), is(Integer.MAX_VALUE));
     }
 
     @Test
-    public void shouldGetInfiniteMinMaxUsernameLengthIfMissingUsernameValidation() throws Exception {
+    public void shouldGetNonEmptyMinMaxUsernameLengthIfMissingUsernameValidation() throws Exception {
         Map<String, Object> values = new HashMap<>();
         values.put("name", "Username-Password-Authentication");
         Map<String, Object> validation = new HashMap<>();
@@ -165,17 +165,17 @@ public class DatabaseConnectionTest {
     }
 
     @Test
-    public void shouldGetDefaultMinMaxUsernameLengthIfMissingValidation() throws Exception {
+    public void shouldGetNonEmptyMinMaxUsernameLengthIfMissingValidation() throws Exception {
         Map<String, Object> values = new HashMap<>();
         values.put("name", "Username-Password-Authentication");
         DatabaseConnection connection = connectionFor(values);
 
         assertThat(connection.getMinUsernameLength(), is(1));
-        assertThat(connection.getMaxUsernameLength(), is(15));
+        assertThat(connection.getMaxUsernameLength(), is(Integer.MAX_VALUE));
     }
 
     @Test
-    public void shouldGetDefaultMinMaxUsernameLengthIfMaxIsLowerThanMin() throws Exception {
+    public void shouldGetNonEmptyMinMaxUsernameLengthIfMaxIsLowerThanMin() throws Exception {
         Map<String, Object> values = new HashMap<>();
         values.put("name", "Username-Password-Authentication");
         Map<String, Object> validation = new HashMap<>();
@@ -187,11 +187,11 @@ public class DatabaseConnectionTest {
         DatabaseConnection connection = connectionFor(values);
 
         assertThat(connection.getMinUsernameLength(), is(1));
-        assertThat(connection.getMaxUsernameLength(), is(15));
+        assertThat(connection.getMaxUsernameLength(), is(Integer.MAX_VALUE));
     }
 
     @Test
-    public void shouldGetDefaultMinMaxUsernameLengthIfMaxIsMissing() throws Exception {
+    public void shouldGetNonEmptyMinMaxUsernameLengthIfMaxIsMissing() throws Exception {
         Map<String, Object> values = new HashMap<>();
         values.put("name", "Username-Password-Authentication");
         Map<String, Object> validation = new HashMap<>();
@@ -202,11 +202,11 @@ public class DatabaseConnectionTest {
         DatabaseConnection connection = connectionFor(values);
 
         assertThat(connection.getMinUsernameLength(), is(1));
-        assertThat(connection.getMaxUsernameLength(), is(15));
+        assertThat(connection.getMaxUsernameLength(), is(Integer.MAX_VALUE));
     }
 
     @Test
-    public void shouldGetDefaultMinMaxUsernameLengthIfMinIsMissing() throws Exception {
+    public void shouldGetNonEmptyMinMaxUsernameLengthIfMinIsMissing() throws Exception {
         Map<String, Object> values = new HashMap<>();
         values.put("name", "Username-Password-Authentication");
         Map<String, Object> validation = new HashMap<>();
@@ -217,7 +217,16 @@ public class DatabaseConnectionTest {
         DatabaseConnection connection = connectionFor(values);
 
         assertThat(connection.getMinUsernameLength(), is(1));
-        assertThat(connection.getMaxUsernameLength(), is(15));
+        assertThat(connection.getMaxUsernameLength(), is(Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void shouldBeCustomDatabaseIfMissingValidation() throws Exception {
+        Map<String, Object> values = new HashMap<>();
+        values.put("name", "Username-Password-Authentication");
+        DatabaseConnection connection = connectionFor(values);
+
+        assertTrue(connection.isCustomDatabase());
     }
 
     @Test


### PR DESCRIPTION
Validate that the username it's non-empty, regardless it's length and format, if the connection to be used it's a custom database connection or an imported one.