### PR TITLE
Use labeled submit button by default and separate signUp/logIn strings

### DIFF
--- a/app/src/main/res/layout/demo_activity.xml
+++ b/app/src/main/res/layout/demo_activity.xml
@@ -40,19 +40,20 @@
             android:orientation="horizontal">
 
             <RadioButton
-                android:id="@+id/radio_use_icon"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:checked="true"
-                android:text="Submit with Icon" />
-
-            <RadioButton
                 android:id="@+id/radio_use_label"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:checked="true"
                 android:text="Submit with Label" />
+
+            <RadioButton
+                android:id="@+id/radio_use_icon"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Submit with Icon" />
+
         </RadioGroup>
 
         <CheckBox

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -390,7 +390,7 @@ public class Lock {
         /**
          * Whether if the submit button will display a label or just an icon.
          *
-         * @param useLabeledSubmitButton or icon. By default it will use icon.
+         * @param useLabeledSubmitButton or icon. By default it will use the label.
          * @return the current builder instance
          */
         public Builder useLabeledSubmitButton(boolean useLabeledSubmitButton) {

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -99,6 +99,7 @@ public class Options implements Parcelable {
         loginAfterSignUp = true;
         useCodePasswordless = true;
         usePKCE = true;
+        useLabeledSubmitButton = true;
         authenticationParameters = new HashMap<>();
         authStyles = new HashMap<>();
         connectionsScope = new HashMap<>();

--- a/lib/src/main/java/com/auth0/android/lock/views/ModeSelectionView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ModeSelectionView.java
@@ -50,10 +50,10 @@ public class ModeSelectionView extends LinearLayout implements TabLayout.OnTabSe
         tabLayout = (TabLayout) findViewById(R.id.com_auth0_lock_tab_layout);
         tabLayout.addTab(tabLayout.newTab()
                 .setCustomView(R.layout.com_auth0_lock_tab)
-                .setText(R.string.com_auth0_lock_action_log_in));
+                .setText(R.string.com_auth0_lock_mode_log_in));
         tabLayout.addTab(tabLayout.newTab()
                 .setCustomView(R.layout.com_auth0_lock_tab)
-                .setText(R.string.com_auth0_lock_action_sign_up));
+                .setText(R.string.com_auth0_lock_mode_sign_up));
         tabLayout.setOnTabSelectedListener(this);
     }
 

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -86,6 +86,8 @@
     <string name="com_auth0_lock_hint_search_country">Search your country</string>
     <string name="com_auth0_lock_action_sign_up">Sign Up</string>
     <string name="com_auth0_lock_action_log_in">Log In</string>
+    <string name="com_auth0_lock_mode_sign_up">Sign Up</string>
+    <string name="com_auth0_lock_mode_log_in">Log In</string>
     <string name="com_auth0_lock_action_send_email">Send Email</string>
     <string name="com_auth0_lock_action_forgot_password">Don\'t remember your password?</string>
     <string name="com_auth0_lock_action_single_login_with_corporate">Login with your corporate credentials.</string>

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
@@ -104,6 +104,7 @@ public class ConfigurationTest extends GsonBaseTest {
         assertThat(configuration.hasExtraFields(), is(false));
         assertThat(configuration.getPasswordPolicy(), is(PasswordStrength.NONE));
         assertThat(configuration.mustAcceptTerms(), is(false));
+        assertThat(configuration.useLabeledSubmitButton(), is(true));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -652,7 +652,7 @@ public class OptionsTest {
         assertThat(options.loginAfterSignUp(), is(true));
         assertThat(options.useCodePasswordless(), is(true));
         assertThat(options.mustAcceptTerms(), is(false));
-        assertThat(options.useLabeledSubmitButton(), is(false));
+        assertThat(options.useLabeledSubmitButton(), is(true));
         assertThat(options.hideMainScreenTitle(), is(false));
         assertThat(options.getScope(), is(nullValue()));
         assertThat(options.getAudience(), is(nullValue()));


### PR DESCRIPTION
### Localization
Before this PR the `Log In` and `Sign Up` strings were the same for the tabs and the submit button. Now they are:
* `com_auth0_lock_action_log_in` and `com_auth0_lock_action_sign_up` for the submit button label.
* `com_auth0_lock_mode_log_in` and `com_auth0_lock_mode_sign_up` for the tabs text.

Default values are the same: "Log In" and "Sign Up".

### Labeled mode
This PR also changes the default value for the `useLabeledSubmitButton` from "use icon" to "use label".