### PR TITLE
Fix NPE when connection scope is missing

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -330,12 +330,15 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
         }
 
         Log.d(TAG, "Couldn't find an specific provider, using the default: " + WebAuthProvider.class.getSimpleName());
-        WebAuthProvider.init(options.getAccount())
+        final WebAuthProvider.Builder builder = WebAuthProvider.init(options.getAccount())
                 .useBrowser(options.useBrowser())
-                .withConnectionScope(options.getConnectionsScope().get(connection))
                 .withParameters(options.getAuthenticationParameters())
-                .withConnection(connection)
-                .start(this, authProviderCallback, WEB_AUTH_REQUEST_CODE);
+                .withConnection(connection);
+        final String connectionScope = options.getConnectionsScope().get(connection);
+        if (connectionScope != null) {
+            builder.withConnectionScope(connectionScope);
+        }
+        builder.start(this, authProviderCallback, WEB_AUTH_REQUEST_CODE);
     }
 
     @SuppressWarnings("unused")

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -73,7 +73,6 @@ import com.squareup.okhttp.OkHttpClient;
 import com.squareup.otto.Bus;
 import com.squareup.otto.Subscribe;
 
-import java.util.HashMap;
 import java.util.List;
 
 public class PasswordlessLockActivity extends AppCompatActivity implements ActivityCompat.OnRequestPermissionsResultCallback {
@@ -479,12 +478,16 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
         }
 
         Log.d(TAG, "Couldn't find an specific provider, using the default: " + WebAuthProvider.class.getSimpleName());
-        WebAuthProvider.init(options.getAccount())
+        final WebAuthProvider.Builder builder = WebAuthProvider.init(options.getAccount())
                 .useBrowser(options.useBrowser())
-                .withConnectionScope(options.getConnectionsScope().get(event.getConnection()))
                 .withParameters(options.getAuthenticationParameters())
-                .withConnection(event.getConnection())
-                .start(this, authProviderCallback, WEB_AUTH_REQUEST_CODE);
+                .withConnection(event.getConnection());
+
+        final String connectionScope = options.getConnectionsScope().get(event.getConnection());
+        if (connectionScope != null) {
+            builder.withConnectionScope(connectionScope);
+        }
+        builder.start(this, authProviderCallback, WEB_AUTH_REQUEST_CODE);
     }
 
     //Callbacks


### PR DESCRIPTION
**Connection Scope** is not supposed to be mandatory. 
This fixes a NPE raised when the user don't specify a non-empty connection scope.