### PR TITLE
Support custom audience for Web Authentication

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compile 'com.android.support:design:24.2.1'
     compile 'com.google.code.gson:gson:2.6.2'
     compile 'com.squareup:otto:1.3.8'
-    compile 'com.auth0.android:auth0:1.3.0'
+    compile 'com.auth0.android:auth0:1.4.0'
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     testCompile 'org.robolectric:robolectric:3.1.2'

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -468,6 +468,17 @@ public class Lock {
         }
 
         /**
+         * Sets the Audience or API Identifier to request access to when performing the Authentication.
+         *
+         * @param audience to use in the Authentication.
+         * @return the current builder instance
+         */
+        public Builder withAudience(@NonNull String audience) {
+            options.withAudience(audience);
+            return this;
+        }
+
+        /**
          * Choose a custom Privacy Policy URL to access when the user clicks the link on the Sign Up form.
          * The default value is 'https://auth0.com/privacy'
          *

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -366,6 +366,17 @@ public class PasswordlessLock {
         }
 
         /**
+         * Sets the Audience or API Identifier to request access to when performing the Authentication.
+         *
+         * @param audience to use in the Authentication.
+         * @return the current builder instance
+         */
+        public Builder withAudience(@NonNull String audience) {
+            options.withAudience(audience);
+            return this;
+        }
+
+        /**
          * Sets the Connection Scope to request when performing an Authentication with the given Connection.
          *
          * @param connectionName to which specify the scopes.

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -137,6 +137,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
         lockBus = new Bus();
         lockBus.register(this);
         handler = new Handler(getMainLooper());
+        webProvider = new WebProvider(options);
 
         setContentView(R.layout.com_auth0_lock_activity_lock_passwordless);
         passwordlessSuccessCover = (LinearLayout) findViewById(R.id.com_auth0_lock_link_sent_cover);

--- a/lib/src/main/java/com/auth0/android/lock/WebProvider.java
+++ b/lib/src/main/java/com/auth0/android/lock/WebProvider.java
@@ -2,7 +2,6 @@ package com.auth0.android.lock;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.content.UriMatcher;
 import android.support.annotation.NonNull;
 
 import com.auth0.android.lock.internal.configuration.Options;
@@ -47,6 +46,10 @@ class WebProvider {
         final String scope = options.getScope();
         if (scope != null) {
             builder.withScope(scope);
+        }
+        final String audience = options.getAudience();
+        if (audience != null) {
+            builder.withAudience(audience);
         }
         builder.start(activity, callback, requestCode);
     }

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -86,6 +86,7 @@ public class Options implements Parcelable {
     private String privacyURL;
     private String termsURL;
     private String scope;
+    private String audience;
 
     public Options() {
         usernameStyle = UsernameStyle.DEFAULT;
@@ -126,6 +127,7 @@ public class Options implements Parcelable {
         privacyURL = in.readString();
         termsURL = in.readString();
         scope = in.readString();
+        audience = in.readString();
         if (in.readByte() == HAS_DATA) {
             connections = new ArrayList<>();
             in.readList(connections, String.class.getClassLoader());
@@ -199,6 +201,7 @@ public class Options implements Parcelable {
         dest.writeString(privacyURL);
         dest.writeString(termsURL);
         dest.writeString(scope);
+        dest.writeString(audience);
         if (connections == null) {
             dest.writeByte((byte) (WITHOUT_DATA));
         } else {
@@ -491,5 +494,14 @@ public class Options implements Parcelable {
     @Nullable
     public String getScope() {
         return scope;
+    }
+
+    public void withAudience(@NonNull String audience) {
+        this.audience = audience;
+    }
+
+    @Nullable
+    public String getAudience() {
+        return audience;
     }
 }

--- a/lib/src/test/java/com/auth0/android/lock/WebProviderTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/WebProviderTest.java
@@ -66,6 +66,7 @@ public class WebProviderTest {
         options.withScope("email profile photos");
         options.withConnectionScope("my-connection", "the connection scope");
         options.setUseBrowser(true);
+        options.withAudience("https://me.auth0.com/myapi");
 
         AuthCallback callback = mock(AuthCallback.class);
         WebProvider webProvider = new WebProvider(options);
@@ -88,6 +89,7 @@ public class WebProviderTest {
         assertThat(intent.getData(), hasParamWithValue("custom-param-2", "value-2"));
         assertThat(intent.getData(), hasParamWithValue("scope", "email profile photos"));
         assertThat(intent.getData(), hasParamWithValue("connection_scope", "the connection scope"));
+        assertThat(intent.getData(), hasParamWithValue("audience", "https://me.auth0.com/myapi"));
         assertThat(intent, hasAction(Intent.ACTION_VIEW));
     }
 
@@ -104,6 +106,7 @@ public class WebProviderTest {
         options.withScope("email profile photos");
         options.withConnectionScope("my-connection", "the connection scope");
         options.setUseBrowser(false);
+        options.withAudience("https://me.auth0.com/myapi");
 
         AuthCallback callback = mock(AuthCallback.class);
         WebProvider webProvider = new WebProvider(options);
@@ -126,6 +129,7 @@ public class WebProviderTest {
         assertThat(intent.getData(), hasParamWithValue("custom-param-2", "value-2"));
         assertThat(intent.getData(), hasParamWithValue("scope", "email profile photos"));
         assertThat(intent.getData(), hasParamWithValue("connection_scope", "the connection scope"));
+        assertThat(intent.getData(), hasParamWithValue("audience", "https://me.auth0.com/myapi"));
         assertThat(intent, hasComponent(WebAuthActivity.class.getName()));
     }
 

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -523,6 +523,19 @@ public class OptionsTest {
         assertThat(parceledOptions.getScope(), is("some connection scope"));
     }
 
+    @Test
+    public void shouldSetAudience() throws Exception {
+        options.withAudience("https://domain.auth0.com/users");
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.getAudience(), is(equalTo("https://domain.auth0.com/users")));
+        assertThat(parceledOptions.getAudience(), is("https://domain.auth0.com/users"));
+    }
+
     @SuppressWarnings("ResourceType")
     @Test
     public void shouldAddAuthStyles() throws Exception {
@@ -629,6 +642,7 @@ public class OptionsTest {
         assertThat(options.useLabeledSubmitButton(), is(false));
         assertThat(options.hideMainScreenTitle(), is(false));
         assertThat(options.getScope(), is(nullValue()));
+        assertThat(options.getAudience(), is(nullValue()));
         assertThat(options.usernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
         assertThat(options.authButtonSize(), is(equalTo(AuthButtonSize.UNSPECIFIED)));
         assertThat(options.getTheme(), is(notNullValue()));


### PR DESCRIPTION
Request a custom audience during Web Authentication. 

```java
Lock lock = lockBuilder.withAudience("https://domain.auth0.com/users")
                      .build(this);
```