### PR TITLE
Send login_hint on enterprise web auth when username/email is available

### DIFF
--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
@@ -217,6 +217,8 @@ public class DemoActivity extends AppCompatActivity {
         if (checkboxConnectionsEnterprise.isChecked()) {
             connections.add("ad");
             connections.add("another");
+            connections.add("fake-saml");
+            connections.add("contoso-ad");
         }
         if (checkboxConnectionsSocial.isChecked()) {
             connections.add("google-oauth2");

--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -77,6 +77,7 @@ import com.squareup.okhttp.OkHttpClient;
 import com.squareup.otto.Bus;
 import com.squareup.otto.Subscribe;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -334,12 +335,9 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
         }
 
         Log.v(TAG, "Looking for a provider to use /authorize with the connection " + connection);
-        HashMap<String, Object> authParameters = new HashMap<>(options.getAuthenticationParameters());
-        if (!TextUtils.isEmpty(event.getUsername())) {
-            authParameters.put(KEY_LOGIN_HINT, event.getUsername());
-        }
         currentProvider = AuthResolver.providerFor(event.getStrategy(), connection);
         if (currentProvider != null) {
+            HashMap<String, Object> authParameters = new HashMap<>(options.getAuthenticationParameters());
             final String connectionScope = options.getConnectionsScope().get(connection);
             if (connectionScope != null) {
                 authParameters.put(Constants.CONNECTION_SCOPE_KEY, connectionScope);
@@ -352,13 +350,20 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
             if (audience != null && options.getAccount().isOIDCConformant()) {
                 authParameters.put(ParameterBuilder.AUDIENCE_KEY, audience);
             }
+            if (!TextUtils.isEmpty(event.getUsername())) {
+                authParameters.put(KEY_LOGIN_HINT, event.getUsername());
+            }
             currentProvider.setParameters(authParameters);
             currentProvider.start(this, authProviderCallback, PERMISSION_REQUEST_CODE, CUSTOM_AUTH_REQUEST_CODE);
             return;
         }
 
+        Map<String, Object> extraAuthParameters = null;
+        if (!TextUtils.isEmpty(event.getUsername())) {
+            extraAuthParameters = Collections.singletonMap(KEY_LOGIN_HINT, (Object) event.getUsername());
+        }
         Log.d(TAG, "Couldn't find an specific provider, using the default: " + WebAuthProvider.class.getSimpleName());
-        webProvider.start(this, connection, authParameters, authProviderCallback, WEB_AUTH_REQUEST_CODE);
+        webProvider.start(this, connection, extraAuthParameters, authProviderCallback, WEB_AUTH_REQUEST_CODE);
     }
 
     @SuppressWarnings("unused")

--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -38,6 +38,7 @@ import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v7.app.AppCompatActivity;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
@@ -84,6 +85,7 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
 
     private static final String TAG = LockActivity.class.getSimpleName();
     private static final String KEY_VERIFICATION_CODE = "mfa_code";
+    private static final String KEY_LOGIN_HINT = "login_hint";
     private static final long RESULT_MESSAGE_DURATION = 3000;
     private static final int WEB_AUTH_REQUEST_CODE = 200;
     private static final int CUSTOM_AUTH_REQUEST_CODE = 201;
@@ -332,9 +334,12 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
         }
 
         Log.v(TAG, "Looking for a provider to use /authorize with the connection " + connection);
