### PR TITLE
Remove "invalid client type" user message

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/errors/LoginErrorMessageBuilder.java
+++ b/lib/src/main/java/com/auth0/android/lock/errors/LoginErrorMessageBuilder.java
@@ -25,6 +25,7 @@
 package com.auth0.android.lock.errors;
 
 import android.support.annotation.StringRes;
+import android.util.Log;
 
 import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.lock.R;
@@ -42,7 +43,6 @@ public class LoginErrorMessageBuilder implements ErrorMessageBuilder<Authenticat
     private static final int unauthorizedResource = R.string.com_auth0_lock_db_login_error_unauthorized_message;
     private static final int invalidMFACodeResource = R.string.com_auth0_lock_db_login_error_invalid_mfa_code_message;
     private static final int tooManyAttemptsResource = R.string.com_auth0_lock_db_too_many_attempts_error_message;
-    private static final int wrongClientTypeResource = R.string.com_auth0_lock_db_login_error_wrong_client_type_message;
 
     private int invalidCredentialsResource;
     private int defaultMessage;
@@ -73,7 +73,8 @@ public class LoginErrorMessageBuilder implements ErrorMessageBuilder<Authenticat
                 description = exception.getDescription();
             }
         } else if (WRONG_CLIENT_TYPE_ERROR.equals(exception.getDescription())) {
-            messageRes = wrongClientTypeResource;
+            Log.w("Lock", "The Client Type must be set to 'native' in order to authenticate using Code Grant (PKCE). Please change the type in your Auth0 client's dashboard: https://manage.auth0.com/#/clients");
+            messageRes = defaultMessage;
         } else if (TOO_MANY_ATTEMPTS_ERROR.equals(exception.getCode())) {
             messageRes = tooManyAttemptsResource;
         } else {

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -126,7 +126,6 @@
     <string name="com_auth0_lock_db_login_error_message">There was an error processing the sign in</string>
     <string name="com_auth0_lock_db_login_error_invalid_credentials_message">Wrong email or password</string>
     <string name="com_auth0_lock_db_login_error_unauthorized_message">User is blocked</string>
-    <string name="com_auth0_lock_db_login_error_wrong_client_type_message">Enable PKCE on your Client\'s Dashboard by setting \'Client Type\' to \'Native\'.</string>
     <string name="com_auth0_lock_db_sign_up_error_message">There was an error processing the sign up</string>
     <string name="com_auth0_lock_db_change_password_message_success">We\'ve just sent you an email to reset your password</string>
     <string name="com_auth0_lock_db_message_change_password_error">Couldn\'t reset your password.</string>

--- a/lib/src/test/java/com/auth0/android/lock/errors/LoginErrorMessageBuilderTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/errors/LoginErrorMessageBuilderTest.java
@@ -103,10 +103,10 @@ public class LoginErrorMessageBuilderTest {
     }
 
     @Test
-    public void shouldHaveCustomMessageIfIsWrongClientType() throws Exception {
+    public void shouldHaveDefaultMessageIfIsWrongClientType() throws Exception {
         Mockito.when(exception.getDescription()).thenReturn("Unauthorized");
         final AuthenticationError error = builder.buildFrom(exception);
-        assertThat(error.getMessageRes(), is(equalTo(R.string.com_auth0_lock_db_login_error_wrong_client_type_message)));
+        assertThat(error.getMessageRes(), is(equalTo(R.string.com_auth0_lock_db_login_error_message)));
     }
 
 }


### PR DESCRIPTION
When authentication using code grant failed because the client type was other than `native`, a custom error message was shown to the user within Lock. This PR removes that and shows a default error message instead. Also, a warning message is logged so the developer can change the client type and avoid this issue.