### PR TITLE
Add flag to prefer OAuth 2.0 endpoints for authentication

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compile 'com.android.support:design:24.2.1'
     compile 'com.google.code.gson:gson:2.6.2'
     compile 'com.squareup:otto:1.3.8'
-    compile 'com.auth0.android:auth0:1.1.2'
+    compile 'com.auth0.android:auth0:1.3.0'
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     testCompile 'org.robolectric:robolectric:3.1.2'

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -265,6 +265,18 @@ public class Lock {
         }
 
         /**
+         * Use OAuth 2.0 Authorization API. You will need to enable this setting in the Dashboard first. Go to Account (top right), Account Settings, click Advanced and check the toggle at the bottom.
+         * Default is {@code false}
+         *
+         * @param use if Lock will use the OAuth 2.0 API or the previous implementation.
+         * @return the current Builder instance
+         */
+        public Builder useOAuth2(boolean use) {
+            options.useOAuth2API(use);
+            return this;
+        }
+
+        /**
          * Whether the LockActivity can be closed when pressing the Back key or not.
          *
          * @param closable or not. By default, the LockActivity is not closable.

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -263,6 +263,18 @@ public class PasswordlessLock {
         }
 
         /**
+         * Use OAuth 2.0 Authorization API. You will need to enable this setting in the Dashboard first. Go to Account (top right), Account Settings, click Advanced and check the toggle at the bottom.
+         * Default is {@code false}
+         *
+         * @param use if Lock will use the OAuth 2.0 API or the previous implementation.
+         * @return the current Builder instance
+         */
+        public Builder useOAuth2(boolean use) {
+            options.useOAuth2API(use);
+            return this;
+        }
+
+        /**
          * Whether the PasswordlessLockActivity can be closed when pressing the Back key or not.
          *
          * @param closable or not. By default, the LockActivity is not closable.

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -263,18 +263,6 @@ public class PasswordlessLock {
         }
 
         /**
-         * Use OAuth 2.0 Authorization API. You will need to enable this setting in the Dashboard first. Go to Account (top right), Account Settings, click Advanced and check the toggle at the bottom.
-         * Default is {@code false}
-         *
-         * @param use if Lock will use the OAuth 2.0 API or the previous implementation.
-         * @return the current Builder instance
-         */
-        public Builder useOAuth2(boolean use) {
-            options.useOAuth2API(use);
-            return this;
-        }
-
-        /**
          * Whether the PasswordlessLockActivity can be closed when pressing the Back key or not.
          *
          * @param closable or not. By default, the LockActivity is not closable.

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -73,7 +73,7 @@ public class Options implements Parcelable {
     private boolean loginAfterSignUp;
     private boolean mustAcceptTerms;
     private boolean useLabeledSubmitButton;
-    private boolean useOAuth2API;
+    private boolean useLegacyMode;
     private String defaultDatabaseConnection;
     private List<String> connections;
     private List<String> enterpriseConnectionsUsingWebForm;
@@ -117,7 +117,7 @@ public class Options implements Parcelable {
         mustAcceptTerms = in.readByte() != WITHOUT_DATA;
         useCodePasswordless = in.readByte() != WITHOUT_DATA;
         useLabeledSubmitButton = in.readByte() != WITHOUT_DATA;
-        useOAuth2API = in.readByte() != WITHOUT_DATA;
+        useLegacyMode = in.readByte() != WITHOUT_DATA;
         defaultDatabaseConnection = in.readString();
         usernameStyle = in.readInt();
         initialScreen = in.readInt();
@@ -190,7 +190,7 @@ public class Options implements Parcelable {
         dest.writeByte((byte) (mustAcceptTerms ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (useCodePasswordless ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (useLabeledSubmitButton ? HAS_DATA : WITHOUT_DATA));
-        dest.writeByte((byte) (useOAuth2API ? HAS_DATA : WITHOUT_DATA));
+        dest.writeByte((byte) (useLegacyMode ? HAS_DATA : WITHOUT_DATA));
         dest.writeString(defaultDatabaseConnection);
         dest.writeInt(usernameStyle);
         dest.writeInt(initialScreen);
@@ -392,7 +392,7 @@ public class Options implements Parcelable {
 
     public AuthenticationAPIClient getAuthenticationAPIClient() {
         AuthenticationAPIClient client = new AuthenticationAPIClient(account);
-        client.setOAuth2Preferred(useOAuth2API);
+        client.setLegacyModeEnabled(useLegacyMode);
         return client;
     }
 
@@ -487,7 +487,7 @@ public class Options implements Parcelable {
         return scope;
     }
 
-    public void setUseOAuth2API(boolean use) {
-        this.useOAuth2API = use;
+    public void setLegacyModeEnabled(boolean enabled) {
+        this.useLegacyMode = enabled;
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -73,6 +73,7 @@ public class Options implements Parcelable {
     private boolean loginAfterSignUp;
     private boolean mustAcceptTerms;
     private boolean useLabeledSubmitButton;
+    private boolean useOAuth2API;
     private String defaultDatabaseConnection;
     private List<String> connections;
     private List<String> enterpriseConnectionsUsingWebForm;
@@ -116,6 +117,7 @@ public class Options implements Parcelable {
         mustAcceptTerms = in.readByte() != WITHOUT_DATA;
         useCodePasswordless = in.readByte() != WITHOUT_DATA;
         useLabeledSubmitButton = in.readByte() != WITHOUT_DATA;
+        useOAuth2API = in.readByte() != WITHOUT_DATA;
         defaultDatabaseConnection = in.readString();
         usernameStyle = in.readInt();
         initialScreen = in.readInt();
@@ -188,6 +190,7 @@ public class Options implements Parcelable {
         dest.writeByte((byte) (mustAcceptTerms ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (useCodePasswordless ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (useLabeledSubmitButton ? HAS_DATA : WITHOUT_DATA));
+        dest.writeByte((byte) (useOAuth2API ? HAS_DATA : WITHOUT_DATA));
         dest.writeString(defaultDatabaseConnection);
         dest.writeInt(usernameStyle);
         dest.writeInt(initialScreen);
@@ -388,7 +391,9 @@ public class Options implements Parcelable {
     }
 
     public AuthenticationAPIClient getAuthenticationAPIClient() {
-        return new AuthenticationAPIClient(account);
+        AuthenticationAPIClient client = new AuthenticationAPIClient(account);
+        client.setOAuth2Preferred(useOAuth2API);
+        return client;
     }
 
     public void setUseCodePasswordless(boolean useCode) {
@@ -480,5 +485,9 @@ public class Options implements Parcelable {
     @Nullable
     public String getScope() {
         return scope;
+    }
+
+    public void setUseOAuth2API(boolean use) {
+        this.useOAuth2API = use;
     }
 }

--- a/lib/src/test/java/com/auth0/android/lock/MockAuthenticationRequest.java
+++ b/lib/src/test/java/com/auth0/android/lock/MockAuthenticationRequest.java
@@ -14,6 +14,7 @@ public class MockAuthenticationRequest implements AuthenticationRequest {
     String grantType;
     String connection;
     String scope;
+    String audience;
     String device;
     String accessToken;
     HashMap<String, Object> parameters;
@@ -46,6 +47,12 @@ public class MockAuthenticationRequest implements AuthenticationRequest {
     }
 
     @Override
+    public AuthenticationRequest setAudience(String audience) {
+        this.audience = audience;
+        return this;
+    }
+
+    @Override
     public AuthenticationRequest setAccessToken(String accessToken) {
         this.accessToken = accessToken;
         return this;
@@ -60,7 +67,7 @@ public class MockAuthenticationRequest implements AuthenticationRequest {
     @Override
     public void start(BaseCallback<Credentials, AuthenticationException> callback) {
         this.callback = callback;
-        this.started=true;
+        this.started = true;
     }
 
     @Override

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -142,8 +142,8 @@ public class OptionsTest {
     }
 
     @Test
-    public void shouldUseOAuth2API() throws Exception {
-        options.setUseOAuth2API(true);
+    public void shouldUseLegacyMode() throws Exception {
+        options.setLegacyModeEnabled(true);
 
         Parcel parcel = Parcel.obtain();
         options.writeToParcel(parcel, 0);
@@ -151,9 +151,9 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options.getAuthenticationAPIClient(), is(notNullValue()));
-        assertThat(options.getAuthenticationAPIClient().isOAuth2Preferred(), is(true));
+        assertThat(options.getAuthenticationAPIClient().isLegacyModeEnabled(), is(true));
         assertThat(parceledOptions.getAuthenticationAPIClient(), is(notNullValue()));
-        assertThat(parceledOptions.getAuthenticationAPIClient().isOAuth2Preferred(), is(true));
+        assertThat(parceledOptions.getAuthenticationAPIClient().isLegacyModeEnabled(), is(true));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -142,6 +142,21 @@ public class OptionsTest {
     }
 
     @Test
+    public void shouldUseOAuth2API() throws Exception {
+        options.setUseOAuth2API(true);
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.getAuthenticationAPIClient(), is(notNullValue()));
+        assertThat(options.getAuthenticationAPIClient().isOAuth2Preferred(), is(true));
+        assertThat(parceledOptions.getAuthenticationAPIClient(), is(notNullValue()));
+        assertThat(parceledOptions.getAuthenticationAPIClient().isOAuth2Preferred(), is(true));
+    }
+
+    @Test
     public void shouldUseLabeledSubmitButton() throws Exception {
         options.setUseLabeledSubmitButton(true);
 


### PR DESCRIPTION
This will try to use the new pipeline endpoints `/oauth/token` and `/userinfo` instead of the legacy ones. The dashboard must be configured to use the OAuth 2.0 API. 

```java
Lock lock = Lock.newBuilder(auth0, callback)
      .setLegacyModeEnabled(true)
      .build(this);
```

This PR depends on https://github.com/auth0/Auth0.Android/pull/57 being merged and released.