+        HashMap<String, Object> authParameters = new HashMap<>(options.getAuthenticationParameters());
+        if (!TextUtils.isEmpty(event.getUsername())) {
+            authParameters.put(KEY_LOGIN_HINT, event.getUsername());
+        }
         currentProvider = AuthResolver.providerFor(event.getStrategy(), connection);
         if (currentProvider != null) {
-            HashMap<String, Object> authParameters = new HashMap<>(options.getAuthenticationParameters());
             final String connectionScope = options.getConnectionsScope().get(connection);
             if (connectionScope != null) {
                 authParameters.put(Constants.CONNECTION_SCOPE_KEY, connectionScope);
@@ -353,7 +358,7 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
         }
 
         Log.d(TAG, "Couldn't find an specific provider, using the default: " + WebAuthProvider.class.getSimpleName());
-        webProvider.start(this, connection, authProviderCallback, WEB_AUTH_REQUEST_CODE);
+        webProvider.start(this, connection, authParameters, authProviderCallback, WEB_AUTH_REQUEST_CODE);
     }
 
     @SuppressWarnings("unused")

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -73,6 +73,7 @@ import com.squareup.okhttp.OkHttpClient;
 import com.squareup.otto.Bus;
 import com.squareup.otto.Subscribe;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -422,8 +423,8 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
         lastPasswordlessCountry = null;
         Log.v(TAG, "Looking for a provider to use with the connection " + event.getConnection());
         currentProvider = AuthResolver.providerFor(event.getStrategy(), event.getConnection());
-        HashMap<String, Object> authParameters = new HashMap<>(options.getAuthenticationParameters());
         if (currentProvider != null) {
+            HashMap<String, Object> authParameters = new HashMap<>(options.getAuthenticationParameters());
             final String connectionScope = options.getConnectionsScope().get(event.getConnection());
             if (connectionScope != null) {
                 authParameters.put(Constants.CONNECTION_SCOPE_KEY, connectionScope);
@@ -442,7 +443,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
         }
 
         Log.d(TAG, "Couldn't find an specific provider, using the default: " + WebAuthProvider.class.getSimpleName());
-        webProvider.start(this, event.getConnection(), authParameters, authProviderCallback, WEB_AUTH_REQUEST_CODE);
+        webProvider.start(this, event.getConnection(), null, authProviderCallback, WEB_AUTH_REQUEST_CODE);
     }
 
     //Callbacks

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -422,8 +422,8 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
         lastPasswordlessCountry = null;
         Log.v(TAG, "Looking for a provider to use with the connection " + event.getConnection());
         currentProvider = AuthResolver.providerFor(event.getStrategy(), event.getConnection());
+        HashMap<String, Object> authParameters = new HashMap<>(options.getAuthenticationParameters());
         if (currentProvider != null) {
-            HashMap<String, Object> authParameters = new HashMap<>(options.getAuthenticationParameters());
             final String connectionScope = options.getConnectionsScope().get(event.getConnection());
             if (connectionScope != null) {
                 authParameters.put(Constants.CONNECTION_SCOPE_KEY, connectionScope);
@@ -442,7 +442,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
         }
 
         Log.d(TAG, "Couldn't find an specific provider, using the default: " + WebAuthProvider.class.getSimpleName());
-        webProvider.start(this, event.getConnection(), authProviderCallback, WEB_AUTH_REQUEST_CODE);
+        webProvider.start(this, event.getConnection(), authParameters, authProviderCallback, WEB_AUTH_REQUEST_CODE);
     }
 
     //Callbacks

