### PR TITLE
Deprecate useImplicitGrant method 

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -251,12 +251,14 @@ public class Lock {
         }
 
         /**
-         * Whether to use implicit grant or code grant when performing calls to /authorize.
+         * Whether to use implicit grant or code grant when performing calls to /authorize. This only affects passive authentication.
          * Default is {@code false}
          *
          * @param useImplicitGrant if Lock will use implicit grant instead of code grant.
          * @return the current Builder instance
+         * @deprecated Lock should always use the code grant for passive authentication. This is the default behavior.
          */
+        @Deprecated
         public Builder useImplicitGrant(boolean useImplicitGrant) {
             options.setUsePKCE(!useImplicitGrant);
             return this;

--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -189,24 +189,11 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
     }
 
     private void deliverAuthenticationResult(Credentials credentials) {
-        String requestedScopes = "openid";  //default authentication scope
-        if (options.getAuthenticationParameters().containsKey("scope")) {
-            requestedScopes = (String) options.getAuthenticationParameters().get("scope");
-        }
-
         Intent intent = new Intent(Constants.AUTHENTICATION_ACTION);
-        if (credentials.getAccessToken() == null) {
-            intent.putExtra(Constants.ERROR_EXTRA, "The access_token is missing from the response.");
-        } else if (requestedScopes.contains("openid") && credentials.getIdToken() == null) {
-            intent.putExtra(Constants.ERROR_EXTRA, "The id_token is missing from the response.");
-        } else if (requestedScopes.contains("offline_access") && credentials.getRefreshToken() == null) {
-            intent.putExtra(Constants.ERROR_EXTRA, "The refresh_token is missing from the response.");
-        } else {
-            intent.putExtra(Constants.ID_TOKEN_EXTRA, credentials.getIdToken());
-            intent.putExtra(Constants.ACCESS_TOKEN_EXTRA, credentials.getAccessToken());
-            intent.putExtra(Constants.REFRESH_TOKEN_EXTRA, credentials.getRefreshToken());
-            intent.putExtra(Constants.TOKEN_TYPE_EXTRA, credentials.getType());
-        }
+        intent.putExtra(Constants.ID_TOKEN_EXTRA, credentials.getIdToken());
+        intent.putExtra(Constants.ACCESS_TOKEN_EXTRA, credentials.getAccessToken());
+        intent.putExtra(Constants.REFRESH_TOKEN_EXTRA, credentials.getRefreshToken());
+        intent.putExtra(Constants.TOKEN_TYPE_EXTRA, credentials.getType());
 
         LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
         finish();

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -249,12 +249,14 @@ public class PasswordlessLock {
         }
 
         /**
-         * Whether to use implicit grant or code grant when performing calls to /authorize.
+         * Whether to use implicit grant or code grant when performing calls to /authorize. This only affects passive authentication.
          * Default is {@code false}
          *
          * @param useImplicitGrant if Lock will use implicit grant instead of code grant.
          * @return the current Builder instance
+         * @deprecated Lock should always use the code grant for passive authentication. This is the default behavior.
          */
+        @Deprecated
         public Builder useImplicitGrant(boolean useImplicitGrant) {
             options.setUsePKCE(!useImplicitGrant);
             return this;

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -223,24 +223,11 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
     }
 
     private void deliverAuthenticationResult(Credentials credentials) {
-        String requestedScopes = "openid";  //default authentication scope
-        if (options.getAuthenticationParameters().containsKey("scope")) {
-            requestedScopes = (String) options.getAuthenticationParameters().get("scope");
-        }
-
         Intent intent = new Intent(Constants.AUTHENTICATION_ACTION);
-        if (credentials.getAccessToken() == null) {
-            intent.putExtra(Constants.ERROR_EXTRA, "The access_token is missing from the response.");
-        } else if (requestedScopes.contains("openid") && credentials.getIdToken() == null) {
-            intent.putExtra(Constants.ERROR_EXTRA, "The id_token is missing from the response.");
-        } else if (requestedScopes.contains("offline_access") && credentials.getRefreshToken() == null) {
-            intent.putExtra(Constants.ERROR_EXTRA, "The refresh_token is missing from the response.");
-        } else {
-            intent.putExtra(Constants.ID_TOKEN_EXTRA, credentials.getIdToken());
-            intent.putExtra(Constants.ACCESS_TOKEN_EXTRA, credentials.getAccessToken());
-            intent.putExtra(Constants.REFRESH_TOKEN_EXTRA, credentials.getRefreshToken());
-            intent.putExtra(Constants.TOKEN_TYPE_EXTRA, credentials.getType());
-        }
+        intent.putExtra(Constants.ID_TOKEN_EXTRA, credentials.getIdToken());
+        intent.putExtra(Constants.ACCESS_TOKEN_EXTRA, credentials.getAccessToken());
+        intent.putExtra(Constants.REFRESH_TOKEN_EXTRA, credentials.getRefreshToken());
+        intent.putExtra(Constants.TOKEN_TYPE_EXTRA, credentials.getType());
 
         LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
         finish();

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -280,10 +280,12 @@ public class Options implements Parcelable {
         return theme;
     }
 
+    @Deprecated
     public boolean usePKCE() {
         return usePKCE;
     }
 
+    @Deprecated
     public void setUsePKCE(boolean usePKCE) {
         this.usePKCE = usePKCE;
     }


### PR DESCRIPTION
Lock will use `response_type = code` as default value. The user can still change this behavior, but the method is now deprecated.