### PR TITLE
Allow to set a custom scope.

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -444,6 +444,17 @@ public class Lock {
         }
 
         /**
+         * Sets the Scope to request when performing the Authentication.
+         *
+         * @param scope to use in the Authentication.
+         * @return the current builder instance
+         */
+        public Builder withScope(@NonNull String scope) {
+            options.withScope(scope);
+            return this;
+        }
+
+        /**
          * Choose a custom Privacy Policy URL to access when the user clicks the link on the Sign Up form.
          * The default value is 'https://auth0.com/privacy'
          *

--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -338,6 +338,10 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
         if (connectionScope != null) {
             builder.withConnectionScope(connectionScope);
         }
+        final String scope = options.getScope();
+        if (scope != null) {
+            builder.withScope(scope);
+        }
         builder.start(this, authProviderCallback, WEB_AUTH_REQUEST_CODE);
     }
 

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -342,6 +342,17 @@ public class PasswordlessLock {
         }
 
         /**
+         * Sets the Scope to request when performing the Authentication.
+         *
+         * @param scope to use in the Authentication.
+         * @return the current builder instance
+         */
+        public Builder withScope(@NonNull String scope) {
+            options.withScope(scope);
+            return this;
+        }
+
+        /**
          * Sets the Connection Scope to request when performing an Authentication with the given Connection.
          *
          * @param connectionName to which specify the scopes.

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -487,6 +487,10 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
         if (connectionScope != null) {
             builder.withConnectionScope(connectionScope);
         }
+        final String scope = options.getScope();
+        if (scope != null) {
+            builder.withScope(scope);
+        }
         builder.start(this, authProviderCallback, WEB_AUTH_REQUEST_CODE);
     }
 

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -29,6 +29,7 @@ import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.annotation.StyleRes;
 import android.util.Patterns;
 
@@ -83,6 +84,7 @@ public class Options implements Parcelable {
     private Theme theme;
     private String privacyURL;
     private String termsURL;
+    private String scope;
 
     public Options() {
         usernameStyle = UsernameStyle.DEFAULT;
@@ -121,6 +123,7 @@ public class Options implements Parcelable {
         theme = in.readParcelable(Theme.class.getClassLoader());
         privacyURL = in.readString();
         termsURL = in.readString();
+        scope = in.readString();
         if (in.readByte() == HAS_DATA) {
             connections = new ArrayList<>();
             in.readList(connections, String.class.getClassLoader());
@@ -192,6 +195,7 @@ public class Options implements Parcelable {
         dest.writeParcelable(theme, flags);
         dest.writeString(privacyURL);
         dest.writeString(termsURL);
+        dest.writeString(scope);
         if (connections == null) {
             dest.writeByte((byte) (WITHOUT_DATA));
         } else {
@@ -465,5 +469,14 @@ public class Options implements Parcelable {
     @NonNull
     public Map<String, String> getConnectionsScope() {
         return connectionsScope;
+    }
+
+    public void withScope(@NonNull String scope) {
+        this.scope = scope;
+    }
+
+    @Nullable
+    public String getScope() {
+        return scope;
     }
 }

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -12,8 +12,6 @@ import com.auth0.android.lock.UsernameStyle;
 import com.auth0.android.lock.utils.CustomField;
 import com.auth0.android.lock.utils.CustomField.FieldType;
 
-import org.hamcrest.collection.IsCollectionWithSize;
-import org.hamcrest.collection.IsMapContaining;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,6 +31,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -497,6 +496,19 @@ public class OptionsTest {
         assertThat(parceledOptions.getConnectionsScope(), hasEntry("other_connection", "scope for other connection"));
     }
 
+    @Test
+    public void shouldSetScope() throws Exception {
+        options.withScope("some connection scope");
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.getScope(), is(equalTo("some connection scope")));
+        assertThat(parceledOptions.getScope(), is("some connection scope"));
+    }
+
     @SuppressWarnings("ResourceType")
     @Test
     public void shouldAddAuthStyles() throws Exception {
@@ -601,6 +613,7 @@ public class OptionsTest {
         assertThat(options.useCodePasswordless(), is(true));
         assertThat(options.mustAcceptTerms(), is(false));
         assertThat(options.useLabeledSubmitButton(), is(false));
+        assertThat(options.getScope(), is(nullValue()));
         assertThat(options.usernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
         assertThat(options.authButtonSize(), is(equalTo(AuthButtonSize.UNSPECIFIED)));
         assertThat(options.getTheme(), is(notNullValue()));


### PR DESCRIPTION
Usage:

```java
Lock lock = Lock.newBuilder(getAccount(), callback)
      .withScope("openid users:email")
      .build(this);
```

This will override any scope specified separately using the `withAuthenticationParameters()` method. Default scope is `openid`.