### PR TITLE
Add option to hide Header Title on the Main screen

### DIFF
--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
@@ -43,12 +43,10 @@ import com.auth0.android.lock.Lock;
 import com.auth0.android.lock.LockCallback;
 import com.auth0.android.lock.PasswordlessLock;
 import com.auth0.android.lock.UsernameStyle;
-import com.auth0.android.lock.utils.CustomField;
 import com.auth0.android.lock.utils.LockException;
 import com.auth0.android.result.Credentials;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class DemoActivity extends AppCompatActivity {
@@ -172,14 +170,7 @@ public class DemoActivity extends AppCompatActivity {
                 builder.setDefaultDatabaseConnection("Username-Password-Authentication");
             }
         }
-        List<CustomField> fields = Arrays.asList(
-                new CustomField(R.drawable.com_auth0_lock_header_logo, CustomField.FieldType.TYPE_EMAIL, "k1", R.string.hint_country),
-                new CustomField(R.drawable.com_auth0_lock_header_logo, CustomField.FieldType.TYPE_EMAIL, "k2", R.string.hint_country),
-                new CustomField(R.drawable.com_auth0_lock_header_logo, CustomField.FieldType.TYPE_EMAIL, "k3", R.string.hint_country),
-                new CustomField(R.drawable.com_auth0_lock_header_logo, CustomField.FieldType.TYPE_EMAIL, "k4", R.string.hint_country)
-        );
-        builder.useContextualHeaderTitle(true);
-        builder.withSignUpFields(fields);
+        builder.hideMainScreenTitle(false);
         lock = builder.build(this);
 
         startActivity(lock.newIntent(this));

--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
@@ -170,7 +170,6 @@ public class DemoActivity extends AppCompatActivity {
                 builder.setDefaultDatabaseConnection("Username-Password-Authentication");
             }
         }
-        builder.hideMainScreenTitle(false);
         lock = builder.build(this);
 
         startActivity(lock.newIntent(this));

--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
@@ -170,6 +170,7 @@ public class DemoActivity extends AppCompatActivity {
                 builder.setDefaultDatabaseConnection("Username-Password-Authentication");
             }
         }
+        builder.useContextualHeaderTitle(true);
         lock = builder.build(this);
 
         startActivity(lock.newIntent(this));

--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
@@ -43,10 +43,12 @@ import com.auth0.android.lock.Lock;
 import com.auth0.android.lock.LockCallback;
 import com.auth0.android.lock.PasswordlessLock;
 import com.auth0.android.lock.UsernameStyle;
+import com.auth0.android.lock.utils.CustomField;
 import com.auth0.android.lock.utils.LockException;
 import com.auth0.android.result.Credentials;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class DemoActivity extends AppCompatActivity {
@@ -170,6 +172,14 @@ public class DemoActivity extends AppCompatActivity {
                 builder.setDefaultDatabaseConnection("Username-Password-Authentication");
             }
         }
+        List<CustomField> fields = Arrays.asList(
+                new CustomField(R.drawable.com_auth0_lock_header_logo, CustomField.FieldType.TYPE_EMAIL, "k1", R.string.hint_country),
+                new CustomField(R.drawable.com_auth0_lock_header_logo, CustomField.FieldType.TYPE_EMAIL, "k2", R.string.hint_country),
+                new CustomField(R.drawable.com_auth0_lock_header_logo, CustomField.FieldType.TYPE_EMAIL, "k3", R.string.hint_country),
+                new CustomField(R.drawable.com_auth0_lock_header_logo, CustomField.FieldType.TYPE_EMAIL, "k4", R.string.hint_country)
+        );
+        builder.useContextualHeaderTitle(true);
+        builder.withSignUpFields(fields);
         lock = builder.build(this);
 
         startActivity(lock.newIntent(this));

--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
@@ -170,7 +170,6 @@ public class DemoActivity extends AppCompatActivity {
                 builder.setDefaultDatabaseConnection("Username-Password-Authentication");
             }
         }
-        builder.useContextualHeaderTitle(true);
         lock = builder.build(this);
 
         startActivity(lock.newIntent(this));

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -399,13 +399,13 @@ public class Lock {
         }
 
         /**
-         * Whether the header's title should hide it's content on the first screen but display the current subtitle on the rest of them or it should display always the configured header title.
+         * Control the visibility of the header's Title on the main screen, this is for Log In and Sign Up. By default it will show the header's Title on the main screen.
          *
-         * @param useContextualHeaderTitle or display always the configured header title. By default it will not use the contextual header.
+         * @param hideMainScreenTitle if it should show or hide the header's Title on the main screen.
          * @return the current builder instance
          */
