### PR TITLE
add withConnectionScope example to initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ public class HomeActivity extends Activity {
     // Your own Activity code
     Auth0 auth0 = new Auth0("YOUR_AUTH0_CLIENT_ID", "YOUR_AUTH0_DOMAIN");
     lock = Lock.newBuilder(auth0, callback)
-      //Customize Lock
+      //Customize Lock, for instance, if you want to implement Google 0Auth:
+      //.withConnectionScope("google-oauth2", "openid")
       .build(this);
   }
 


### PR DESCRIPTION
since the 2.1.0 release it seems that a connection scope is mandatory so I suggest to make it more explicit in the readme/doc. Maybe it would be nice if the sdk could throw a better error than the one thrown right now:
```
java.lang.RuntimeException: Could not dispatch event: class com.auth0.android.lock.events.OAuthLoginEvent to handler [EventHandler public void com.auth0.android.lock.LockActivity.onOAuthAuthenticationRequest(com.auth0.android.lock.events.OAuthLoginEvent)]: Attempt to invoke virtual method 'java.lang.String java.lang.String.trim()' on a null object reference
```