### PR TITLE
Show Terms of Service and Privacy Policy on Passwordless

### DIFF
--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
@@ -56,6 +56,7 @@ public class DemoActivity extends AppCompatActivity {
     private View rootLayout;
     private RadioGroup groupSubmitMode;
     private CheckBox checkboxClosable;
+    private CheckBox checkboxHasTermsOfUse;
     private RadioGroup groupPasswordlessChannel;
     private RadioGroup groupPasswordlessMode;
     private CheckBox checkboxConnectionsDB;
@@ -85,6 +86,7 @@ public class DemoActivity extends AppCompatActivity {
         groupSubmitMode = (RadioGroup) findViewById(R.id.group_submitmode);
         checkboxClosable = (CheckBox) findViewById(R.id.checkbox_closable);
         checkboxHideMainScreenTitle = (CheckBox) findViewById(R.id.checkbox_hide_title);
+        checkboxClosable = (CheckBox) findViewById(R.id.checkbox_has_terms_or_use);
 
         checkboxConnectionsDB = (CheckBox) findViewById(R.id.checkbox_connections_db);
         checkboxConnectionsEnterprise = (CheckBox) findViewById(R.id.checkbox_connections_enterprise);
@@ -172,6 +174,7 @@ public class DemoActivity extends AppCompatActivity {
                 builder.setDefaultDatabaseConnection("Username-Password-Authentication");
             }
         }
+
         builder.hideMainScreenTitle(checkboxHideMainScreenTitle.isChecked());
         lock = builder.build(this);
 
@@ -197,8 +200,11 @@ public class DemoActivity extends AppCompatActivity {
 
         builder.allowedConnections(generateConnections());
         builder.hideMainScreenTitle(checkboxHideMainScreenTitle.isChecked());
+        builder.setShowTermsOfUse(checkboxClosable.isChecked());
+
 
         passwordlessLock = builder.build(this);
+
 
         startActivity(passwordlessLock.newIntent(this));
     }

--- a/app/src/main/res/layout/demo_activity.xml
+++ b/app/src/main/res/layout/demo_activity.xml
@@ -76,6 +76,13 @@
                 android:text="Hide Main Title" />
         </LinearLayout>
 
+        <CheckBox
+            android:id="@+id/checkbox_has_terms_or_use"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="true"
+            android:text="Show terms of use for Passwordless" />
+
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -415,5 +415,40 @@ public class PasswordlessLock {
             }
             return this;
         }
+
+        /**
+         * Choose a custom Privacy Policy URL to access when the user clicks the link on the Sign Up form.
+         * The default value is 'https://auth0.com/privacy'
+         *
+         * @param url a valid url to use.
+         * @return the current builder instance
+         */
+        public Builder setPrivacyURL(@NonNull String url) {
+            options.setPrivacyURL(url);
+            return this;
+        }
+
+        /**
+         * Choose a custom Terms of Service URL to access when the user clicks the link on the Sign Up form.
+         * The default value is 'https://auth0.com/terms'
+         *
+         * @param url a valid url to use.
+         * @return the current builder instance
+         */
+        public Builder setTermsURL(@NonNull String url) {
+            options.setTermsURL(url);
+            return this;
+        }
+
+        /**
+         * Whether the PasswordlessLockActivity display or not Terms of Service and Privacy Policy banner.
+         *
+         * @param showTermsOfUse or not. By default, the LockActivity is not closable.
+         * @return the current builder instance
+         */
+        public Builder setShowTermsOfUse(boolean showTermsOfUse) {
+            options.setShowTermsOfUse(showTermsOfUse);
+            return this;
+        }
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
@@ -62,6 +62,7 @@ public class Configuration {
     private boolean useLabeledSubmitButton;
     private boolean hideMainScreenTitle;
     private boolean passwordlessAutoSubmit;
+    private boolean showTermsOfUse;
     @UsernameStyle
     private int usernameStyle;
     @AuthButtonSize
@@ -173,6 +174,7 @@ public class Configuration {
         useLabeledSubmitButton = options.useLabeledSubmitButton();
         hideMainScreenTitle = options.hideMainScreenTitle();
         passwordlessAutoSubmit = options.rememberLastPasswordlessAccount();
+        showTermsOfUse = options.showTermsOfUse();
 
         authStyles = options.getAuthStyles();
         extraSignUpFields = options.getCustomFields();
@@ -296,5 +298,9 @@ public class Configuration {
 
     public boolean usePasswordlessAutoSubmit() {
         return passwordlessAutoSubmit;
+    }
+
+    public boolean showTermsOfUse() {
+        return showTermsOfUse;
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -75,6 +75,7 @@ public class Options implements Parcelable {
     private boolean useLabeledSubmitButton;
     private boolean hideMainScreenTitle;
     private boolean rememberLastPasswordlessLogin;
+    private boolean showTermsOfUse;
     private String defaultDatabaseConnection;
     private List<String> connections;
     private List<String> enterpriseConnectionsUsingWebForm;
@@ -101,6 +102,7 @@ public class Options implements Parcelable {
         useCodePasswordless = true;
         usePKCE = true;
         useLabeledSubmitButton = true;
+        showTermsOfUse = true;
         authenticationParameters = new HashMap<>();
         authStyles = new HashMap<>();
         connectionsScope = new HashMap<>();
@@ -123,6 +125,7 @@ public class Options implements Parcelable {
         useLabeledSubmitButton = in.readByte() != WITHOUT_DATA;
         hideMainScreenTitle = in.readByte() != WITHOUT_DATA;
         rememberLastPasswordlessLogin = in.readByte() != WITHOUT_DATA;
+        showTermsOfUse = in.readByte() != WITHOUT_DATA;
         defaultDatabaseConnection = in.readString();
         usernameStyle = in.readInt();
         initialScreen = in.readInt();
@@ -199,6 +202,7 @@ public class Options implements Parcelable {
         dest.writeByte((byte) (useLabeledSubmitButton ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (hideMainScreenTitle ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (rememberLastPasswordlessLogin ? HAS_DATA : WITHOUT_DATA));
+        dest.writeByte((byte) (showTermsOfUse ? HAS_DATA : WITHOUT_DATA));
         dest.writeString(defaultDatabaseConnection);
         dest.writeInt(usernameStyle);
         dest.writeInt(initialScreen);
@@ -491,6 +495,14 @@ public class Options implements Parcelable {
 
     public boolean rememberLastPasswordlessAccount() {
         return rememberLastPasswordlessLogin;
+    }
+
+    public void setShowTermsOfUse(boolean showTermsOfUse) {
+        this.showTermsOfUse = showTermsOfUse;
+    }
+
+    public boolean showTermsOfUse() {
+        return showTermsOfUse;
     }
 
     public void withConnectionScope(@NonNull String connectionName, @NonNull String scope) {


### PR DESCRIPTION
Add possibility to show Terms of Service and Privacy Policy on Passwordlees by setting
_setShowTermsOfUse_. By default it's _true_
![screenshot_1491413792](https://cloud.githubusercontent.com/assets/26456688/24718727/b96b9c56-1a3f-11e7-9231-7588f2f1798d.png)
