### PR TITLE
Support custom schemes for Web Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ startActivity(lock.newIntent(this));
 ```
 
 #### Android App Links - Custom Scheme
-Currently the default scheme used for Web Authentication is `https`. This works best for Android API 23 or newer if you're using [Android App Links](https://developer.android.com/training/app-links/index.html), but in previous Android versions this may show the intent chooser dialog prompting the user to chose either your application or the browser to resolve the intent. You can change this behavior by using a custom unique scheme, so that the OS opens directly the link with your app.
+Currently the default scheme used for the redirect url used to send the Web Auth results is `https`. This works best for Android API 23 or newer if you're using [Android App Links](https://developer.android.com/training/app-links/index.html), but in previous Android versions this may show the intent chooser dialog prompting the user to chose either your application or the browser to resolve the intent. You can change this behavior by using a custom unique scheme, so that the OS opens directly the link with your app.
+
 1. Update the Intent Filter definition in the Android Manifest and change the custom scheme.
 2. Update the allowed callback urls in your [Auth0 Dashboard](https://manage.auth0.com/#/applications) client's settings to match urls that begin with the new scheme.
 3. Call `withScheme()` in the Lock Builder passing the scheme you want to use.

--- a/README.md
+++ b/README.md
@@ -201,6 +201,14 @@ Then just start `PasswordlessLockActivity` from inside your `Activity`
 startActivity(lock.newIntent(this));
 ```
 