-        public Builder useContextualHeaderTitle(boolean useContextualHeaderTitle) {
-            options.setUseContextualHeaderTitle(useContextualHeaderTitle);
+        public Builder hideMainScreenTitle(boolean hideMainScreenTitle) {
+            options.setHideMainScreenTitle(hideMainScreenTitle);
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -399,6 +399,17 @@ public class Lock {
         }
 
         /**
+         * Whether the header's title should hide it's content on the first screen but display the current subtitle on the rest of them or it should display always the configured header title.
+         *
+         * @param useContextualHeaderTitle or display always the configured header title. By default it will not use the contextual header.
+         * @return the current builder instance
+         */
+        public Builder useContextualHeaderTitle(boolean useContextualHeaderTitle) {
+            options.setUseContextualHeaderTitle(useContextualHeaderTitle);
+            return this;
+        }
+
+        /**
          * Change the connection name to use on the Database authentication flow.
          * Defaults to the first Database connection found.
          *

--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -160,11 +160,9 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
 
     private boolean hasValidTheme() {
         TypedArray a = getTheme().obtainStyledAttributes(R.styleable.Lock_Theme);
-        if (!a.hasValue(R.styleable.Lock_Theme_Auth0_HeaderLogo)) {
-            a.recycle();
-            return false;
-        }
-        return true;
+        boolean validTheme = a.hasValue(R.styleable.Lock_Theme_Auth0_HeaderLogo);
+        a.recycle();
+        return validTheme;
     }
 
     private boolean hasValidOptions() {

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -216,13 +216,13 @@ public class PasswordlessLock {
         }
 
         /**
-         * Whether the header's title should hide it's content on the first screen but display the current subtitle on the rest of them or it should display always the configured header title.
+         * Control the visibility of the header's Title on the main screen. By default it will show the header's Title on the main screen.
          *
-         * @param useContextualHeaderTitle or display always the configured header title. By default it will not use the contextual header.
+         * @param hideMainScreenTitle if it should show or hide the header's Title on the main screen.
          * @return the current builder instance
          */
-        public Builder useContextualHeaderTitle(boolean useContextualHeaderTitle) {
-            options.setUseContextualHeaderTitle(useContextualHeaderTitle);
+        public Builder hideMainScreenTitle(boolean hideMainScreenTitle) {
+            options.setHideMainScreenTitle(hideMainScreenTitle);
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -216,6 +216,17 @@ public class PasswordlessLock {
         }
 
         /**
+         * Whether the header's title should hide it's content on the first screen but display the current subtitle on the rest of them or it should display always the configured header title.
+         *
+         * @param useContextualHeaderTitle or display always the configured header title. By default it will not use the contextual header.
+         * @return the current builder instance
+         */
+        public Builder useContextualHeaderTitle(boolean useContextualHeaderTitle) {
+            options.setUseContextualHeaderTitle(useContextualHeaderTitle);
+            return this;
+        }
+
+        /**
          * Defines the Passwordless type to use in the Authentication as Code. Default value is to use Code
          *
          * @return the current Builder instance

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -175,11 +175,9 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
 
     private boolean hasValidTheme() {
         TypedArray a = getTheme().obtainStyledAttributes(R.styleable.Lock_Theme);
-        if (!a.hasValue(R.styleable.Lock_Theme_Auth0_HeaderLogo)) {
-            a.recycle();
-            return false;
-        }
-        return true;
+        boolean validTheme = a.hasValue(R.styleable.Lock_Theme_Auth0_HeaderLogo);
+        a.recycle();
+        return validTheme;
     }
 
     private boolean hasValidOptions() {

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -258,6 +258,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
         gotCodeButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                lockView.setVisibility(View.VISIBLE);
                 passwordlessSuccessCover.setVisibility(View.GONE);
             }
         });
@@ -278,6 +279,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
                 passwordlessSuccessCover.setVisibility(View.GONE);
             }
         });
+        lockView.setVisibility(View.GONE);
         passwordlessSuccessCover.setVisibility(View.VISIBLE);
         handler.removeCallbacks(resendTimeoutShower);
         handler.postDelayed(resendTimeoutShower, RESEND_TIMEOUT);

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
@@ -61,6 +61,7 @@ public class Configuration {
     private boolean usernameRequired;
     private boolean mustAcceptTerms;
     private boolean useLabeledSubmitButton;
+    private boolean useContextualHeaderTitle;
     @UsernameStyle
     private int usernameStyle;
     @AuthButtonSize
@@ -170,6 +171,7 @@ public class Configuration {
         loginAfterSignUp = options.loginAfterSignUp();
         mustAcceptTerms = options.mustAcceptTerms();
         useLabeledSubmitButton = options.useLabeledSubmitButton();
+        useContextualHeaderTitle = options.useContextualHeaderTitle();
 
         authStyles = options.getAuthStyles();
         extraSignUpFields = options.getCustomFields();
@@ -285,5 +287,9 @@ public class Configuration {
 
     public boolean useLabeledSubmitButton() {
         return useLabeledSubmitButton;
+    }
+
+    public boolean useContextualHeaderTitle() {
+        return useContextualHeaderTitle;
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
@@ -61,7 +61,7 @@ public class Configuration {
     private boolean usernameRequired;
     private boolean mustAcceptTerms;
     private boolean useLabeledSubmitButton;
-    private boolean useContextualHeaderTitle;
+    private boolean hideMainScreenTitle;
     @UsernameStyle
     private int usernameStyle;
     @AuthButtonSize
@@ -171,7 +171,7 @@ public class Configuration {
         loginAfterSignUp = options.loginAfterSignUp();
         mustAcceptTerms = options.mustAcceptTerms();
         useLabeledSubmitButton = options.useLabeledSubmitButton();
-        useContextualHeaderTitle = options.useContextualHeaderTitle();
+        hideMainScreenTitle = options.hideMainScreenTitle();
 
         authStyles = options.getAuthStyles();
         extraSignUpFields = options.getCustomFields();
@@ -289,7 +289,7 @@ public class Configuration {
         return useLabeledSubmitButton;
     }
 
-    public boolean useContextualHeaderTitle() {
-        return useContextualHeaderTitle;
+    public boolean hideMainScreenTitle() {
+        return hideMainScreenTitle;
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -73,6 +73,7 @@ public class Options implements Parcelable {
     private boolean loginAfterSignUp;
     private boolean mustAcceptTerms;
     private boolean useLabeledSubmitButton;
+    private boolean useContextualHeaderTitle;
     private String defaultDatabaseConnection;
     private List<String> connections;
     private List<String> enterpriseConnectionsUsingWebForm;
@@ -116,6 +117,7 @@ public class Options implements Parcelable {
         mustAcceptTerms = in.readByte() != WITHOUT_DATA;
         useCodePasswordless = in.readByte() != WITHOUT_DATA;
         useLabeledSubmitButton = in.readByte() != WITHOUT_DATA;
+        useContextualHeaderTitle = in.readByte() != WITHOUT_DATA;
         defaultDatabaseConnection = in.readString();
         usernameStyle = in.readInt();
         initialScreen = in.readInt();
@@ -188,6 +190,7 @@ public class Options implements Parcelable {
         dest.writeByte((byte) (mustAcceptTerms ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (useCodePasswordless ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (useLabeledSubmitButton ? HAS_DATA : WITHOUT_DATA));
+        dest.writeByte((byte) (useContextualHeaderTitle ? HAS_DATA : WITHOUT_DATA));
         dest.writeString(defaultDatabaseConnection);
         dest.writeInt(usernameStyle);
         dest.writeInt(initialScreen);
@@ -462,6 +465,14 @@ public class Options implements Parcelable {
 
     public boolean useLabeledSubmitButton() {
         return useLabeledSubmitButton;
+    }
+
+    public void setUseContextualHeaderTitle(boolean useContextualHeaderTitle) {
+        this.useContextualHeaderTitle = useContextualHeaderTitle;
+    }
+
+    public boolean useContextualHeaderTitle() {
+        return useContextualHeaderTitle;
     }
 
     public void withConnectionScope(@NonNull String connectionName, @NonNull String scope) {

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -73,7 +73,7 @@ public class Options implements Parcelable {
     private boolean loginAfterSignUp;
     private boolean mustAcceptTerms;
     private boolean useLabeledSubmitButton;
-    private boolean useContextualHeaderTitle;
+    private boolean hideMainScreenTitle;
     private String defaultDatabaseConnection;
     private List<String> connections;
     private List<String> enterpriseConnectionsUsingWebForm;
@@ -117,7 +117,7 @@ public class Options implements Parcelable {
         mustAcceptTerms = in.readByte() != WITHOUT_DATA;
         useCodePasswordless = in.readByte() != WITHOUT_DATA;
         useLabeledSubmitButton = in.readByte() != WITHOUT_DATA;
-        useContextualHeaderTitle = in.readByte() != WITHOUT_DATA;
+        hideMainScreenTitle = in.readByte() != WITHOUT_DATA;
         defaultDatabaseConnection = in.readString();
         usernameStyle = in.readInt();
         initialScreen = in.readInt();
@@ -190,7 +190,7 @@ public class Options implements Parcelable {
         dest.writeByte((byte) (mustAcceptTerms ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (useCodePasswordless ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (useLabeledSubmitButton ? HAS_DATA : WITHOUT_DATA));
-        dest.writeByte((byte) (useContextualHeaderTitle ? HAS_DATA : WITHOUT_DATA));
+        dest.writeByte((byte) (hideMainScreenTitle ? HAS_DATA : WITHOUT_DATA));
         dest.writeString(defaultDatabaseConnection);
         dest.writeInt(usernameStyle);
         dest.writeInt(initialScreen);
@@ -467,12 +467,12 @@ public class Options implements Parcelable {
         return useLabeledSubmitButton;
     }
 
-    public void setUseContextualHeaderTitle(boolean useContextualHeaderTitle) {
-        this.useContextualHeaderTitle = useContextualHeaderTitle;
+    public void setHideMainScreenTitle(boolean hideMainScreenTitle) {
+        this.hideMainScreenTitle = hideMainScreenTitle;
     }
 
-    public boolean useContextualHeaderTitle() {
-        return useContextualHeaderTitle;
+    public boolean hideMainScreenTitle() {
+        return hideMainScreenTitle;
     }
 
     public void withConnectionScope(@NonNull String connectionName, @NonNull String scope) {

--- a/lib/src/main/java/com/auth0/android/lock/views/ChangePasswordFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ChangePasswordFormView.java
@@ -100,15 +100,4 @@ public class ChangePasswordFormView extends FormView implements TextView.OnEdito
         lockWidget.onEmailChanged(email);
     }
 
-    /**
-     * Change the visibility of this form Title.
-     *
-     * @param show whether to show or hide this form title.
-     */
-    public void showTitle(boolean show) {
-        View titleView = findViewById(R.id.com_auth0_lock_title);
-        if (titleView != null) {
-            titleView.setVisibility(show ? VISIBLE : GONE);
-        }
-    }
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/ChangePasswordFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ChangePasswordFormView.java
@@ -28,6 +28,7 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.util.Log;
 import android.view.KeyEvent;
+import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.widget.TextView;
 
@@ -47,16 +48,14 @@ public class ChangePasswordFormView extends FormView implements TextView.OnEdito
         lockWidget = null;
     }
 
-    public ChangePasswordFormView(LockWidgetForm lockWidget, String email, boolean showTitle) {
+    public ChangePasswordFormView(LockWidgetForm lockWidget, String email) {
         super(lockWidget.getContext());
         this.lockWidget = lockWidget;
-        init(email, showTitle);
+        init(email);
     }
 
-    private void init(String email, boolean showTitle) {
+    private void init(String email) {
         inflate(getContext(), R.layout.com_auth0_lock_changepwd_form_view, this);
-        TextView title = (TextView) findViewById(R.id.com_auth0_lock_title);
-        title.setVisibility(showTitle ? VISIBLE : GONE);
         emailInput = (ValidatedInputView) findViewById(R.id.com_auth0_lock_input_email);
         emailInput.setText(email);
         emailInput.setIdentityListener(this);
@@ -99,5 +98,17 @@ public class ChangePasswordFormView extends FormView implements TextView.OnEdito
     @Override
     public void onEmailChanged(String email) {
         lockWidget.onEmailChanged(email);
+    }
+
+    /**
+     * Change the visibility of this form Title.
+     *
+     * @param show whether to show or hide this form title.
+     */
+    public void showTitle(boolean show) {
+        View titleView = findViewById(R.id.com_auth0_lock_title);
+        if (titleView != null) {
+            titleView.setVisibility(show ? VISIBLE : GONE);
+        }
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/ChangePasswordFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ChangePasswordFormView.java
@@ -47,14 +47,16 @@ public class ChangePasswordFormView extends FormView implements TextView.OnEdito
         lockWidget = null;
     }
 
-    public ChangePasswordFormView(LockWidgetForm lockWidget, String email) {
+    public ChangePasswordFormView(LockWidgetForm lockWidget, String email, boolean showTitle) {
         super(lockWidget.getContext());
         this.lockWidget = lockWidget;
-        init(email);
+        init(email, showTitle);
     }
 
-    private void init(String email) {
+    private void init(String email, boolean showTitle) {
         inflate(getContext(), R.layout.com_auth0_lock_changepwd_form_view, this);
+        TextView title = (TextView) findViewById(R.id.com_auth0_lock_title);
+        title.setVisibility(showTitle ? VISIBLE : GONE);
         emailInput = (ValidatedInputView) findViewById(R.id.com_auth0_lock_input_email);
         emailInput.setText(email);
         emailInput.setIdentityListener(this);

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -144,7 +144,7 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
                 });
             }
         });
-        actionButton.showLabel(configuration.useLabeledSubmitButton());
+        actionButton.showLabel(configuration.useLabeledSubmitButton() || configuration.hideMainScreenTitle());
         addView(actionButton, wrapHeightParams);
 
         boolean showDatabase = configuration.getDatabaseConnection() != null;

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -217,7 +217,6 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
     public void showChangePasswordForm(boolean show) {
         if (show) {
             ChangePasswordFormView form = new ChangePasswordFormView(this, lastEmailInput);
-            form.showTitle(!configuration.useContextualHeaderTitle());
             updateHeaderTitle(R.string.com_auth0_lock_title_change_password);
             addSubForm(form);
             updateButtonLabel(R.string.com_auth0_lock_action_send_email);
@@ -227,9 +226,6 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
     }
 
     private void updateHeaderTitle(@StringRes int titleRes) {
-        if (!configuration.useContextualHeaderTitle()) {
-            return;
-        }
         headerView.setTitle(getContext().getString(titleRes));
         headerView.showTitle(true);
     }
@@ -269,11 +265,10 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
      */
     public boolean onBackPressed() {
         if (subForm != null) {
-            resetHeaderTitle();
             final boolean shouldDisplayPreviousForm = configuration.allowLogIn() || configuration.allowSignUp();
             if (shouldDisplayPreviousForm) {
+                resetHeaderTitle();
                 showSignUpTerms(subForm instanceof CustomFieldsFormView);
-
                 removeSubForm();
                 return true;
             }
@@ -338,14 +333,12 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
     public void showCustomFieldsForm(DatabaseSignUpEvent event) {
         CustomFieldsFormView form = new CustomFieldsFormView(this, event.getEmail(), event.getPassword(), event.getUsername());
         addSubForm(form);
-        form.showTitle(!configuration.useContextualHeaderTitle());
         updateHeaderTitle(R.string.com_auth0_lock_action_sign_up);
         showSignUpTerms(false);
     }
 
     public void showMFACodeForm(DatabaseLoginEvent event) {
         MFACodeFormView form = new MFACodeFormView(this, event.getUsernameOrEmail(), event.getPassword());
-        form.showTitle(!configuration.useContextualHeaderTitle());
         updateHeaderTitle(R.string.com_auth0_lock_title_mfa_input_code);
         addSubForm(form);
     }

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -227,8 +227,11 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
     }
 
     private void updateHeaderTitle(@StringRes int titleRes) {
+        if (!configuration.useContextualHeaderTitle()) {
+            return;
+        }
         headerView.setTitle(getContext().getString(titleRes));
-        headerView.showTitle(configuration.useContextualHeaderTitle());
+        headerView.showTitle(true);
     }
 
     private void resetHeaderTitle() {

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -216,17 +216,18 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
     @Override
     public void showChangePasswordForm(boolean show) {
         if (show) {
-            addSubForm(new ChangePasswordFormView(this, lastEmailInput, !configuration.useContextualHeaderTitle()));
+            ChangePasswordFormView form = new ChangePasswordFormView(this, lastEmailInput);
+            form.showTitle(!configuration.useContextualHeaderTitle());
+            updateHeaderTitle(R.string.com_auth0_lock_title_change_password);
+            addSubForm(form);
             updateButtonLabel(R.string.com_auth0_lock_action_send_email);
-            updateHeaderTitle();
         } else {
             removeSubForm();
-            resetHeaderTitle();
         }
     }
 
-    private void updateHeaderTitle() {
-        headerView.setTitle(getContext().getString(R.string.com_auth0_lock_title_change_password));
+    private void updateHeaderTitle(@StringRes int titleRes) {
+        headerView.setTitle(getContext().getString(titleRes));
         headerView.showTitle(configuration.useContextualHeaderTitle());
     }
 
@@ -255,6 +256,7 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
         formLayout.refreshIdentityInput();
         addView(formLayout, FORM_INDEX, params);
         updateButtonLabel(formLayout.getSelectedMode() == AuthMode.SIGN_UP ? R.string.com_auth0_lock_action_sign_up : R.string.com_auth0_lock_action_log_in);
+        resetHeaderTitle();
     }
 
     /**
@@ -331,12 +333,18 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
 
     @Override
     public void showCustomFieldsForm(DatabaseSignUpEvent event) {
-        addSubForm(new CustomFieldsFormView(this, event.getEmail(), event.getPassword(), event.getUsername()));
+        CustomFieldsFormView form = new CustomFieldsFormView(this, event.getEmail(), event.getPassword(), event.getUsername());
+        addSubForm(form);
+        form.showTitle(!configuration.useContextualHeaderTitle());
+        updateHeaderTitle(R.string.com_auth0_lock_action_sign_up);
         showSignUpTerms(false);
     }
 
     public void showMFACodeForm(DatabaseLoginEvent event) {
-        addSubForm(new MFACodeFormView(this, event.getUsernameOrEmail(), event.getPassword()));
+        MFACodeFormView form = new MFACodeFormView(this, event.getUsernameOrEmail(), event.getPassword());
+        form.showTitle(!configuration.useContextualHeaderTitle());
+        updateHeaderTitle(R.string.com_auth0_lock_title_mfa_input_code);
+        addSubForm(form);
     }
 
     @Override

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -61,6 +61,7 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
     private final Theme lockTheme;
     private Configuration configuration;
 
+    private HeaderView headerView;
     private FormLayout formLayout;
     private FormView subForm;
 
@@ -102,7 +103,8 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
         LayoutParams wrapHeightParams = new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         LayoutParams formLayoutParams = new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT, 1);
 
-        HeaderView headerView = new HeaderView(getContext(), lockTheme);
+        headerView = new HeaderView(getContext(), lockTheme);
+        resetHeaderTitle();
         addView(headerView, wrapHeightParams);
 
         topBanner = inflate(getContext(), R.layout.com_auth0_lock_sso_layout, null);
@@ -214,11 +216,23 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
     @Override
     public void showChangePasswordForm(boolean show) {
         if (show) {
-            addSubForm(new ChangePasswordFormView(this, lastEmailInput));
+            addSubForm(new ChangePasswordFormView(this, lastEmailInput, !configuration.useContextualHeaderTitle()));
             updateButtonLabel(R.string.com_auth0_lock_action_send_email);
+            updateHeaderTitle();
         } else {
             removeSubForm();
+            resetHeaderTitle();
         }
+    }
+
+    private void updateHeaderTitle() {
+        headerView.setTitle(getContext().getString(R.string.com_auth0_lock_title_change_password));
+        headerView.showTitle(configuration.useContextualHeaderTitle());
+    }
+
+    private void resetHeaderTitle() {
+        headerView.setTitle(lockTheme.getHeaderTitle(getContext()));
+        headerView.showTitle(!configuration.useContextualHeaderTitle());
     }
 
     private void addSubForm(@NonNull FormView form) {
@@ -250,6 +264,7 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
      */
     public boolean onBackPressed() {
         if (subForm != null) {
+            resetHeaderTitle();
             final boolean shouldDisplayPreviousForm = configuration.allowLogIn() || configuration.allowSignUp();
             if (shouldDisplayPreviousForm) {
                 showSignUpTerms(subForm instanceof CustomFieldsFormView);

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -232,7 +232,7 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
 
     private void resetHeaderTitle() {
         headerView.setTitle(lockTheme.getHeaderTitle(getContext()));
-        headerView.showTitle(!configuration.useContextualHeaderTitle());
+        headerView.showTitle(!configuration.hideMainScreenTitle());
     }
 
     private void addSubForm(@NonNull FormView form) {

--- a/lib/src/main/java/com/auth0/android/lock/views/CustomFieldsFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/CustomFieldsFormView.java
@@ -30,7 +30,6 @@ import android.support.annotation.Nullable;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.KeyEvent;
-import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.widget.LinearLayout;
@@ -144,17 +143,5 @@ public class CustomFieldsFormView extends FormView implements TextView.OnEditorA
             lockWidget.onFormSubmit();
         }
         return false;
-    }
-
-    /**
-     * Change the visibility of this form Title.
-     *
-     * @param show whether to show or hide this form title.
-     */
-    public void showTitle(boolean show) {
-        View titleView = findViewById(R.id.com_auth0_lock_title);
-        if (titleView != null) {
-            titleView.setVisibility(show ? VISIBLE : GONE);
-        }
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/CustomFieldsFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/CustomFieldsFormView.java
@@ -30,14 +30,15 @@ import android.support.annotation.Nullable;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.KeyEvent;
+import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import com.auth0.android.lock.utils.CustomField;
 import com.auth0.android.lock.R;
 import com.auth0.android.lock.events.DatabaseSignUpEvent;
+import com.auth0.android.lock.utils.CustomField;
 import com.auth0.android.lock.views.interfaces.LockWidgetForm;
 
 import java.util.HashMap;
@@ -82,7 +83,7 @@ public class CustomFieldsFormView extends FormView implements TextView.OnEditorA
 
     private LinearLayout.LayoutParams defineFieldParams() {
         int horizontalMargin = getResources().getDimensionPixelSize(R.dimen.com_auth0_lock_widget_horizontal_margin);
-        int verticalMargin =  getResources().getDimensionPixelSize(R.dimen.com_auth0_lock_widget_vertical_margin_field);
+        int verticalMargin = getResources().getDimensionPixelSize(R.dimen.com_auth0_lock_widget_vertical_margin_field);
         LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         params.gravity = Gravity.CENTER_HORIZONTAL;
         params.setMargins(horizontalMargin, verticalMargin / 2, horizontalMargin, verticalMargin / 2);
@@ -143,5 +144,17 @@ public class CustomFieldsFormView extends FormView implements TextView.OnEditorA
             lockWidget.onFormSubmit();
         }
         return false;
+    }
+
+    /**
+     * Change the visibility of this form Title.
+     *
+     * @param show whether to show or hide this form title.
+     */
+    public void showTitle(boolean show) {
+        View titleView = findViewById(R.id.com_auth0_lock_title);
+        if (titleView != null) {
+            titleView.setVisibility(show ? VISIBLE : GONE);
+        }
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/HeaderView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/HeaderView.java
@@ -27,7 +27,6 @@ package com.auth0.android.lock.views;
 import android.content.Context;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DrawableRes;
-import android.support.annotation.StringRes;
 import android.support.v4.content.ContextCompat;
 import android.view.View;
 import android.widget.ImageView;
@@ -72,8 +71,8 @@ public class HeaderView extends RelativeLayout {
      *
      * @param title the title to use
      */
-    public void setTitle(@StringRes int title) {
-        this.text.setText(getResources().getString(title));
+    public void setTitle(String title) {
+        this.text.setText(title);
     }
 
     public void showTitle(boolean show) {

--- a/lib/src/main/java/com/auth0/android/lock/views/MFACodeFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/MFACodeFormView.java
@@ -36,7 +36,6 @@ import com.auth0.android.lock.views.interfaces.LockWidget;
 
 public class MFACodeFormView extends FormView implements TextView.OnEditorActionListener {
 
-    private static final String TAG = MFACodeFormView.class.getSimpleName();
     private final String usernameOrEmail;
     private final String password;
 
@@ -87,17 +86,5 @@ public class MFACodeFormView extends FormView implements TextView.OnEditorAction
             lockWidget.onFormSubmit();
         }
         return false;
-    }
-
-    /**
-     * Change the visibility of this form Title.
-     *
-     * @param show whether to show or hide this form title.
-     */
-    public void showTitle(boolean show) {
-        View titleView = findViewById(R.id.com_auth0_lock_title);
-        if (titleView != null) {
-            titleView.setVisibility(show ? VISIBLE : GONE);
-        }
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/MFACodeFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/MFACodeFormView.java
@@ -26,6 +26,7 @@ package com.auth0.android.lock.views;
 
 import android.support.annotation.Nullable;
 import android.view.KeyEvent;
+import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.widget.TextView;
 
@@ -58,7 +59,6 @@ public class MFACodeFormView extends FormView implements TextView.OnEditorAction
         codeInput.setOnEditorActionListener(this);
     }
 
-
     @Override
     public Object getActionEvent() {
         DatabaseLoginEvent event = new DatabaseLoginEvent(usernameOrEmail, password);
@@ -89,4 +89,15 @@ public class MFACodeFormView extends FormView implements TextView.OnEditorAction
         return false;
     }
 
+    /**
+     * Change the visibility of this form Title.
+     *
+     * @param show whether to show or hide this form title.
+     */
+    public void showTitle(boolean show) {
+        View titleView = findViewById(R.id.com_auth0_lock_title);
+        if (titleView != null) {
+            titleView.setVisibility(show ? VISIBLE : GONE);
+        }
+    }
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordlessFormLayout.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordlessFormLayout.java
@@ -143,6 +143,7 @@ public class PasswordlessFormLayout extends LinearLayout implements Passwordless
             removeView(passwordlessInputCodeLayout);
             addView(passwordlessRequestCodeLayout);
             passwordlessInputCodeLayout = null;
+            lockWidget.resetHeaderTitle();
             return true;
         }
         return false;
@@ -164,6 +165,7 @@ public class PasswordlessFormLayout extends LinearLayout implements Passwordless
             }
         }
         addPasswordlessInputCodeLayout(emailOrNumber);
+        lockWidget.updateHeaderTitle(R.string.com_auth0_lock_title_passwordless);
     }
 
     /**
@@ -197,6 +199,7 @@ public class PasswordlessFormLayout extends LinearLayout implements Passwordless
         addView(passwordlessRequestCodeLayout);
         passwordlessRequestCodeLayout.showGotCodeButton();
         showGotCodeButton = true;
+        lockWidget.resetHeaderTitle();
     }
 
     @Override

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordlessLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordlessLockView.java
@@ -55,6 +55,7 @@ public class PasswordlessLockView extends LinearLayout implements LockWidgetPass
     private PasswordlessFormLayout formLayout;
     private ActionButton actionButton;
     private ProgressBar loadingProgressBar;
+    private HeaderView headerView;
 
     public PasswordlessLockView(Context context, Bus lockBus, Theme lockTheme) {
         super(context);
@@ -84,7 +85,8 @@ public class PasswordlessLockView extends LinearLayout implements LockWidgetPass
     private void showContentLayout() {
         LayoutParams wrapHeightParams = new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
 
-        HeaderView headerView = new HeaderView(getContext(), lockTheme);
+        headerView = new HeaderView(getContext(), lockTheme);
+        resetHeaderTitle();
         addView(headerView, wrapHeightParams);
 
         int verticalMargin = getResources().getDimensionPixelSize(R.dimen.com_auth0_lock_widget_vertical_margin_field);
@@ -146,6 +148,18 @@ public class PasswordlessLockView extends LinearLayout implements LockWidgetPass
         errorLayout.addView(errorText, childParams);
         errorLayout.addView(retryButton, childParams);
         addView(errorLayout, params);
+    }
+
+    @Override
+    public void updateHeaderTitle(@StringRes int titleRes) {
+        headerView.setTitle(getContext().getString(titleRes));
+        headerView.showTitle(configuration.useContextualHeaderTitle());
+    }
+
+    @Override
+    public void resetHeaderTitle() {
+        headerView.setTitle(lockTheme.getHeaderTitle(getContext()));
+        headerView.showTitle(!configuration.useContextualHeaderTitle());
     }
 
     /**

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordlessLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordlessLockView.java
@@ -152,9 +152,6 @@ public class PasswordlessLockView extends LinearLayout implements LockWidgetPass
 
     @Override
     public void updateHeaderTitle(@StringRes int titleRes) {
-        if (!configuration.useContextualHeaderTitle()) {
-            return;
-        }
         headerView.setTitle(getContext().getString(titleRes));
         headerView.showTitle(true);
     }

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordlessLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordlessLockView.java
@@ -152,8 +152,11 @@ public class PasswordlessLockView extends LinearLayout implements LockWidgetPass
 
     @Override
     public void updateHeaderTitle(@StringRes int titleRes) {
+        if (!configuration.useContextualHeaderTitle()) {
+            return;
+        }
         headerView.setTitle(getContext().getString(titleRes));
-        headerView.showTitle(configuration.useContextualHeaderTitle());
+        headerView.showTitle(true);
     }
 
     @Override

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordlessLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordlessLockView.java
@@ -159,7 +159,7 @@ public class PasswordlessLockView extends LinearLayout implements LockWidgetPass
     @Override
     public void resetHeaderTitle() {
         headerView.setTitle(lockTheme.getHeaderTitle(getContext()));
-        headerView.showTitle(!configuration.useContextualHeaderTitle());
+        headerView.showTitle(!configuration.hideMainScreenTitle());
     }
 
     /**

--- a/lib/src/main/java/com/auth0/android/lock/views/interfaces/LockWidgetPasswordless.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/interfaces/LockWidgetPasswordless.java
@@ -24,9 +24,21 @@
 
 package com.auth0.android.lock.views.interfaces;
 
+import android.support.annotation.StringRes;
+
 public interface LockWidgetPasswordless extends LockWidgetOAuth {
 
     void onCountryCodeChangeRequest();
 
     void onPasswordlessCodeSent(String emailOrNumber);
+
+    /**
+     * Change the Header Title to the given value and update the visibility depending on the Contextual Header Title flag.
+     */
+    void updateHeaderTitle(@StringRes int titleRes);
+
+    /**
+     * Return the Header Title to the default text and visibility depending on the Contextual Header Title flag.
+     */
+    void resetHeaderTitle();
 }

--- a/lib/src/main/res/layout/com_auth0_lock_changepwd_form_view.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_changepwd_form_view.xml
@@ -33,12 +33,6 @@
     android:orientation="vertical">
 
     <com.auth0.android.lock.views.LineSpacingTextView
-        android:id="@+id/com_auth0_lock_title"
-        style="@style/Lock.Theme.Text.Title.ResetPassword"
-        android:layout_marginBottom="@dimen/com_auth0_lock_widget_vertical_margin_field"
-        android:text="@string/com_auth0_lock_title_change_password" />
-
-    <com.auth0.android.lock.views.LineSpacingTextView
         android:id="@+id/com_auth0_lock_text"
         style="@style/Lock.Theme.Text.Subtitle.ResetPassword"
         android:layout_marginBottom="@dimen/com_auth0_lock_widget_vertical_margin_passwordless"

--- a/lib/src/main/res/layout/com_auth0_lock_custom_fields_form_view.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_custom_fields_form_view.xml
@@ -29,23 +29,9 @@
     android:scrollbarStyle="outsideInset">
 
     <LinearLayout
+        android:id="@+id/com_auth0_lock_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:gravity="center"
-        android:orientation="vertical">
-
-        <com.auth0.android.lock.views.LineSpacingTextView
-            style="@style/Lock.Theme.Text.Title.SignUpCustomFields"
-            android:layout_marginTop="@dimen/com_auth0_lock_widget_vertical_margin_field"
-            android:text="@string/com_auth0_lock_title_sign_up_custom_fields"
-            android:visibility="gone" />
-
-        <LinearLayout
-            android:id="@+id/com_auth0_lock_container"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/com_auth0_lock_widget_vertical_margin_field"
-            android:orientation="vertical" />
-    </LinearLayout>
+        android:layout_marginBottom="@dimen/com_auth0_lock_widget_vertical_margin_field"
+        android:orientation="vertical" />
 </ScrollView>

--- a/lib/src/main/res/layout/com_auth0_lock_custom_fields_form_view.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_custom_fields_form_view.xml
@@ -36,7 +36,6 @@
         android:orientation="vertical">
 
         <com.auth0.android.lock.views.LineSpacingTextView
-            android:id="@+id/com_auth0_lock_title"
             style="@style/Lock.Theme.Text.Title.SignUpCustomFields"
             android:layout_marginTop="@dimen/com_auth0_lock_widget_vertical_margin_field"
             android:text="@string/com_auth0_lock_title_sign_up_custom_fields"

--- a/lib/src/main/res/layout/com_auth0_lock_header.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_header.xml
@@ -27,7 +27,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/com_auth0_lock_header_background"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="@dimen/com_auth0_lock_header_size"
     android:background="?attr/Auth0.HeaderBackground"
     android:gravity="center"
     tools:background="#40000000"

--- a/lib/src/main/res/layout/com_auth0_lock_mfa_input_code_form_view.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_mfa_input_code_form_view.xml
@@ -35,12 +35,6 @@
     android:paddingTop="@dimen/com_auth0_lock_widget_vertical_margin_field">
 
     <com.auth0.android.lock.views.LineSpacingTextView
-        android:id="@+id/com_auth0_lock_title"
-        style="@style/Lock.Theme.Text.Title.ResetPassword"
-        android:layout_marginBottom="@dimen/com_auth0_lock_widget_vertical_margin_field"
-        android:text="@string/com_auth0_lock_title_mfa_input_code" />
-
-    <com.auth0.android.lock.views.LineSpacingTextView
         android:id="@+id/com_auth0_lock_text"
         style="@style/Lock.Theme.Text.Subtitle.ResetPassword"
         android:text="@string/com_auth0_lock_description_mfa_input_code"

--- a/lib/src/main/res/values-sw400dp/dimens.xml
+++ b/lib/src/main/res/values-sw400dp/dimens.xml
@@ -26,6 +26,7 @@
     <dimen name="com_auth0_lock_widget_corner_radius">4dp</dimen>
     <dimen name="com_auth0_lock_list_item_height">55dp</dimen>
     <dimen name="com_auth0_lock_header_logo_size">80dp</dimen>
+    <dimen name="com_auth0_lock_header_size">138dp</dimen>
 
     <dimen name="com_auth0_lock_input_field_stroke_width">2dp</dimen>
     <dimen name="com_auth0_lock_widget_with_text_horizontal_padding">15dp</dimen>

--- a/lib/src/main/res/values/dimens.xml
+++ b/lib/src/main/res/values/dimens.xml
@@ -26,6 +26,7 @@
     <dimen name="com_auth0_lock_widget_corner_radius">3dp</dimen>
     <dimen name="com_auth0_lock_list_item_height">52dp</dimen>
     <dimen name="com_auth0_lock_header_logo_size">72dp</dimen>
+    <dimen name="com_auth0_lock_header_size">116dp</dimen>
 
     <dimen name="com_auth0_lock_input_field_stroke_width">2dp</dimen>
     <dimen name="com_auth0_lock_widget_with_text_horizontal_padding">13dp</dimen>

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -101,6 +101,7 @@
     <string name="com_auth0_lock_title_change_password">Reset Password</string>
     <string name="com_auth0_lock_title_sign_up_custom_fields">Complete the sign up process</string>
     <string name="com_auth0_lock_description_change_password">Please enter your email address. We will send you an email to reset your password.</string>
+    <string name="com_auth0_lock_title_passwordless">Code Sent</string>
     <string name="com_auth0_lock_title_passwordless_code_email_sent">An email with the code has been sent to %s</string>
     <string name="com_auth0_lock_title_passwordless_code_sms_sent">An SMS with the code has been sent to %s</string>
     <string name="com_auth0_lock_title_passwordless_link_sent">We sent you a link to sign in to\n %s</string>

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -156,16 +156,16 @@ public class OptionsTest {
     }
 
     @Test
-    public void shouldUseContextualHeaderTitle() throws Exception {
-        options.setUseContextualHeaderTitle(true);
+    public void shouldHideMainScreenTitle() throws Exception {
+        options.setHideMainScreenTitle(true);
 
         Parcel parcel = Parcel.obtain();
         options.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(options.useContextualHeaderTitle(), is(true));
-        assertThat(options.useContextualHeaderTitle(), is(equalTo(parceledOptions.useContextualHeaderTitle())));
+        assertThat(options.hideMainScreenTitle(), is(true));
+        assertThat(options.hideMainScreenTitle(), is(equalTo(parceledOptions.hideMainScreenTitle())));
     }
 
     @Test
@@ -627,7 +627,7 @@ public class OptionsTest {
         assertThat(options.useCodePasswordless(), is(true));
         assertThat(options.mustAcceptTerms(), is(false));
         assertThat(options.useLabeledSubmitButton(), is(false));
-        assertThat(options.useContextualHeaderTitle(), is(false));
+        assertThat(options.hideMainScreenTitle(), is(false));
         assertThat(options.getScope(), is(nullValue()));
         assertThat(options.usernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
         assertThat(options.authButtonSize(), is(equalTo(AuthButtonSize.UNSPECIFIED)));
@@ -651,7 +651,7 @@ public class OptionsTest {
         options.setAuthButtonSize(AuthButtonSize.BIG);
         options.setLoginAfterSignUp(true);
         options.setUseLabeledSubmitButton(true);
-        options.setUseContextualHeaderTitle(true);
+        options.setHideMainScreenTitle(true);
 
 
         Parcel parcel = Parcel.obtain();
@@ -671,7 +671,7 @@ public class OptionsTest {
         assertThat(options.authButtonSize(), is(equalTo(parceledOptions.authButtonSize())));
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
         assertThat(options.useLabeledSubmitButton(), is(equalTo(parceledOptions.useLabeledSubmitButton())));
-        assertThat(options.useContextualHeaderTitle(), is(equalTo(parceledOptions.useContextualHeaderTitle())));
+        assertThat(options.hideMainScreenTitle(), is(equalTo(parceledOptions.hideMainScreenTitle())));
     }
 
     @Test
@@ -688,7 +688,7 @@ public class OptionsTest {
         options.setAuthButtonSize(AuthButtonSize.SMALL);
         options.setLoginAfterSignUp(false);
         options.setUseLabeledSubmitButton(false);
-        options.setUseContextualHeaderTitle(false);
+        options.setHideMainScreenTitle(false);
 
 
         Parcel parcel = Parcel.obtain();
@@ -708,7 +708,7 @@ public class OptionsTest {
         assertThat(options.authButtonSize(), is(equalTo(parceledOptions.authButtonSize())));
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
         assertThat(options.useLabeledSubmitButton(), is(equalTo(parceledOptions.useLabeledSubmitButton())));
-        assertThat(options.useContextualHeaderTitle(), is(equalTo(parceledOptions.useContextualHeaderTitle())));
+        assertThat(options.hideMainScreenTitle(), is(equalTo(parceledOptions.hideMainScreenTitle())));
     }
 
 

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -156,6 +156,19 @@ public class OptionsTest {
     }
 
     @Test
+    public void shouldUseContextualHeaderTitle() throws Exception {
+        options.setUseContextualHeaderTitle(true);
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.useContextualHeaderTitle(), is(true));
+        assertThat(options.useContextualHeaderTitle(), is(equalTo(parceledOptions.useContextualHeaderTitle())));
+    }
+
+    @Test
     public void shouldUseBigSocialButtonStyle() throws Exception {
         options.setAuthButtonSize(AuthButtonSize.BIG);
 
@@ -614,6 +627,7 @@ public class OptionsTest {
         assertThat(options.useCodePasswordless(), is(true));
         assertThat(options.mustAcceptTerms(), is(false));
         assertThat(options.useLabeledSubmitButton(), is(false));
+        assertThat(options.useContextualHeaderTitle(), is(false));
         assertThat(options.getScope(), is(nullValue()));
         assertThat(options.usernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
         assertThat(options.authButtonSize(), is(equalTo(AuthButtonSize.UNSPECIFIED)));
@@ -637,6 +651,7 @@ public class OptionsTest {
         options.setAuthButtonSize(AuthButtonSize.BIG);
         options.setLoginAfterSignUp(true);
         options.setUseLabeledSubmitButton(true);
+        options.setUseContextualHeaderTitle(true);
 
 
         Parcel parcel = Parcel.obtain();
@@ -656,6 +671,7 @@ public class OptionsTest {
         assertThat(options.authButtonSize(), is(equalTo(parceledOptions.authButtonSize())));
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
         assertThat(options.useLabeledSubmitButton(), is(equalTo(parceledOptions.useLabeledSubmitButton())));
+        assertThat(options.useContextualHeaderTitle(), is(equalTo(parceledOptions.useContextualHeaderTitle())));
     }
 
     @Test
@@ -672,6 +688,7 @@ public class OptionsTest {
         options.setAuthButtonSize(AuthButtonSize.SMALL);
         options.setLoginAfterSignUp(false);
         options.setUseLabeledSubmitButton(false);
+        options.setUseContextualHeaderTitle(false);
 
 
         Parcel parcel = Parcel.obtain();
@@ -691,6 +708,7 @@ public class OptionsTest {
         assertThat(options.authButtonSize(), is(equalTo(parceledOptions.authButtonSize())));
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
         assertThat(options.useLabeledSubmitButton(), is(equalTo(parceledOptions.useLabeledSubmitButton())));
+        assertThat(options.useContextualHeaderTitle(), is(equalTo(parceledOptions.useContextualHeaderTitle())));
     }
 
 


### PR DESCRIPTION
This option would be enabled by calling:
```java
lock = builder.hideMainScreenTitle(true)
       .build(this);
```

Header title on screens different from the main one now display the form title as it's shown on the screenshots below.

On the Log in and Sign up screens, the title will be hidden. But on the rest of the screens it will show the current action description.
If this option is enabled, the `ActionButton` will use a label instead of the icon.

### Log in / Sign Up with feature option disabled
<img width="870" alt="main-title" src="https://cloud.githubusercontent.com/assets/3900123/21551989/3b3c6756-cddd-11e6-982c-127aaf6527dc.png">

### Log in / Sign Up with feature option enabled
<img width="418" alt="main-title" src="https://cloud.githubusercontent.com/assets/3900123/21571593/96d9646a-ceaf-11e6-8918-1b8510570cac.png">

### Password reset
<img width="421" alt="reset-pwd" src="https://cloud.githubusercontent.com/assets/3900123/21571594/9c8f4df2-ceaf-11e6-91b7-e7a231f784f3.png">

### Custom fields
<img width="418" alt="custom-fields" src="https://cloud.githubusercontent.com/assets/3900123/21571604/a0aca0ec-ceaf-11e6-890a-145a095bf9a5.png">

### MFA
<img width="422" alt="mfa" src="https://cloud.githubusercontent.com/assets/3900123/21571607/a45361e0-ceaf-11e6-8266-49c9f14ee159.png">

### Passwordless
<img width="422" alt="pwless" src="https://cloud.githubusercontent.com/assets/3900123/21571611/a812cb72-ceaf-11e6-841d-9e3419c004c9.png">