--- a/lib/src/main/java/com/auth0/android/lock/WebProvider.java
+++ b/lib/src/main/java/com/auth0/android/lock/WebProvider.java
@@ -32,19 +32,24 @@ class WebProvider {
     /**
      * Configures a new instance of the WebAuthProvider.Builder and starts it.
      *
-     * @param activity       a valid Activity context
-     * @param connection     to use in the authentication
-     * @param authParameters extra authentication parameters to use. If null, it will use the ones defined by Options#getAuthenticationParameters
-     * @param callback       to deliver the authentication result to
-     * @param requestCode    to use in the startActivityForResult request
+     * @param activity            a valid Activity context
+     * @param connection          to use in the authentication
+     * @param extraAuthParameters extra authentication parameters to use along with the provided in the Options instance
+     * @param callback            to deliver the authentication result to
+     * @param requestCode         to use in the startActivityForResult request
      */
-    public void start(@NonNull Activity activity, @NonNull String connection, @Nullable Map<String, Object> authParameters, @NonNull AuthCallback callback, int requestCode) {
-        if (authParameters == null) {
-            authParameters = new HashMap<>(options.getAuthenticationParameters());
+    public void start(@NonNull Activity activity, @NonNull String connection, @Nullable Map<String, Object> extraAuthParameters, @NonNull AuthCallback callback, int requestCode) {
+        HashMap<String, Object> parameters;
+        if (extraAuthParameters == null) {
+            parameters = options.getAuthenticationParameters();
+        } else {
+            parameters = new HashMap<>(options.getAuthenticationParameters());
+            parameters.putAll(extraAuthParameters);
         }
+
         WebAuthProvider.Builder builder = WebAuthProvider.init(options.getAccount())
                 .useBrowser(options.useBrowser())
-                .withParameters(authParameters)
+                .withParameters(parameters)
                 .withConnection(connection);
 
         final String connectionScope = options.getConnectionsScope().get(connection);

--- a/lib/src/main/java/com/auth0/android/lock/WebProvider.java
+++ b/lib/src/main/java/com/auth0/android/lock/WebProvider.java
@@ -3,13 +3,17 @@ package com.auth0.android.lock;
 import android.app.Activity;
 import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.auth0.android.lock.internal.configuration.Options;
 import com.auth0.android.provider.AuthCallback;
 import com.auth0.android.provider.WebAuthProvider;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
- * The WebProvider class is a wrapper for calls to the WebAuthProvider static methods.
+ * The WebProvider class is an internal wrapper for calls to the WebAuthProvider static methods.
  * This is only for testing purposes.
  */
 class WebProvider {
@@ -28,15 +32,19 @@ class WebProvider {
     /**
      * Configures a new instance of the WebAuthProvider.Builder and starts it.
      *
-     * @param activity    a valid Activity context
-     * @param connection  to use in the authentication
-     * @param callback    to deliver the authentication result to
-     * @param requestCode to use in the startActivityForResult request
+     * @param activity       a valid Activity context
+     * @param connection     to use in the authentication
+     * @param authParameters extra authentication parameters to use. If null, it will use the ones defined by Options#getAuthenticationParameters
+     * @param callback       to deliver the authentication result to
+     * @param requestCode    to use in the startActivityForResult request
      */
-    public void start(Activity activity, String connection, AuthCallback callback, int requestCode) {
+    public void start(@NonNull Activity activity, @NonNull String connection, @Nullable Map<String, Object> authParameters, @NonNull AuthCallback callback, int requestCode) {
+        if (authParameters == null) {
+            authParameters = new HashMap<>(options.getAuthenticationParameters());
+        }
         WebAuthProvider.Builder builder = WebAuthProvider.init(options.getAccount())
                 .useBrowser(options.useBrowser())
-                .withParameters(options.getAuthenticationParameters())
+                .withParameters(authParameters)
                 .withConnection(connection);
 
         final String connectionScope = options.getConnectionsScope().get(connection);

--- a/lib/src/main/java/com/auth0/android/lock/events/OAuthLoginEvent.java
+++ b/lib/src/main/java/com/auth0/android/lock/events/OAuthLoginEvent.java
@@ -18,7 +18,7 @@ public class OAuthLoginEvent {
      * @param username   the username to use.
      * @param password   the password to use.
      */
-    public OAuthLoginEvent(@NonNull OAuthConnection connection, @NonNull String username, @NonNull String password) {
+    public OAuthLoginEvent(@NonNull OAuthConnection connection, @NonNull String username, @Nullable String password) {
         this(connection);
         this.username = username;
         this.password = password;

--- a/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
@@ -179,7 +179,14 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
     }
 
     private String getUsername() {
-        return currentConnection == null && fallbackToDatabase ? emailInput.getText() : usernameInput.getText();
+        boolean usingDatabase = currentConnection == null && fallbackToDatabase;
+        boolean usingOAuthEnterprise = currentConnection != null && !currentConnection.isActiveFlowEnabled();
+        if (usingDatabase || usingOAuthEnterprise) {
+            return emailInput.getText();
+        } else {
+            //Using RO: we get the Username from the "second screen".
+            return usernameInput.getText();
+        }
     }
 
     private String getPassword() {
@@ -224,7 +231,7 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
         }
         if (currentConnection != null) {
             Log.d(TAG, String.format("Form submitted. Logging in with enterprise connection %s using authorize screen", currentConnection.getName()));
-            return new OAuthLoginEvent(currentConnection);
+            return new OAuthLoginEvent(currentConnection, getUsername(), null);
         }
         if (fallbackToDatabase) {
             Log.d(TAG, "Logging in with database connection using active flow");

--- a/lib/src/test/java/com/auth0/android/lock/LockActivityTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/LockActivityTest.java
@@ -40,6 +40,7 @@ import edu.emory.mathcs.backport.java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
@@ -134,7 +135,7 @@ public class LockActivityTest {
 
         verify(lockView).showProgress(true);
         verify(options).getAuthenticationAPIClient();
-        verify(client).login(eq("username"), eq("password"), eq("connection"));
+        verify(client).login("username", "password", "connection");
         verify(authRequest).addAuthenticationParameters(mapCaptor.capture());
         verify(authRequest).start(any(BaseCallback.class));
         verify(authRequest).setScope("openid user photos");
@@ -155,7 +156,7 @@ public class LockActivityTest {
 
         verify(lockView).showProgress(true);
         verify(options).getAuthenticationAPIClient();
-        verify(client).login(eq("username"), eq("password"), eq("connection"));
+        verify(client).login("username", "password", "connection");
         verify(authRequest).addAuthenticationParameters(mapCaptor.capture());
         verify(authRequest).start(any(BaseCallback.class));
         verify(authRequest).setScope("openid user photos");
@@ -185,7 +186,7 @@ public class LockActivityTest {
 
         verify(lockView).showProgress(true);
         verify(options).getAuthenticationAPIClient();
-        verify(client).login(eq("username"), eq("password"), eq("connection"));
+        verify(client).login("username", "password", "connection");
         verify(authRequest).addAuthenticationParameters(mapCaptor.capture());
         verify(authRequest).setScope("openid user photos");
         verify(authRequest).setAudience("aud");
@@ -222,7 +223,7 @@ public class LockActivityTest {
         verify(lockView).showProgress(true);
         verify(options).getAuthenticationAPIClient();
         verify(dbRequest).start(any(BaseCallback.class));
-        verify(client).createUser(eq("email@domain.com"), eq("password"), eq("username"), eq("connection"));
+        verify(client).createUser("email@domain.com", "password", "username", "connection");
         verify(configuration, atLeastOnce()).getDatabaseConnection();
     }
 
@@ -236,7 +237,7 @@ public class LockActivityTest {
         verify(lockView).showProgress(true);
         verify(options).getAuthenticationAPIClient();
         verify(dbRequest).start(any(BaseCallback.class));
-        verify(client).createUser(eq("email@domain.com"), eq("password"), eq("connection"));
+        verify(client).createUser("email@domain.com", "password", "connection");
         verify(configuration, atLeastOnce()).getDatabaseConnection();
     }
 
@@ -264,7 +265,7 @@ public class LockActivityTest {
         verify(signUpRequest).start(any(BaseCallback.class));
         verify(signUpRequest).setScope("openid user photos");
         verify(signUpRequest).setAudience("aud");
-        verify(client).signUp(eq("email@domain.com"), eq("password"), eq("username"), eq("connection"));
+        verify(client).signUp("email@domain.com", "password", "username", "connection");
         verify(configuration, atLeastOnce()).getDatabaseConnection();
 
         Map<String, String> reqParams = mapCaptor.getValue();
@@ -286,7 +287,7 @@ public class LockActivityTest {
         verify(signUpRequest).start(any(BaseCallback.class));
         verify(signUpRequest).setScope("openid user photos");
         verify(signUpRequest, never()).setAudience("aud");
-        verify(client).signUp(eq("email@domain.com"), eq("password"), eq("username"), eq("connection"));
+        verify(client).signUp("email@domain.com", "password", "username", "connection");
         verify(configuration, atLeastOnce()).getDatabaseConnection();
 
         Map<String, String> reqParams = mapCaptor.getValue();
@@ -308,7 +309,7 @@ public class LockActivityTest {
         verify(signUpRequest).start(any(BaseCallback.class));
         verify(signUpRequest).setScope("openid user photos");
         verify(signUpRequest, never()).setAudience("aud");
-        verify(client).signUp(eq("email"), eq("password"), eq("connection"));
+        verify(client).signUp("email", "password", "connection");
         verify(configuration, atLeastOnce()).getDatabaseConnection();
 
         Map<String, String> reqParams = mapCaptor.getValue();
@@ -339,7 +340,7 @@ public class LockActivityTest {
         verify(options).getAuthenticationAPIClient();
         verify(dbRequest, never()).addParameters(any(Map.class));
         verify(dbRequest).start(any(BaseCallback.class));
-        verify(client).resetPassword(eq("email@domain.com"), eq("connection"));
+        verify(client).resetPassword("email@domain.com", "connection");
         verify(configuration, atLeastOnce()).getDatabaseConnection();
     }
 
@@ -358,7 +359,7 @@ public class LockActivityTest {
         verify(authRequest).start(any(BaseCallback.class));
         verify(authRequest).setScope("openid user photos");
         verify(authRequest, never()).setAudience("aud");
-        verify(client).login(eq("email@domain.com"), eq("password"), eq("my-connection"));
+        verify(client).login("email@domain.com", "password", "my-connection");
 
         Map<String, String> reqParams = mapCaptor.getValue();
         assertThat(reqParams, is(notNullValue()));
@@ -475,13 +476,13 @@ public class LockActivityTest {
         when(options.useBrowser()).thenReturn(true);
         activity.onOAuthAuthenticationRequest(event);
 
-        verify(lockView, never()).showProgress(eq(true));
+        verify(lockView, never()).showProgress(true);
         verify(webProvider).start(eq(activity), eq("my-connection"), mapCaptor.capture(), any(AuthCallback.class), eq(REQ_CODE_WEB_PROVIDER));
 
-        Map<String, String> reqParams = mapCaptor.getValue();
-        assertThat(reqParams, is(notNullValue()));
-        assertThat(reqParams, hasEntry("extra", "value"));
-        assertThat(reqParams, hasEntry("login_hint", "user@domain.com"));
+        Map<String, String> extraParams = mapCaptor.getValue();
+        assertThat(extraParams, is(notNullValue()));
+        assertThat(extraParams.size(), is(1));
+        assertThat(extraParams, hasEntry("login_hint", "user@domain.com"));
     }
 
     @Test
@@ -496,7 +497,7 @@ public class LockActivityTest {
         activity.onActivityResult(REQ_CODE_WEB_PROVIDER, Activity.RESULT_OK, intent);
 
         verify(lockView).showProgress(false);
-        verify(webProvider).resume(eq(REQ_CODE_WEB_PROVIDER), eq(Activity.RESULT_OK), eq(intent));
+        verify(webProvider).resume(REQ_CODE_WEB_PROVIDER, Activity.RESULT_OK, intent);
     }
 
     @Test
@@ -507,12 +508,11 @@ public class LockActivityTest {
         when(options.useBrowser()).thenReturn(true);
         activity.onOAuthAuthenticationRequest(event);
 
-        verify(lockView, never()).showProgress(eq(true));
+        verify(lockView, never()).showProgress(true);
         verify(webProvider).start(eq(activity), eq("my-connection"), mapCaptor.capture(), any(AuthCallback.class), eq(REQ_CODE_WEB_PROVIDER));
 
-        Map<String, String> reqParams = mapCaptor.getValue();
-        assertThat(reqParams, is(notNullValue()));
-        assertThat(reqParams, hasEntry("extra", "value"));
+        Map<String, String> extraParams = mapCaptor.getValue();
+        assertThat(extraParams, is(nullValue()));
     }
 
     @Test
@@ -526,7 +526,7 @@ public class LockActivityTest {
         activity.onActivityResult(REQ_CODE_WEB_PROVIDER, Activity.RESULT_OK, intent);
 
         verify(lockView).showProgress(false);
-        verify(webProvider).resume(eq(REQ_CODE_WEB_PROVIDER), eq(Activity.RESULT_OK), eq(intent));
+        verify(webProvider).resume(REQ_CODE_WEB_PROVIDER, Activity.RESULT_OK, intent);
     }
 
     @Test
@@ -545,7 +545,7 @@ public class LockActivityTest {
         activity.onActivityResult(REQ_CODE_CUSTOM_PROVIDER, Activity.RESULT_OK, intent);
 
         verify(lockView).showProgress(false);
-        verify(customProvider).authorize(eq(REQ_CODE_CUSTOM_PROVIDER), eq(Activity.RESULT_OK), eq(intent));
+        verify(customProvider).authorize(REQ_CODE_CUSTOM_PROVIDER, Activity.RESULT_OK, intent);
         AuthResolver.setAuthHandlers(Collections.emptyList());
     }
 
@@ -560,7 +560,7 @@ public class LockActivityTest {
         activity.onNewIntent(intent);
 
         verify(lockView).showProgress(false);
-        verify(webProvider).resume(eq(intent));
+        verify(webProvider).resume(intent);
     }
 
     @Test
@@ -579,7 +579,7 @@ public class LockActivityTest {
         activity.onNewIntent(intent);
 
         verify(lockView).showProgress(false);
-        verify(customProvider).authorize(eq(intent));
+        verify(customProvider).authorize(intent);
         AuthResolver.setAuthHandlers(Collections.emptyList());
     }
 
@@ -594,6 +594,6 @@ public class LockActivityTest {
         activity.onNewIntent(intent);
 
         verify(lockView).showProgress(false);
-        verify(webProvider).resume(eq(intent));
+        verify(webProvider).resume(intent);
     }
 }

--- a/lib/src/test/java/com/auth0/android/lock/PasswordlessLockActivityTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/PasswordlessLockActivityTest.java
@@ -287,7 +287,13 @@ public class PasswordlessLockActivityTest {
         activity.onOAuthAuthenticationRequest(event);
 
         verify(lockView, never()).showProgress(eq(true));
-        verify(webProvider).start(eq(activity), eq("my-connection"), any(AuthCallback.class), eq(REQ_CODE_WEB_PROVIDER));
+
+        ArgumentCaptor<Map> mapCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(webProvider).start(eq(activity), eq("my-connection"), mapCaptor.capture(), any(AuthCallback.class), eq(REQ_CODE_WEB_PROVIDER));
+
+        Map<String, String> reqParams = mapCaptor.getValue();
+        assertThat(reqParams, is(notNullValue()));
+        assertThat(reqParams, hasEntry("extra", "value"));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/android/lock/PasswordlessLockActivityTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/PasswordlessLockActivityTest.java
@@ -23,6 +23,8 @@ import com.auth0.android.provider.AuthProvider;
 import com.auth0.android.request.AuthenticationRequest;
 import com.auth0.android.request.ParameterizableRequest;
 
+import org.hamcrest.collection.IsEmptyCollection;
+import org.hamcrest.collection.IsMapContaining;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,6 +42,7 @@ import edu.emory.mathcs.backport.java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
@@ -292,8 +295,7 @@ public class PasswordlessLockActivityTest {
         verify(webProvider).start(eq(activity), eq("my-connection"), mapCaptor.capture(), any(AuthCallback.class), eq(REQ_CODE_WEB_PROVIDER));
 
         Map<String, String> reqParams = mapCaptor.getValue();
-        assertThat(reqParams, is(notNullValue()));
-        assertThat(reqParams, hasEntry("extra", "value"));
+        assertThat(reqParams, is(nullValue()));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/android/lock/WebProviderTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/WebProviderTest.java
@@ -3,13 +3,13 @@ package com.auth0.android.lock;
 import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
-import android.support.test.espresso.core.deps.guava.collect.ObjectArrays;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.lock.internal.configuration.Options;
 import com.auth0.android.provider.AuthCallback;
 import com.auth0.android.provider.WebAuthActivity;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -43,8 +43,16 @@ public class WebProviderTest {
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
-    @Mock
-    public Map<String, Object> map;
+    private Activity activity;
+
+    @Before
+    public void setUp() throws Exception {
+        activity = spy(Robolectric.buildActivity(Activity.class)
+                .create()
+                .start()
+                .resume()
+                .get());
+    }
 
     @Test
     public void shouldStart() throws Exception {
@@ -52,13 +60,8 @@ public class WebProviderTest {
         options.setAccount(new Auth0("clientId", "domain.auth0.com"));
         AuthCallback callback = mock(AuthCallback.class);
         WebProvider webProvider = new WebProvider(options);
-        Activity activity = Robolectric.buildActivity(Activity.class)
-                .create()
-                .start()
-                .resume()
-                .get();
 
-        webProvider.start(activity, "my-connection", map, callback, 123);
+        webProvider.start(activity, "my-connection", null, callback, 123);
     }
 
     @Test
@@ -73,11 +76,6 @@ public class WebProviderTest {
 
         AuthCallback callback = mock(AuthCallback.class);
         WebProvider webProvider = new WebProvider(options);
-        Activity activity = spy(Robolectric.buildActivity(Activity.class)
-                .create()
-                .start()
-                .resume()
-                .get());
 
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("custom-param-1", "value-1");
@@ -90,6 +88,8 @@ public class WebProviderTest {
         Intent intent = intentCaptor.getValue();
         assertThat(intent, is(notNullValue()));
         assertThat(intent.getData(), hasHost("domain.auth0.com"));
+        assertThat(intent.getData(), hasParamWithValue("custom-param-1", "value-1"));
+        assertThat(intent.getData(), hasParamWithValue("custom-param-2", "value-2"));
         assertThat(intent.getData(), hasParamWithValue("client_id", "clientId"));
         assertThat(intent.getData(), hasParamWithValue("connection", "my-connection"));
         assertThat(intent.getData(), hasParamWithValue("audience", "https://me.auth0.com/myapi"));
@@ -108,11 +108,6 @@ public class WebProviderTest {
 
         AuthCallback callback = mock(AuthCallback.class);
         WebProvider webProvider = new WebProvider(options);
-        Activity activity = spy(Robolectric.buildActivity(Activity.class)
-                .create()
-                .start()
-                .resume()
-                .get());
 
         webProvider.start(activity, "my-connection", null, callback, 123);
         ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
@@ -144,11 +139,6 @@ public class WebProviderTest {
 
         AuthCallback callback = mock(AuthCallback.class);
         WebProvider webProvider = new WebProvider(options);
-        Activity activity = spy(Robolectric.buildActivity(Activity.class)
-                .create()
-                .start()
-                .resume()
-                .get());
 
         webProvider.start(activity, "my-connection", null, callback, 123);
         ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
@@ -186,11 +176,6 @@ public class WebProviderTest {
 
         AuthCallback callback = mock(AuthCallback.class);
         WebProvider webProvider = new WebProvider(options);
-        Activity activity = spy(Robolectric.buildActivity(Activity.class)
-                .create()
-                .start()
-                .resume()
-                .get());
 
         webProvider.start(activity, "my-connection", null, callback, 123);
         ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);


### PR DESCRIPTION
When an enterprise connection supports logging in using Web OAuth, the query parameter `login_hint` will be sent in the authorize url containing the username/email.