+#### Android App Links - Custom Scheme
+Currently the default scheme used for Web Authentication is `https`. This works best for Android API 23 or newer if you're using [Android App Links](https://developer.android.com/training/app-links/index.html), but in previous Android versions this may show the intent chooser dialog prompting the user to chose either your application or the browser to resolve the intent. You can change this behavior by using a custom unique scheme, so that the OS opens directly the link with your app.
+1. Update the Intent Filter definition in the Android Manifest and change the custom scheme.
+2. Update the allowed callback urls in your [Auth0 Dashboard](https://manage.auth0.com/#/applications) client's settings to match urls that begin with the new scheme.
+3. Call `withScheme()` in the Lock Builder passing the scheme you want to use.
+
+> The scheme value **must** be lowercase. A warning message will be logged if this is not the case, and the lowercase version of the scheme will be used instead.
+
 ##Proguard
 The rules should be applied automatically if your application is using `minifyEnabled = true`. If you want to include them manually check the [proguard directory](proguard).
 By default you should at least use the following files:

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -479,6 +479,17 @@ public class Lock {
         }
 
         /**
+         * Specify a custom Scheme to use for Web Authentication. Default scheme is 'https'.
+         *
+         * @param scheme to use in the Web Authentication.
+         * @return the current builder instance
+         */
+        public Builder withScheme(@NonNull String scheme) {
+            options.withScheme(scheme);
+            return this;
+        }
+
+        /**
          * Choose a custom Privacy Policy URL to access when the user clicks the link on the Sign Up form.
          * The default value is 'https://auth0.com/privacy'
          *

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -479,9 +479,9 @@ public class Lock {
         }
 
         /**
-         * Specify a custom Scheme to use for Web Authentication. Default scheme is 'https'.
+         * Specify a custom Scheme for the redirect url used to send the Web Auth results. Default redirect url scheme is 'https'.
          *
-         * @param scheme to use in the Web Authentication.
+         * @param scheme to use in the Web Auth redirect uri.
          * @return the current builder instance
          */
         public Builder withScheme(@NonNull String scheme) {

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -377,6 +377,17 @@ public class PasswordlessLock {
         }
 
         /**
+         * Specify a custom Scheme to use for Web Authentication. Default scheme is 'https'.
+         *
+         * @param scheme to use in the Web Authentication.
+         * @return the current builder instance
+         */
+        public Builder withScheme(@NonNull String scheme) {
+            options.withScheme(scheme);
+            return this;
+        }
+
+        /**
          * Sets the Connection Scope to request when performing an Authentication with the given Connection.
          *
          * @param connectionName to which specify the scopes.

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -377,9 +377,9 @@ public class PasswordlessLock {
         }
 
         /**
-         * Specify a custom Scheme to use for Web Authentication. Default scheme is 'https'.
+         * Specify a custom Scheme for the redirect url used to send the Web Auth results. Default redirect url scheme is 'https'.
          *
-         * @param scheme to use in the Web Authentication.
+         * @param scheme to use in the Web Auth redirect uri.
          * @return the current builder instance
          */
         public Builder withScheme(@NonNull String scheme) {

--- a/lib/src/main/java/com/auth0/android/lock/WebProvider.java
+++ b/lib/src/main/java/com/auth0/android/lock/WebProvider.java
@@ -51,6 +51,10 @@ class WebProvider {
         if (audience != null) {
             builder.withAudience(audience);
         }
+        final String scheme = options.getScheme();
+        if (scheme != null) {
+            builder.withScheme(scheme);
+        }
         builder.start(activity, callback, requestCode);
     }
 

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -87,6 +87,7 @@ public class Options implements Parcelable {
     private String termsURL;
     private String scope;
     private String audience;
+    private String scheme;
 
     public Options() {
         usernameStyle = UsernameStyle.DEFAULT;
@@ -128,6 +129,7 @@ public class Options implements Parcelable {
         termsURL = in.readString();
         scope = in.readString();
         audience = in.readString();
+        scheme = in.readString();
         if (in.readByte() == HAS_DATA) {
             connections = new ArrayList<>();
             in.readList(connections, String.class.getClassLoader());
@@ -202,6 +204,7 @@ public class Options implements Parcelable {
         dest.writeString(termsURL);
         dest.writeString(scope);
         dest.writeString(audience);
+        dest.writeString(scheme);
         if (connections == null) {
             dest.writeByte((byte) (WITHOUT_DATA));
         } else {
@@ -503,5 +506,14 @@ public class Options implements Parcelable {
     @Nullable
     public String getAudience() {
         return audience;
+    }
+
+    public void withScheme(@NonNull String scheme) {
+        this.scheme = scheme;
+    }
+
+    @Nullable
+    public String getScheme() {
+        return scheme;
     }
 }

--- a/lib/src/test/java/com/auth0/android/lock/WebProviderTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/WebProviderTest.java
@@ -2,6 +2,7 @@ package com.auth0.android.lock;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.net.Uri;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.lock.internal.configuration.Options;
@@ -23,6 +24,7 @@ import static android.support.test.espresso.intent.matcher.IntentMatchers.hasAct
 import static android.support.test.espresso.intent.matcher.IntentMatchers.hasComponent;
 import static android.support.test.espresso.intent.matcher.UriMatchers.hasHost;
 import static android.support.test.espresso.intent.matcher.UriMatchers.hasParamWithValue;
+import static android.support.test.espresso.intent.matcher.UriMatchers.hasScheme;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -67,6 +69,7 @@ public class WebProviderTest {
         options.withConnectionScope("my-connection", "the connection scope");
         options.setUseBrowser(true);
         options.withAudience("https://me.auth0.com/myapi");
+        options.withScheme("auth0");
 
         AuthCallback callback = mock(AuthCallback.class);
         WebProvider webProvider = new WebProvider(options);
@@ -82,6 +85,9 @@ public class WebProviderTest {
 
         Intent intent = intentCaptor.getValue();
         assertThat(intent, is(notNullValue()));
+        assertThat(intent.getData().getQueryParameter("redirect_uri"), is(notNullValue()));
+        Uri redirectUri = Uri.parse(intent.getData().getQueryParameter("redirect_uri"));
+        assertThat(redirectUri, hasScheme("auth0"));
         assertThat(intent.getData(), hasHost("domain.auth0.com"));
         assertThat(intent.getData(), hasParamWithValue("client_id", "clientId"));
         assertThat(intent.getData(), hasParamWithValue("connection", "my-connection"));
@@ -107,6 +113,7 @@ public class WebProviderTest {
         options.withConnectionScope("my-connection", "the connection scope");
         options.setUseBrowser(false);
         options.withAudience("https://me.auth0.com/myapi");
+        options.withScheme("auth0");
 
         AuthCallback callback = mock(AuthCallback.class);
         WebProvider webProvider = new WebProvider(options);
@@ -122,6 +129,9 @@ public class WebProviderTest {
 
         Intent intent = intentCaptor.getValue();
         assertThat(intent, is(notNullValue()));
+        assertThat(intent.getData().getQueryParameter("redirect_uri"), is(notNullValue()));
+        Uri redirectUri = Uri.parse(intent.getData().getQueryParameter("redirect_uri"));
+        assertThat(redirectUri, hasScheme("auth0"));
         assertThat(intent.getData(), hasHost("domain.auth0.com"));
         assertThat(intent.getData(), hasParamWithValue("client_id", "clientId"));
         assertThat(intent.getData(), hasParamWithValue("connection", "my-connection"));

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -536,6 +536,19 @@ public class OptionsTest {
         assertThat(parceledOptions.getAudience(), is("https://domain.auth0.com/users"));
     }
 
+    @Test
+    public void shouldSetScheme() throws Exception {
+        options.withScheme("auth0");
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.getScheme(), is(equalTo("auth0")));
+        assertThat(parceledOptions.getScheme(), is("auth0"));
+    }
+
     @SuppressWarnings("ResourceType")
     @Test
     public void shouldAddAuthStyles() throws Exception {
@@ -643,6 +656,7 @@ public class OptionsTest {
         assertThat(options.hideMainScreenTitle(), is(false));
         assertThat(options.getScope(), is(nullValue()));
         assertThat(options.getAudience(), is(nullValue()));
+        assertThat(options.getScheme(), is(nullValue()));
         assertThat(options.usernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
         assertThat(options.authButtonSize(), is(equalTo(AuthButtonSize.UNSPECIFIED)));
         assertThat(options.getTheme(), is(notNullValue()));


### PR DESCRIPTION
For *Android App Links* a scheme equal to `https` is required, but if you're not targeting API 23 or upper or you don't want to support Android App Links then you might want to use a custom scheme so that the user isn't prompted to chose an App to resolve the intent whenever a Web Authentication is successful. 

```java
Lock lock = lockBuilder.withScheme("auth0")
                      .build(this);
```