### PR TITLE
Add Passwordless auto login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath 'gradle.plugin.com.auth0.gradle:oss-library:0.5.21'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
-        classpath 'gradle.plugin.com.auth0.gradle:oss-library:0.5.21'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+        classpath "gradle.plugin.com.auth0.gradle:oss-library:0.6.0"
     }
 }
 

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -247,12 +247,12 @@ public class PasswordlessLock {
         }
 
         /**
-         * Whether Lock should remember the last used identity and auto request a passwordless sign in or not. By default, the auto submit is disabled.
+         * Whether Lock should remember the last used passwordless identity and auto request a sign or not. By default, lock will not remember the last login.
          *
          * @return the current Builder instance
          */
-        public Builder usePasswordlessAutoSubmit(boolean autoSubmit) {
-            options.setPasswordlessAutoSubmit(autoSubmit);
+        public Builder rememberLastLogin(boolean remember) {
+            options.setRememberLastPasswordlessLogin(remember);
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -247,6 +247,16 @@ public class PasswordlessLock {
         }
 
         /**
+         * Whether Lock should remember the last used identity and auto request a passwordless sign in or not. By default, the auto submit is disabled.
+         *
+         * @return the current Builder instance
+         */
+        public Builder usePasswordlessAutoSubmit(boolean autoSubmit) {
+            options.setPasswordlessAutoSubmit(autoSubmit);
+            return this;
+        }
+
+        /**
          * Whether to use the Browser for Authentication with Identity Providers or the inner WebView.
          *
          * @param useBrowser or WebView. By default, the Authentication flow will use the Browser.

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -285,7 +285,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
     };
 
     private void reloadRecentPasswordlessData(boolean submitForm) {
-        if (!identityHelper.hasLoggedInBefore()) {
+        if (!configuration.usePasswordlessAutoSubmit() || !identityHelper.hasLoggedInBefore()) {
             return;
         }
 
@@ -485,8 +485,10 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
     private com.auth0.android.callback.AuthenticationCallback<Credentials> authCallback = new com.auth0.android.callback.AuthenticationCallback<Credentials>() {
         @Override
         public void onSuccess(Credentials credentials) {
-            Log.d(TAG, "Saving passwordless identity for a future log in request.");
-            identityHelper.saveIdentity(lastPasswordlessIdentity, lastPasswordlessCountry);
+            if (configuration.usePasswordlessAutoSubmit()) {
+                Log.d(TAG, "Saving passwordless identity for a future log in request.");
+                identityHelper.saveIdentity(lastPasswordlessIdentity, lastPasswordlessCountry);
+            }
             deliverAuthenticationResult(credentials);
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -26,9 +26,7 @@ package com.auth0.android.lock;
 
 
 import android.app.Dialog;
-import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.content.res.TypedArray;
 import android.os.Build;
 import android.os.Bundle;
@@ -63,6 +61,7 @@ import com.auth0.android.lock.internal.configuration.Configuration;
 import com.auth0.android.lock.internal.configuration.Connection;
 import com.auth0.android.lock.internal.configuration.Options;
 import com.auth0.android.lock.internal.configuration.PasswordlessMode;
+import com.auth0.android.lock.internal.configuration.PasswordlessUserHelper;
 import com.auth0.android.lock.provider.AuthResolver;
 import com.auth0.android.lock.views.PasswordlessLockView;
 import com.auth0.android.provider.AuthCallback;
@@ -84,14 +83,6 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
     private static final int COUNTRY_CODE_REQUEST_CODE = 120;
     private static final long RESULT_MESSAGE_DURATION = 3000;
     private static final long RESEND_TIMEOUT = 20 * 1000;
-    private static final long CODE_TTL = 2 * 60 * 1000;
-
-    private static final String LAST_PASSWORDLESS_TIME_KEY = "last_passwordless_time";
-    private static final String LAST_PASSWORDLESS_EMAIL_NUMBER_KEY = "last_passwordless_email_number";
-    private static final String LAST_PASSWORDLESS_COUNTRY_KEY = "last_passwordless_country";
-    private static final String LAST_PASSWORDLESS_MODE_KEY = "last_passwordless_mode";
-    private static final String LOCK_PREFERENCES_NAME = "Lock";
-    private static final String COUNTRY_DATA_DIV = "@";
 
     private ApplicationFetcher applicationFetcher;
     private Configuration configuration;
@@ -102,7 +93,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
     private LinearLayout passwordlessSuccessCover;
     private TextView resultMessage;
 
-    private String lastPasswordlessEmailOrNumber;
+    private String lastPasswordlessIdentity;
     private Country lastPasswordlessCountry;
     private Bus lockBus;
     private ScrollView rootView;
@@ -112,6 +103,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
     private WebProvider webProvider;
 
     private LoginErrorMessageBuilder loginErrorBuilder;
+    private PasswordlessUserHelper passwordlessHelper;
 
     @SuppressWarnings("unused")
     public PasswordlessLockActivity() {
@@ -123,7 +115,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
         this.options = options;
         this.lockView = lockView;
         this.webProvider = webProvider;
-        this.lastPasswordlessEmailOrNumber = lastEmailOrNumber;
+        this.lastPasswordlessIdentity = lastEmailOrNumber;
     }
 
     @Override
@@ -210,7 +202,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
     public void onBackPressed() {
         boolean showingSuccessLayout = passwordlessSuccessCover.getVisibility() == View.VISIBLE;
         if (!showingSuccessLayout && lockView.onBackPressed()) {
-            reloadRecentPasswordlessData();
+            reloadRecentPasswordlessData(false);
             return;
         }
         if (!options.isClosable()) {
@@ -252,7 +244,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
 
     private void showLinkSentLayout() {
         TextView successMessage = (TextView) passwordlessSuccessCover.findViewById(R.id.com_auth0_lock_passwordless_message);
-        successMessage.setText(String.format(getString(R.string.com_auth0_lock_title_passwordless_link_sent), lastPasswordlessEmailOrNumber));
+        successMessage.setText(String.format(getString(R.string.com_auth0_lock_title_passwordless_link_sent), lastPasswordlessIdentity));
         TextView gotCodeButton = (TextView) passwordlessSuccessCover.findViewById(R.id.com_auth0_lock_got_code);
         gotCodeButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -270,7 +262,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
                 lockView = new PasswordlessLockView(PasswordlessLockActivity.this, lockBus, options.getTheme());
                 if (configuration != null) {
                     lockView.configure(configuration);
-                    reloadRecentPasswordlessData();
+                    reloadRecentPasswordlessData(false);
                 } else {
                     lockBus.post(new FetchApplicationEvent());
                 }
@@ -293,53 +285,17 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
         }
     };
 
-    private void reloadRecentPasswordlessData() {
-        int choosenMode = configuration.getPasswordlessMode();
-        if (choosenMode == PasswordlessMode.DISABLED) {
-            return;
-        }
-        SharedPreferences sp = getSharedPreferences(LOCK_PREFERENCES_NAME, Context.MODE_PRIVATE);
-        int savedMode = sp.getInt(LAST_PASSWORDLESS_MODE_KEY, PasswordlessMode.DISABLED);
-        if (sp.getLong(LAST_PASSWORDLESS_TIME_KEY, 0) + CODE_TTL < System.currentTimeMillis() || choosenMode != savedMode) {
-            Log.d(TAG, "Previous Passwordless data is too old to reload.");
+    private void reloadRecentPasswordlessData(boolean submitForm) {
+        if (!passwordlessHelper.hadLoggedInBefore()) {
+            Log.e(TAG, "User has never logged in using passwordless.");
             return;
         }
 
-        String text = sp.getString(LAST_PASSWORDLESS_EMAIL_NUMBER_KEY, "");
-        lastPasswordlessEmailOrNumber = text;
-        String countryInfo = sp.getString(LAST_PASSWORDLESS_COUNTRY_KEY, null);
-        if (countryInfo != null) {
-            String isoCode = countryInfo.split(COUNTRY_DATA_DIV)[0];
-            String dialCode = countryInfo.split(COUNTRY_DATA_DIV)[1];
-            if (text.startsWith(dialCode)) {
-                text = text.substring(dialCode.length());
-            }
-            lastPasswordlessCountry = new Country(isoCode, dialCode);
+        Log.e(TAG, "User has logged in in the past.. Reloading passwordless data");
+        lockView.loadPasswordlessData(passwordlessHelper.getLastIdentity(), passwordlessHelper.getLastCountry());
+        if (submitForm) {
+            lockView.onFormSubmit();
         }
-        lockView.loadPasswordlessData(text, lastPasswordlessCountry);
-    }
-
-    private void persistRecentPasswordlessData(@NonNull String emailOrNumber, @Nullable Country country) {
-        Log.v(TAG, "Saving recently used Passwordless data for the next time.");
-        SharedPreferences sp = getSharedPreferences(LOCK_PREFERENCES_NAME, Context.MODE_PRIVATE);
-        String countryData = country != null ? country.getIsoCode() + COUNTRY_DATA_DIV + country.getDialCode() : null;
-        sp.edit()
-                .putLong(LAST_PASSWORDLESS_TIME_KEY, System.currentTimeMillis())
-                .putString(LAST_PASSWORDLESS_EMAIL_NUMBER_KEY, emailOrNumber)
-                .putString(LAST_PASSWORDLESS_COUNTRY_KEY, countryData)
-                .putInt(LAST_PASSWORDLESS_MODE_KEY, configuration.getPasswordlessMode())
-                .apply();
-    }
-
-    public void clearRecentPasswordlessData() {
-        Log.v(TAG, "Deleting recent Passwordless data.");
-        SharedPreferences sp = getSharedPreferences(LOCK_PREFERENCES_NAME, Context.MODE_PRIVATE);
-        sp.edit()
-                .putLong(LAST_PASSWORDLESS_TIME_KEY, 0)
-                .putString(LAST_PASSWORDLESS_EMAIL_NUMBER_KEY, "")
-                .putString(LAST_PASSWORDLESS_COUNTRY_KEY, null)
-                .putInt(LAST_PASSWORDLESS_MODE_KEY, PasswordlessMode.DISABLED)
-                .apply();
     }
 
     @Override
@@ -389,7 +345,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
         }
 
         boolean useMagicLink = configuration.getPasswordlessMode() == PasswordlessMode.EMAIL_LINK || configuration.getPasswordlessMode() == PasswordlessMode.SMS_LINK;
-        if (lastPasswordlessEmailOrNumber != null && useMagicLink) {
+        if (lastPasswordlessIdentity != null && useMagicLink) {
             String code = intent.getData().getQueryParameter("code");
             if (code == null || code.isEmpty()) {
                 Log.w(TAG, "Passwordless Code is missing or could not be parsed");
@@ -441,14 +397,14 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
         AuthenticationAPIClient apiClient = options.getAuthenticationAPIClient();
         String connectionName = configuration.getPasswordlessConnection().getName();
         if (event.getCode() != null) {
-            event.getLoginRequest(apiClient, lastPasswordlessEmailOrNumber)
+            event.getLoginRequest(apiClient, lastPasswordlessIdentity)
                     .addAuthenticationParameters(options.getAuthenticationParameters())
                     .setConnection(connectionName)
                     .start(authCallback);
             return;
         }
 
-        lastPasswordlessEmailOrNumber = event.getEmailOrNumber();
+        lastPasswordlessIdentity = event.getEmailOrNumber();
         lastPasswordlessCountry = event.getCountry();
         event.getCodeRequest(apiClient, connectionName)
                 .start(passwordlessCodeCallback);
@@ -457,7 +413,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
     @SuppressWarnings("unused")
     @Subscribe
     public void onOAuthAuthenticationRequest(OAuthLoginEvent event) {
-        lastPasswordlessEmailOrNumber = null;
+        lastPasswordlessIdentity = null;
         lastPasswordlessCountry = null;
         Log.v(TAG, "Looking for a provider to use with the connection " + event.getConnection());
         currentProvider = AuthResolver.providerFor(event.getStrategy(), event.getConnection());
@@ -476,11 +432,12 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
         @Override
         public void onSuccess(final List<Connection> connections) {
             configuration = new Configuration(connections, options);
+            passwordlessHelper = new PasswordlessUserHelper(PasswordlessLockActivity.this, configuration.getPasswordlessMode());
             handler.post(new Runnable() {
                 @Override
                 public void run() {
                     lockView.configure(configuration);
-                    reloadRecentPasswordlessData();
+                    reloadRecentPasswordlessData(true);
                 }
             });
             applicationFetcher = null;
@@ -506,11 +463,10 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
                 @Override
                 public void run() {
                     lockView.showProgress(false);
-                    lockView.onPasswordlessCodeSent(lastPasswordlessEmailOrNumber);
+                    lockView.onPasswordlessCodeSent(lastPasswordlessIdentity);
                     if (!options.useCodePasswordless()) {
                         showLinkSentLayout();
                     }
-                    persistRecentPasswordlessData(lastPasswordlessEmailOrNumber, lastPasswordlessCountry);
                 }
             });
         }
@@ -531,7 +487,8 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
     private com.auth0.android.callback.AuthenticationCallback<Credentials> authCallback = new com.auth0.android.callback.AuthenticationCallback<Credentials>() {
         @Override
         public void onSuccess(Credentials credentials) {
-            clearRecentPasswordlessData();
+            Log.e(TAG, "Saving passwordless data for next auto-login.");
+            passwordlessHelper.saveIdentity(lastPasswordlessIdentity, lastPasswordlessCountry);
             deliverAuthenticationResult(credentials);
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
@@ -61,6 +61,7 @@ public class Configuration {
     private boolean mustAcceptTerms;
     private boolean useLabeledSubmitButton;
     private boolean hideMainScreenTitle;
+    private boolean passwordlessAutoSubmit;
     @UsernameStyle
     private int usernameStyle;
     @AuthButtonSize
@@ -171,6 +172,7 @@ public class Configuration {
         mustAcceptTerms = options.mustAcceptTerms();
         useLabeledSubmitButton = options.useLabeledSubmitButton();
         hideMainScreenTitle = options.hideMainScreenTitle();
+        passwordlessAutoSubmit = options.usePasswordlessAutoSubmit();
 
         authStyles = options.getAuthStyles();
         extraSignUpFields = options.getCustomFields();
@@ -290,5 +292,9 @@ public class Configuration {
 
     public boolean hideMainScreenTitle() {
         return hideMainScreenTitle;
+    }
+
+    public boolean usePasswordlessAutoSubmit() {
+        return passwordlessAutoSubmit;
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
@@ -172,7 +172,7 @@ public class Configuration {
         mustAcceptTerms = options.mustAcceptTerms();
         useLabeledSubmitButton = options.useLabeledSubmitButton();
         hideMainScreenTitle = options.hideMainScreenTitle();
-        passwordlessAutoSubmit = options.usePasswordlessAutoSubmit();
+        passwordlessAutoSubmit = options.rememberLastPasswordlessAccount();
 
         authStyles = options.getAuthStyles();
         extraSignUpFields = options.getCustomFields();

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -74,7 +74,7 @@ public class Options implements Parcelable {
     private boolean mustAcceptTerms;
     private boolean useLabeledSubmitButton;
     private boolean hideMainScreenTitle;
-    private boolean passwordlessAutoSubmit;
+    private boolean rememberLastPasswordlessLogin;
     private String defaultDatabaseConnection;
     private List<String> connections;
     private List<String> enterpriseConnectionsUsingWebForm;
@@ -122,7 +122,7 @@ public class Options implements Parcelable {
         useCodePasswordless = in.readByte() != WITHOUT_DATA;
         useLabeledSubmitButton = in.readByte() != WITHOUT_DATA;
         hideMainScreenTitle = in.readByte() != WITHOUT_DATA;
-        passwordlessAutoSubmit = in.readByte() != WITHOUT_DATA;
+        rememberLastPasswordlessLogin = in.readByte() != WITHOUT_DATA;
         defaultDatabaseConnection = in.readString();
         usernameStyle = in.readInt();
         initialScreen = in.readInt();
@@ -198,7 +198,7 @@ public class Options implements Parcelable {
         dest.writeByte((byte) (useCodePasswordless ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (useLabeledSubmitButton ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (hideMainScreenTitle ? HAS_DATA : WITHOUT_DATA));
-        dest.writeByte((byte) (passwordlessAutoSubmit ? HAS_DATA : WITHOUT_DATA));
+        dest.writeByte((byte) (rememberLastPasswordlessLogin ? HAS_DATA : WITHOUT_DATA));
         dest.writeString(defaultDatabaseConnection);
         dest.writeInt(usernameStyle);
         dest.writeInt(initialScreen);
@@ -485,12 +485,12 @@ public class Options implements Parcelable {
         return hideMainScreenTitle;
     }
 
-    public void setPasswordlessAutoSubmit(boolean autoSubmit) {
-        this.passwordlessAutoSubmit = autoSubmit;
+    public void setRememberLastPasswordlessLogin(boolean remember) {
+        this.rememberLastPasswordlessLogin = remember;
     }
 
-    public boolean usePasswordlessAutoSubmit() {
-        return passwordlessAutoSubmit;
+    public boolean rememberLastPasswordlessAccount() {
+        return rememberLastPasswordlessLogin;
     }
 
     public void withConnectionScope(@NonNull String connectionName, @NonNull String scope) {

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -74,6 +74,7 @@ public class Options implements Parcelable {
     private boolean mustAcceptTerms;
     private boolean useLabeledSubmitButton;
     private boolean hideMainScreenTitle;
+    private boolean passwordlessAutoSubmit;
     private String defaultDatabaseConnection;
     private List<String> connections;
     private List<String> enterpriseConnectionsUsingWebForm;
@@ -121,6 +122,7 @@ public class Options implements Parcelable {
         useCodePasswordless = in.readByte() != WITHOUT_DATA;
         useLabeledSubmitButton = in.readByte() != WITHOUT_DATA;
         hideMainScreenTitle = in.readByte() != WITHOUT_DATA;
+        passwordlessAutoSubmit = in.readByte() != WITHOUT_DATA;
         defaultDatabaseConnection = in.readString();
         usernameStyle = in.readInt();
         initialScreen = in.readInt();
@@ -196,6 +198,7 @@ public class Options implements Parcelable {
         dest.writeByte((byte) (useCodePasswordless ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (useLabeledSubmitButton ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (hideMainScreenTitle ? HAS_DATA : WITHOUT_DATA));
+        dest.writeByte((byte) (passwordlessAutoSubmit ? HAS_DATA : WITHOUT_DATA));
         dest.writeString(defaultDatabaseConnection);
         dest.writeInt(usernameStyle);
         dest.writeInt(initialScreen);
@@ -480,6 +483,14 @@ public class Options implements Parcelable {
 
     public boolean hideMainScreenTitle() {
         return hideMainScreenTitle;
+    }
+
+    public void setPasswordlessAutoSubmit(boolean autoSubmit) {
+        this.passwordlessAutoSubmit = autoSubmit;
+    }
+
+    public boolean usePasswordlessAutoSubmit() {
+        return passwordlessAutoSubmit;
     }
 
     public void withConnectionScope(@NonNull String connectionName, @NonNull String scope) {

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/PasswordlessUserHelper.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/PasswordlessUserHelper.java
@@ -1,0 +1,60 @@
+package com.auth0.android.lock.internal.configuration;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.auth0.android.lock.adapters.Country;
+
+public class PasswordlessUserHelper {
+    private static final String LAST_PASSWORDLESS_IDENTITY_KEY = "last_passwordless_identity";
+    private static final String LAST_PASSWORDLESS_COUNTRY_KEY = "last_passwordless_country";
+    private static final String LAST_PASSWORDLESS_MODE_KEY = "last_passwordless_mode";
+    private static final String LOCK_PREFERENCES_NAME = "Lock";
+    private static final String COUNTRY_DATA_DIV = "@";
+
+    private final SharedPreferences sp;
+    @PasswordlessMode
+    private final int passwordlessMode;
+
+    public PasswordlessUserHelper(@NonNull Context context, @PasswordlessMode int passwordlessMode) {
+        sp = context.getSharedPreferences(LOCK_PREFERENCES_NAME, Context.MODE_PRIVATE);
+        this.passwordlessMode = passwordlessMode;
+    }
+
+    public void saveIdentity(@NonNull String identity, @Nullable Country country) {
+        String countryData = country != null ? country.getIsoCode() + COUNTRY_DATA_DIV + country.getDialCode() : null;
+        sp.edit()
+                .putString(LAST_PASSWORDLESS_IDENTITY_KEY, identity)
+                .putString(LAST_PASSWORDLESS_COUNTRY_KEY, countryData)
+                .putInt(LAST_PASSWORDLESS_MODE_KEY, passwordlessMode)
+                .apply();
+    }
+
+    public Country getLastCountry() {
+        Country country = null;
+        String countryInfo = sp.getString(LAST_PASSWORDLESS_COUNTRY_KEY, null);
+        if (countryInfo != null) {
+            String isoCode = countryInfo.split(COUNTRY_DATA_DIV)[0];
+            String dialCode = countryInfo.split(COUNTRY_DATA_DIV)[1];
+            country = new Country(isoCode, dialCode);
+        }
+        return country;
+    }
+
+    public String getLastIdentity() {
+        String identity = sp.getString(LAST_PASSWORDLESS_IDENTITY_KEY, "");
+        Country country = getLastCountry();
+        if (country != null && identity.startsWith(country.getDialCode())) {
+            identity = identity.substring(country.getDialCode().length());
+        }
+        return identity;
+    }
+
+    public boolean hadLoggedInBefore() {
+        @PasswordlessMode
+        int lastMode = sp.getInt(LAST_PASSWORDLESS_MODE_KEY, PasswordlessMode.DISABLED);
+        return lastMode != PasswordlessMode.DISABLED && lastMode == passwordlessMode;
+    }
+}

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordlessFormLayout.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordlessFormLayout.java
@@ -41,7 +41,7 @@ import com.auth0.android.lock.adapters.Country;
 import com.auth0.android.lock.internal.configuration.PasswordlessMode;
 import com.auth0.android.lock.views.interfaces.LockWidgetPasswordless;
 
-public class PasswordlessFormLayout extends LinearLayout implements PasswordlessInputCodeFormView.OnCodeResendListener, PasswordlessRequestCodeFormView.OnAlreadyGotCodeListener {
+public class PasswordlessFormLayout extends LinearLayout implements PasswordlessInputCodeFormView.OnCodeResendListener {
 
     private static final String TAG = PasswordlessFormLayout.class.getSimpleName();
     private static final int MAX_SOCIAL_BIG_BUTTONS_WITH_PASSWORDLESS = 3;
@@ -51,7 +51,6 @@ public class PasswordlessFormLayout extends LinearLayout implements Passwordless
     private TextView orSeparatorMessage;
     private PasswordlessRequestCodeFormView passwordlessRequestCodeLayout;
     private PasswordlessInputCodeFormView passwordlessInputCodeLayout;
-    private boolean showGotCodeButton;
 
     public PasswordlessFormLayout(Context context) {
         super(context);
@@ -116,7 +115,7 @@ public class PasswordlessFormLayout extends LinearLayout implements Passwordless
 
     private void addPasswordlessRequestCodeLayout() {
         if (passwordlessRequestCodeLayout == null) {
-            passwordlessRequestCodeLayout = new PasswordlessRequestCodeFormView(lockWidget, this);
+            passwordlessRequestCodeLayout = new PasswordlessRequestCodeFormView(lockWidget);
         }
         addView(passwordlessRequestCodeLayout);
     }
@@ -199,19 +198,7 @@ public class PasswordlessFormLayout extends LinearLayout implements Passwordless
             passwordlessInputCodeLayout = null;
         }
         addView(passwordlessRequestCodeLayout);
-        passwordlessRequestCodeLayout.showGotCodeButton();
-        showGotCodeButton = true;
         lockWidget.resetHeaderTitle();
-    }
-
-    @Override
-    public void onAlreadyGotCode(String emailOrCode) {
-        codeSent(emailOrCode);
-    }
-
-    @Override
-    public boolean shouldShowGotCodeButton() {
-        return showGotCodeButton;
     }
 
     /**
@@ -229,14 +216,10 @@ public class PasswordlessFormLayout extends LinearLayout implements Passwordless
     public void loadPasswordlessData(String emailOrNumber, @Nullable Country country) {
         if (passwordlessRequestCodeLayout != null) {
             Log.d(TAG, String.format("Loading recent passwordless data into the form. Identity %s with Country %s", emailOrNumber, country));
-            showGotCodeButton = true;
             passwordlessRequestCodeLayout.setInputText(emailOrNumber);
             if (country != null) {
                 passwordlessRequestCodeLayout.onCountryCodeSelected(country.getIsoCode(), country.getDialCode());
-                emailOrNumber = country.getDialCode() + emailOrNumber;
             }
-            passwordlessRequestCodeLayout.setLastEmailOrNumber(emailOrNumber);
-            passwordlessRequestCodeLayout.showGotCodeButton();
         }
     }
 }

--- a/lib/src/main/res/layout/com_auth0_lock_passwordless_request_code_form_view.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_passwordless_request_code_form_view.xml
@@ -48,10 +48,4 @@
         android:layout_height="wrap_content"
         lock:Auth0.InputDataType="username_or_email" />
 
-    <TextView
-        android:id="@+id/com_auth0_lock_got_code"
-        style="@style/Lock.Theme.Text.Link"
-        android:text="@string/com_auth0_lock_title_passwordless_got_code"
-        android:visibility="gone" />
-
 </LinearLayout>

--- a/lib/src/test/java/com/auth0/android/lock/PasswordlessIdentityHelperTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/PasswordlessIdentityHelperTest.java
@@ -1,0 +1,147 @@
+package com.auth0.android.lock;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.auth0.android.lock.adapters.Country;
+import com.auth0.android.lock.internal.configuration.PasswordlessMode;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class PasswordlessIdentityHelperTest {
+
+    private Context context;
+    private SharedPreferences sp;
+    private SharedPreferences.Editor editor;
+
+    @SuppressLint("CommitPrefEdits")
+    @Before
+    public void setUp() throws Exception {
+        context = Mockito.mock(Context.class);
+        sp = Mockito.mock(SharedPreferences.class);
+        editor = Mockito.mock(SharedPreferences.Editor.class);
+        when(context.getSharedPreferences(eq("Lock"), eq(Context.MODE_PRIVATE))).thenReturn(sp);
+        when(sp.edit()).thenReturn(editor);
+        when(editor.putString(anyString(), anyString())).thenReturn(editor);
+        when(editor.putInt(anyString(), anyInt())).thenReturn(editor);
+    }
+
+    @Test
+    public void shouldSaveIdentity() throws Exception {
+        PasswordlessIdentityHelper helper = new PasswordlessIdentityHelper(context, PasswordlessMode.SMS_CODE);
+        helper.saveIdentity("me@auth0.com", null);
+
+        verify(editor).putString("last_passwordless_identity", "me@auth0.com");
+        verify(editor).putString("last_passwordless_country", null);
+        verify(editor).putInt("last_passwordless_mode", PasswordlessMode.SMS_CODE);
+    }
+
+    @Test
+    public void shouldSaveIdentityWithCountry() throws Exception {
+        PasswordlessIdentityHelper helper = new PasswordlessIdentityHelper(context, PasswordlessMode.SMS_CODE);
+        helper.saveIdentity("1234567890", new Country("ar", "54"));
+
+        verify(editor).putString("last_passwordless_identity", "1234567890");
+        verify(editor).putString("last_passwordless_country", "ar@54");
+        verify(editor).putInt("last_passwordless_mode", PasswordlessMode.SMS_CODE);
+    }
+
+    @Test
+    public void shouldGetSavedIdentity() throws Exception {
+        PasswordlessIdentityHelper helper = new PasswordlessIdentityHelper(context, PasswordlessMode.SMS_CODE);
+        when(sp.getString(eq("last_passwordless_identity"), anyString())).thenReturn("me@auth0.com");
+
+        String identity = helper.getLastIdentity();
+        assertThat(identity, is("me@auth0.com"));
+    }
+
+    @Test
+    public void shouldGetSavedCountry() throws Exception {
+        PasswordlessIdentityHelper helper = new PasswordlessIdentityHelper(context, PasswordlessMode.SMS_CODE);
+        when(sp.getString(eq("last_passwordless_country"), anyString())).thenReturn("ar@54");
+
+        Country country = helper.getLastCountry();
+        assertThat(country, is(notNullValue()));
+        assertThat(country.getDialCode(), is("54"));
+        assertThat(country.getIsoCode(), is("ar"));
+    }
+
+    @Test
+    public void shouldNotHaveLoggedInBeforeIfCurrentPasswordlessModeIsDisabled() throws Exception {
+        PasswordlessIdentityHelper helper = new PasswordlessIdentityHelper(context, PasswordlessMode.DISABLED);
+        assertThat(helper.hasLoggedInBefore(), is(false));
+    }
+
+    @Test
+    public void shouldNotHaveLoggedInBeforeIfLastPasswordlessModeIsDisabled() throws Exception {
+        PasswordlessIdentityHelper helper = new PasswordlessIdentityHelper(context, PasswordlessMode.SMS_CODE);
+        when(sp.getInt(eq("last_passwordless_mode"), anyInt())).thenReturn(PasswordlessMode.DISABLED);
+        assertThat(helper.hasLoggedInBefore(), is(false));
+    }
+
+    @Test
+    public void shouldNotHaveLoggedInBeforeOnDifferentConnections() throws Exception {
+        PasswordlessIdentityHelper helper = new PasswordlessIdentityHelper(context, PasswordlessMode.SMS_CODE);
+        when(sp.getInt(eq("last_passwordless_mode"), anyInt())).thenReturn(PasswordlessMode.EMAIL_CODE);
+        assertThat(helper.hasLoggedInBefore(), is(false));
+        when(sp.getInt(eq("last_passwordless_mode"), anyInt())).thenReturn(PasswordlessMode.EMAIL_LINK);
+        assertThat(helper.hasLoggedInBefore(), is(false));
+
+        helper = new PasswordlessIdentityHelper(context, PasswordlessMode.SMS_LINK);
+        when(sp.getInt(eq("last_passwordless_mode"), anyInt())).thenReturn(PasswordlessMode.EMAIL_CODE);
+        assertThat(helper.hasLoggedInBefore(), is(false));
+        when(sp.getInt(eq("last_passwordless_mode"), anyInt())).thenReturn(PasswordlessMode.EMAIL_LINK);
+        assertThat(helper.hasLoggedInBefore(), is(false));
+
+        helper = new PasswordlessIdentityHelper(context, PasswordlessMode.EMAIL_CODE);
+        when(sp.getInt(eq("last_passwordless_mode"), anyInt())).thenReturn(PasswordlessMode.SMS_CODE);
+        assertThat(helper.hasLoggedInBefore(), is(false));
+        when(sp.getInt(eq("last_passwordless_mode"), anyInt())).thenReturn(PasswordlessMode.SMS_LINK);
+        assertThat(helper.hasLoggedInBefore(), is(false));
+
+        helper = new PasswordlessIdentityHelper(context, PasswordlessMode.EMAIL_LINK);
+        when(sp.getInt(eq("last_passwordless_mode"), anyInt())).thenReturn(PasswordlessMode.SMS_CODE);
+        assertThat(helper.hasLoggedInBefore(), is(false));
+        when(sp.getInt(eq("last_passwordless_mode"), anyInt())).thenReturn(PasswordlessMode.SMS_LINK);
+        assertThat(helper.hasLoggedInBefore(), is(false));
+    }
+
+    @Test
+    public void shouldHaveLoggedInBeforeOnSameConnections() throws Exception {
+        PasswordlessIdentityHelper helper = new PasswordlessIdentityHelper(context, PasswordlessMode.EMAIL_CODE);
+        when(sp.getInt(eq("last_passwordless_mode"), anyInt())).thenReturn(PasswordlessMode.EMAIL_CODE);
+        assertThat(helper.hasLoggedInBefore(), is(true));
+        when(sp.getInt(eq("last_passwordless_mode"), anyInt())).thenReturn(PasswordlessMode.EMAIL_LINK);
+        assertThat(helper.hasLoggedInBefore(), is(true));
+
+        helper = new PasswordlessIdentityHelper(context, PasswordlessMode.EMAIL_LINK);
+        when(sp.getInt(eq("last_passwordless_mode"), anyInt())).thenReturn(PasswordlessMode.EMAIL_CODE);
+        assertThat(helper.hasLoggedInBefore(), is(true));
+        when(sp.getInt(eq("last_passwordless_mode"), anyInt())).thenReturn(PasswordlessMode.EMAIL_LINK);
+        assertThat(helper.hasLoggedInBefore(), is(true));
+
+        helper = new PasswordlessIdentityHelper(context, PasswordlessMode.SMS_CODE);
+        when(sp.getInt(eq("last_passwordless_mode"), anyInt())).thenReturn(PasswordlessMode.SMS_CODE);
+        assertThat(helper.hasLoggedInBefore(), is(true));
+        when(sp.getInt(eq("last_passwordless_mode"), anyInt())).thenReturn(PasswordlessMode.SMS_LINK);
+        assertThat(helper.hasLoggedInBefore(), is(true));
+
+        helper = new PasswordlessIdentityHelper(context, PasswordlessMode.SMS_LINK);
+        when(sp.getInt(eq("last_passwordless_mode"), anyInt())).thenReturn(PasswordlessMode.SMS_CODE);
+        assertThat(helper.hasLoggedInBefore(), is(true));
+        when(sp.getInt(eq("last_passwordless_mode"), anyInt())).thenReturn(PasswordlessMode.SMS_LINK);
+        assertThat(helper.hasLoggedInBefore(), is(true));
+    }
+}

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/ApplicationGsonTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/ApplicationGsonTest.java
@@ -69,25 +69,46 @@ public class ApplicationGsonTest extends GsonBaseTest {
     @Test
     public void shouldRequireId() throws Exception {
         expectedException.expect(JsonParseException.class);
+        expectedException.expectMessage("Missing required attribute id");
         buildApplicationFrom(new StringReader("{\"tenant\":\"samples\",\"authorize\":\"https://samples.auth0.com/authorize\",\"strategies\":[{\"name\":\"twitter\",\"connections\":[{\"name\":\"twitter\"}]}]}"));
     }
 
     @Test
     public void shouldRequireTenant() throws Exception {
         expectedException.expect(JsonParseException.class);
+        expectedException.expectMessage("Missing required attribute tenant");
         buildApplicationFrom(new StringReader("{\"id\":\"CBBlULbbyQHSVWj5EqZSTMhUrJAS3UFA\",\"authorize\":\"https://samples.auth0.com/authorize\",\"strategies\":[{\"name\":\"twitter\",\"connections\":[{\"name\":\"twitter\"}]}]}"));
     }
 
     @Test
     public void shouldRequireAuthorize() throws Exception {
         expectedException.expect(JsonParseException.class);
+        expectedException.expectMessage("Missing required attribute authorize");
         buildApplicationFrom(new StringReader("{\"id\":\"CBBlULbbyQHSVWj5EqZSTMhUrJAS3UFA\",\"tenant\":\"samples\",\"strategies\":[{\"name\":\"twitter\",\"connections\":[{\"name\":\"twitter\"}]}]}"));
+    }
+
+    @Test
+    public void shouldAllowEmptyAuthorize() throws Exception {
+        buildApplicationFrom(new StringReader("{\"id\":\"CBBlULbbyQHSVWj5EqZSTMhUrJAS3UFA\",\"callback\":\"https://samples.auth0.com/callback\",\"tenant\":\"samples\",\"authorize\":\"\",\"strategies\":[{\"name\":\"twitter\",\"connections\":[{\"name\":\"twitter\"}]}]}"));
+    }
+
+    @Test
+    public void shouldRequireCallback() throws Exception {
+        expectedException.expect(JsonParseException.class);
+        expectedException.expectMessage("Missing required attribute callback");
+        buildApplicationFrom(new StringReader("{\"id\":\"CBBlULbbyQHSVWj5EqZSTMhUrJAS3UFA\",\"authorize\":\"https://samples.auth0.com/authorize\",\"tenant\":\"samples\",\"strategies\":[{\"name\":\"twitter\",\"connections\":[{\"name\":\"twitter\"}]}]}"));
+    }
+
+    @Test
+    public void shouldAllowEmptyCallback() throws Exception {
+        buildApplicationFrom(new StringReader("{\"id\":\"CBBlULbbyQHSVWj5EqZSTMhUrJAS3UFA\",\"tenant\":\"samples\",\"authorize\":\"https://samples.auth0.com/authorize\",\"callback\":\"\",\"strategies\":[{\"name\":\"twitter\",\"connections\":[{\"name\":\"twitter\"}]}]}"));
     }
 
     @Test
     public void shouldRequireStrategies() throws Exception {
         expectedException.expect(JsonParseException.class);
-        buildApplicationFrom(new StringReader("{\"id\":\"CBBlULbbyQHSVWj5EqZSTMhUrJAS3UFA\",\"tenant\":\"samples\",\"authorize\":\"https://samples.auth0.com/authorize\"}"));
+        expectedException.expectMessage("Missing required attribute strategies");
+        buildApplicationFrom(new StringReader("{\"id\":\"CBBlULbbyQHSVWj5EqZSTMhUrJAS3UFA\",\"tenant\":\"samples\",\"authorize\":\"https://samples.auth0.com/authorize\",\"callback\":\"https://samples.auth0.com/callback\"}"));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
@@ -525,7 +525,7 @@ public class ConfigurationTest extends GsonBaseTest {
 
     @Test
     public void shouldUsePasswordlessAutoSubmit() throws Exception {
-        options.setPasswordlessAutoSubmit(true);
+        options.setRememberLastPasswordlessLogin(true);
         configuration = new Configuration(connections, options);
         assertThat(configuration.usePasswordlessAutoSubmit(), is(true));
     }

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
@@ -105,6 +105,8 @@ public class ConfigurationTest extends GsonBaseTest {
         assertThat(configuration.getPasswordPolicy(), is(PasswordStrength.NONE));
         assertThat(configuration.mustAcceptTerms(), is(false));
         assertThat(configuration.useLabeledSubmitButton(), is(true));
+        assertThat(configuration.hideMainScreenTitle(), is(false));
+        assertThat(configuration.usePasswordlessAutoSubmit(), is(false));
     }
 
     @Test
@@ -498,6 +500,34 @@ public class ConfigurationTest extends GsonBaseTest {
         options.setMustAcceptTerms(true);
         configuration = new Configuration(connections, options);
         assertThat(configuration.mustAcceptTerms(), is(true));
+    }
+
+    @Test
+    public void shouldNotUseLabeledSubmitButton() throws Exception {
+        options.setUseLabeledSubmitButton(false);
+        configuration = new Configuration(connections, options);
+        assertThat(configuration.useLabeledSubmitButton(), is(false));
+    }
+
+    @Test
+    public void shouldGetPasswordPolicy() throws Exception {
+        options.useDatabaseConnection("with-strength");
+        configuration = new Configuration(connections, options);
+        assertThat(configuration.getPasswordPolicy(), is(PasswordStrength.EXCELLENT));
+    }
+
+    @Test
+    public void shouldHideMainScreenTitle() throws Exception {
+        options.setHideMainScreenTitle(true);
+        configuration = new Configuration(connections, options);
+        assertThat(configuration.hideMainScreenTitle(), is(true));
+    }
+
+    @Test
+    public void shouldUsePasswordlessAutoSubmit() throws Exception {
+        options.setPasswordlessAutoSubmit(true);
+        configuration = new Configuration(connections, options);
+        assertThat(configuration.usePasswordlessAutoSubmit(), is(true));
     }
 
     private Configuration unfilteredConfig() {

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -168,6 +168,20 @@ public class OptionsTest {
         assertThat(options.hideMainScreenTitle(), is(equalTo(parceledOptions.hideMainScreenTitle())));
     }
 
+
+    @Test
+    public void shouldSetPasswordlessAutoSubmit() throws Exception {
+        options.setPasswordlessAutoSubmit(true);
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.usePasswordlessAutoSubmit(), is(true));
+        assertThat(options.usePasswordlessAutoSubmit(), is(equalTo(parceledOptions.usePasswordlessAutoSubmit())));
+    }
+
     @Test
     public void shouldUseBigSocialButtonStyle() throws Exception {
         options.setAuthButtonSize(AuthButtonSize.BIG);
@@ -654,6 +668,7 @@ public class OptionsTest {
         assertThat(options.mustAcceptTerms(), is(false));
         assertThat(options.useLabeledSubmitButton(), is(true));
         assertThat(options.hideMainScreenTitle(), is(false));
+        assertThat(options.usePasswordlessAutoSubmit(), is(false));
         assertThat(options.getScope(), is(nullValue()));
         assertThat(options.getAudience(), is(nullValue()));
         assertThat(options.getScheme(), is(nullValue()));
@@ -680,6 +695,7 @@ public class OptionsTest {
         options.setLoginAfterSignUp(true);
         options.setUseLabeledSubmitButton(true);
         options.setHideMainScreenTitle(true);
+        options.setPasswordlessAutoSubmit(true);
 
 
         Parcel parcel = Parcel.obtain();
@@ -700,6 +716,7 @@ public class OptionsTest {
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
         assertThat(options.useLabeledSubmitButton(), is(equalTo(parceledOptions.useLabeledSubmitButton())));
         assertThat(options.hideMainScreenTitle(), is(equalTo(parceledOptions.hideMainScreenTitle())));
+        assertThat(options.usePasswordlessAutoSubmit(), is(equalTo(parceledOptions.usePasswordlessAutoSubmit())));
     }
 
     @Test
@@ -717,6 +734,7 @@ public class OptionsTest {
         options.setLoginAfterSignUp(false);
         options.setUseLabeledSubmitButton(false);
         options.setHideMainScreenTitle(false);
+        options.setPasswordlessAutoSubmit(false);
 
 
         Parcel parcel = Parcel.obtain();
@@ -737,6 +755,7 @@ public class OptionsTest {
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
         assertThat(options.useLabeledSubmitButton(), is(equalTo(parceledOptions.useLabeledSubmitButton())));
         assertThat(options.hideMainScreenTitle(), is(equalTo(parceledOptions.hideMainScreenTitle())));
+        assertThat(options.usePasswordlessAutoSubmit(), is(equalTo(parceledOptions.usePasswordlessAutoSubmit())));
     }
 
 

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -171,15 +171,15 @@ public class OptionsTest {
 
     @Test
     public void shouldSetPasswordlessAutoSubmit() throws Exception {
-        options.setPasswordlessAutoSubmit(true);
+        options.setRememberLastPasswordlessLogin(true);
 
         Parcel parcel = Parcel.obtain();
         options.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(options.usePasswordlessAutoSubmit(), is(true));
-        assertThat(options.usePasswordlessAutoSubmit(), is(equalTo(parceledOptions.usePasswordlessAutoSubmit())));
+        assertThat(options.rememberLastPasswordlessAccount(), is(true));
+        assertThat(options.rememberLastPasswordlessAccount(), is(equalTo(parceledOptions.rememberLastPasswordlessAccount())));
     }
 
     @Test
@@ -668,7 +668,7 @@ public class OptionsTest {
         assertThat(options.mustAcceptTerms(), is(false));
         assertThat(options.useLabeledSubmitButton(), is(true));
         assertThat(options.hideMainScreenTitle(), is(false));
-        assertThat(options.usePasswordlessAutoSubmit(), is(false));
+        assertThat(options.rememberLastPasswordlessAccount(), is(false));
         assertThat(options.getScope(), is(nullValue()));
         assertThat(options.getAudience(), is(nullValue()));
         assertThat(options.getScheme(), is(nullValue()));
@@ -695,7 +695,7 @@ public class OptionsTest {
         options.setLoginAfterSignUp(true);
         options.setUseLabeledSubmitButton(true);
         options.setHideMainScreenTitle(true);
-        options.setPasswordlessAutoSubmit(true);
+        options.setRememberLastPasswordlessLogin(true);
 
 
         Parcel parcel = Parcel.obtain();
@@ -716,7 +716,7 @@ public class OptionsTest {
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
         assertThat(options.useLabeledSubmitButton(), is(equalTo(parceledOptions.useLabeledSubmitButton())));
         assertThat(options.hideMainScreenTitle(), is(equalTo(parceledOptions.hideMainScreenTitle())));
-        assertThat(options.usePasswordlessAutoSubmit(), is(equalTo(parceledOptions.usePasswordlessAutoSubmit())));
+        assertThat(options.rememberLastPasswordlessAccount(), is(equalTo(parceledOptions.rememberLastPasswordlessAccount())));
     }
 
     @Test
@@ -734,7 +734,7 @@ public class OptionsTest {
         options.setLoginAfterSignUp(false);
         options.setUseLabeledSubmitButton(false);
         options.setHideMainScreenTitle(false);
-        options.setPasswordlessAutoSubmit(false);
+        options.setRememberLastPasswordlessLogin(false);
 
 
         Parcel parcel = Parcel.obtain();
@@ -755,7 +755,7 @@ public class OptionsTest {
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
         assertThat(options.useLabeledSubmitButton(), is(equalTo(parceledOptions.useLabeledSubmitButton())));
         assertThat(options.hideMainScreenTitle(), is(equalTo(parceledOptions.hideMainScreenTitle())));
-        assertThat(options.usePasswordlessAutoSubmit(), is(equalTo(parceledOptions.usePasswordlessAutoSubmit())));
+        assertThat(options.rememberLastPasswordlessAccount(), is(equalTo(parceledOptions.rememberLastPasswordlessAccount())));
     }
 
 

--- a/lib/src/test/resources/appinfo.json
+++ b/lib/src/test/resources/appinfo.json
@@ -1,110 +1,150 @@
 {
-    "id": "CBBlULbbyQHSVWj5EqZSTMhUrJAS3UFA",
-    "tenant": "samples",
-    "subscription": "dev",
-    "authorize": "https://samples.auth0.com/authorize",
-    "callback": "http://localhost:3000/",
-    "hasAllowedOrigins": true,
-    "strategies": [{
-                   "name": "auth0",
-                   "connections": [{
-                                   "name": "Username-Password-Authentication",
-                                   "domain": null,
-                                   "forgot_password_url": "https://login.auth0.com/lo/forgot?wtrealm=urn:auth0:samples:Username-Password-Authentication",
-                                   "signup_url": "https://login.auth0.com/lo/signup?wtrealm=urn:auth0:samples:Username-Password-Authentication",
-                                   "showSignup": true,
-                                   "showForgot": true,
-                                   "requires_username": false
-                                   }, {
-                                   "name": "CustomDatabase",
-                                   "forgot_password_url": "https://login.auth0.com/lo/forgot?wtrealm=urn:auth0:samples:CustomDatabase",
-                                   "signup_url": "https://login.auth0.com/lo/signup?wtrealm=urn:auth0:samples:CustomDatabase",
-                                   "showSignup": true,
-                                   "showForgot": true,
-                                   "requires_username": false
-                                   }, {
-                                   "name": "RestrictiveDatabase",
-                                   "forgot_password_url": "https://login.auth0.com/lo/forgot?wtrealm=urn:auth0:samples:RestrictiveDatabase",
-                                   "signup_url": "https://login.auth0.com/lo/signup?wtrealm=urn:auth0:samples:RestrictiveDatabase",
-                                   "showSignup": false,
-                                   "showForgot": false,
-                                   "requires_username": false
-                                 }]
-                   }, {
-                   "name": "ad",
-                   "connections": [{
-                                   "name": "MyAD",
-                                   "domain": "pepe.com",
-                                   "domain_aliases": [
-                                                      "pepe.com",
-                                                      "pep.com"
-                                                      ]
-                                   }, {
-                                   "name": "mySecondAD",
-                                   "domain": "second.com",
-                                   "domain_aliases": [
-                                                      "second.com"
-                                                      ]
-                                   }]
-                   }, {
-                   "name": "google-apps",
-                   "connections": [{
-                                   "name": "auth0.com",
-                                   "domain": "auth0.com",
-                                   "domain_aliases": [
-                                                      "auth10.com"
-                                                      ],
-                                   "scope": [
-                                             "email",
-                                             "profile"
-                                             ]
-                                   }]
-                   }, {
-                   "name": "facebook",
-                   "connections": [{
-                                   "name": "facebook",
-                                   "scope": "public_profile"
-                                   }]
-                   }, {
-                   "name": "google-oauth2",
-                   "connections": [{
-                                   "name": "google-oauth2",
-                                   "scope": [
-                                             "email",
-                                             "profile"
-                                             ]
-                                   }]
-                   }, {
-                   "name": "instagram",
-                   "connections": [{
-                                   "name": "instagram",
-                                   "scope": [
-                                             "basic"
-                                             ]
-                                   }]
-                   }, {
-                   "name": "sms",
-                   "connections": [{
-                                   "name": "sms"
-                                   },
-                                   {
-                                   "name": "my-sms-connection"
-                                   }]
-                   }, {
-                   "name": "email",
-                   "connections": [{
-                                   "name": "email"
-                                   }]
-                   }, {
-                   "name": "twitter",
-                   "connections": [{
-                                   "name": "twitter"
-                                   },
-                                   {
-                                     "name": "twitter-dev"
-                                   }]
-                   }, {
-                   "name": "linkedin",
-                   "connections": []
-                   }]
+  "id": "CBBlULbbyQHSVWj5EqZSTMhUrJAS3UFA",
+  "tenant": "samples",
+  "subscription": "dev",
+  "authorize": "https://samples.auth0.com/authorize",
+  "callback": "http://localhost:3000/",
+  "hasAllowedOrigins": true,
+  "strategies": [
+    {
+      "name": "auth0",
+      "connections": [
+        {
+          "name": "Username-Password-Authentication",
+          "domain": null,
+          "forgot_password_url": "https://login.auth0.com/lo/forgot?wtrealm=urn:auth0:samples:Username-Password-Authentication",
+          "signup_url": "https://login.auth0.com/lo/signup?wtrealm=urn:auth0:samples:Username-Password-Authentication",
+          "showSignup": true,
+          "showForgot": true,
+          "requires_username": false
+        },
+        {
+          "name": "CustomDatabase",
+          "forgot_password_url": "https://login.auth0.com/lo/forgot?wtrealm=urn:auth0:samples:CustomDatabase",
+          "signup_url": "https://login.auth0.com/lo/signup?wtrealm=urn:auth0:samples:CustomDatabase",
+          "showSignup": true,
+          "showForgot": true,
+          "requires_username": false
+        },
+        {
+          "name": "RestrictiveDatabase",
+          "forgot_password_url": "https://login.auth0.com/lo/forgot?wtrealm=urn:auth0:samples:RestrictiveDatabase",
+          "signup_url": "https://login.auth0.com/lo/signup?wtrealm=urn:auth0:samples:RestrictiveDatabase",
+          "showSignup": false,
+          "showForgot": false,
+          "requires_username": false
+        },
+        {
+          "name": "with-strength",
+          "forgot_password_url": "https://login.auth0.com/lo/forgot?wtrealm=urn:auth0:lbalmaceda:with-strength",
+          "signup_url": "https://login.auth0.com/lo/signup?wtrealm=urn:auth0:lbalmaceda:with-strength",
+          "passwordPolicy": "excellent",
+          "showSignup": true,
+          "showForgot": true
+        }
+      ]
+    },
+    {
+      "name": "ad",
+      "connections": [
+        {
+          "name": "MyAD",
+          "domain": "pepe.com",
+          "domain_aliases": [
+            "pepe.com",
+            "pep.com"
+          ]
+        },
+        {
+          "name": "mySecondAD",
+          "domain": "second.com",
+          "domain_aliases": [
+            "second.com"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "google-apps",
+      "connections": [
+        {
+          "name": "auth0.com",
+          "domain": "auth0.com",
+          "domain_aliases": [
+            "auth10.com"
+          ],
+          "scope": [
+            "email",
+            "profile"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "facebook",
+      "connections": [
+        {
+          "name": "facebook",
+          "scope": "public_profile"
+        }
+      ]
+    },
+    {
+      "name": "google-oauth2",
+      "connections": [
+        {
+          "name": "google-oauth2",
+          "scope": [
+            "email",
+            "profile"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "instagram",
+      "connections": [
+        {
+          "name": "instagram",
+          "scope": [
+            "basic"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "sms",
+      "connections": [
+        {
+          "name": "sms"
+        },
+        {
+          "name": "my-sms-connection"
+        }
+      ]
+    },
+    {
+      "name": "email",
+      "connections": [
+        {
+          "name": "email"
+        }
+      ]
+    },
+    {
+      "name": "twitter",
+      "connections": [
+        {
+          "name": "twitter"
+        },
+        {
+          "name": "twitter-dev"
+        }
+      ]
+    },
+    {
+      "name": "linkedin",
+      "connections": []
+    }
+  ]
 }


### PR DESCRIPTION
If the user has already logged in successfully in the past using the same passwordless connection that he's now trying to log in with, the email/phone field is auto completed with that identity and the form is submitted. Users can still go to the previous screen by pressing the back key or waiting for the "retry" link to appear after a few seconds.

By default this behavior is disabled although it can be changed by calling `rememberLastLogin(true)` on the PasswordlessLock.Builder.