### PR TITLE
Add Hosted Login Page button to the demo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The next step is to create an instance of `Auth0` with your client information:
 Auth0 account = new Auth0("{YOUR_AUTH0_CLIENT_ID}", "{YOUR_AUTH0_DOMAIN}");
 ```
 
-Another way to create it is using the values defined previously in the `string.xml` file, by passing just an Android Context. The name of the keys must match the ones listed above or the constructor will throw an exception.
+Another way to create it is using the values defined previously in the `string.xml` file, by passing an Android Context. The name of the keys must match the ones listed above or the constructor will throw an exception.
 
 ```java
 Auth0 account = new Auth0(context);
@@ -184,7 +184,7 @@ public class HomeActivity extends Activity {
 }
 ```
 
-And start `LockActivity` from inside your `Activity`.
+Start `LockActivity` from inside your `Activity`.
 
 ```java
 startActivity(lock.newIntent(this));
@@ -315,7 +315,7 @@ public class HomeActivity extends Activity {
 }
 ```
 
-And start `PasswordlessLockActivity` from inside your `Activity`.
+Start `PasswordlessLockActivity` from inside your `Activity`.
 
 ```java
 startActivity(lock.newIntent(this));

--- a/README.md
+++ b/README.md
@@ -34,25 +34,43 @@ If you haven't done yet, go to [Auth0](https://auth0.com) and create an Account,
 https://{YOUR_AUTH0_DOMAIN}/android/{YOUR_APP_PACKAGE_NAME}/callback
 ```
 
-The *package name* value required in the Callback URL can be found in your app's `build.gradle` file in the `applicationId` property. Both the *domain* and *client id* values can be found at the top of your client's settings.
+The *package name* value required in the Callback URL can be found in your app's `build.gradle` file in the `applicationId` property. Both the *domain* and *client id* values can be found at the top of your client's settings. You're going to use them to setup the SDK so let's add them to the `strings.xml` file:
+
+```xml
+<resources>
+    <string name="com_auth0_client_id">YOUR_AUTH0_CLIENT_ID</string>
+    <string name="com_auth0_domain">YOUR_AUTH0_DOMAIN</string>
+</resources>
+```
+
+In your app/build.gradle file add a **Manifest Placeholder** for the Auth0 Domain property which is going to be used internally by the library to register an **intent-filter**. You can also add the intent-filter manually to the corresponding Lock activity in the Android Manifest as described later.
+
+```groovy
+apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion 25
+    defaultConfig {
+        applicationId "com.auth0.samples"
+        minSdkVersion 15
+        targetSdkVersion 25
+        //...
+
+        //---> Add the next line
+        manifestPlaceholders = [auth0Domain: "@string/com_auth0_domain"]
+        //<---
+    }
+    //...
+}
+``` 
 
 The next step is to create an instance of `Auth0` with your client information:
 
 ```java
-Auth0 account = new Auth0("{YOUR_CLIENT_ID}", "{YOUR_DOMAIN}");
+Auth0 account = new Auth0("{YOUR_AUTH0_CLIENT_ID}", "{YOUR_AUTH0_DOMAIN}");
 ```
 
-Alternatively, you can save your client information in the `strings.xml` file using the following names:
-
-```xml
-<resources>
-    <string name="com_auth0_client_id">YOUR_CLIENT_ID</string>
-    <string name="com_auth0_domain">YOUR_DOMAIN</string>
-</resources>
-
-```
-
-And then create a new Auth0 instance by passing an Android Context:
+Another way to create it is using the values defined previously in the `string.xml` file, by passing just an Android Context. The name of the keys must match the ones listed above or the constructor will throw an exception.
 
 ```java
 Auth0 account = new Auth0(context);
@@ -63,7 +81,7 @@ Auth0 account = new Auth0(context);
 It is strongly encouraged that Lock be used in OIDC Conformant mode. When this mode is enabled, it will force Lock to use Auth0's current authentication pipeline and will prevent it from reaching legacy endpoints. By default is `false`.
 
 ```java
-Auth0 account = new Auth0("{YOUR_CLIENT_ID}", "{YOUR_DOMAIN}");
+Auth0 account = new Auth0("{YOUR_AUTH0_CLIENT_ID}", "{YOUR_AUTH0_DOMAIN}");
 //Configure the account in OIDC conformant mode
 account.setOIDCConformant(true);
 //Use the account to launch Lock
@@ -74,7 +92,26 @@ Passwordless Lock *cannot be used* with this flag set to `true`. For more inform
 
 ### Email/Password, Enterprise & Social authentication
 
-You'll need to configure `LockActivity` in your `AndroidManifest.xml`, inside the `application` tag:
+Modify the `AndroidManifest.xml` file, to include the Internet permission:
+
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+```
+
+Next, add the `LockActivity` inside the `application` tag:
+
+```xml
+<activity
+  android:name="com.auth0.android.lock.LockActivity"
+  android:label="@string/app_name"
+  android:launchMode="singleTask"
+  android:screenOrientation="portrait"
+  android:theme="@style/Lock.Theme"/>
+```
+
+> In versions 2.5.0 or lower of Lock.Android you had to define an **intent-filter** inside the `LockActivity` to make possible to the library to capture a social provider's authentication result. This intent-filter declaration is no longer required for versions greater than 2.5.0 unless you need to use a custom scheme, as it's now done internally by the library for you.
+
+In case you are using an older version of Lock or require to use a custom scheme for Social Authentication, the **intent-filter** must be added to the `LockActivity` by you. i.e. with a scheme value of `demo`.
 
 ```xml
 <activity
@@ -90,19 +127,16 @@ You'll need to configure `LockActivity` in your `AndroidManifest.xml`, inside th
       <category android:name="android.intent.category.BROWSABLE" />
 
       <data
-        android:host="{YOUR_AUTH0_DOMAIN}"
-        android:pathPrefix="/android/{YOUR_APP_PACKAGE_NAME}/callback"
-        android:scheme="https" />
+        android:host="@string/com_auth0_domain"
+        android:pathPrefix="/android/${applicationId}/callback"
+        android:scheme="demo" />
     </intent-filter>
 </activity>
 ```
 
-Make sure the Activity's `launchMode` is declared as `"singleTask"` or the result won't come back in the authentication.
 
-Also, you'll need to add *Internet* permission to your application:
-```xml
-<uses-permission android:name="android.permission.INTERNET" />
-```
+Make sure the Activity's `launchMode` is declared as `singleTask` or the result won't come back in the authentication.
+
 
 Then in any of your Activities you need to initialize **Lock**:
 
@@ -150,7 +184,7 @@ public class HomeActivity extends Activity {
 }
 ```
 
-Then just start `LockActivity` from inside your `Activity`.
+And start `LockActivity` from inside your `Activity`.
 
 ```java
 startActivity(lock.newIntent(this));
@@ -162,7 +196,14 @@ The Passwordless feature requires your client to have the *Resource Owner* Legac
 
 `PasswordlessLockActivity` authenticates users by sending them an Email or SMS (similar to how WhatsApp authenticates you). In order to be able to authenticate the user, your application must have the SMS/Email connection enabled and configured in your [dashboard](https://manage.auth0.com/#/connections/passwordless).
 
-You'll need to configure PasswordlessLockActivity in your `AndroidManifest.xml`, inside the `application` tag:
+
+Modify the `AndroidManifest.xml` file, to include the Internet permission:
+
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+```
+
+Next, add the `PasswordlessLockActivity` inside the `application` tag:
 
 ```xml
 <activity
@@ -178,19 +219,55 @@ You'll need to configure PasswordlessLockActivity in your `AndroidManifest.xml`,
       <category android:name="android.intent.category.BROWSABLE" />
 
       <data
-        android:host="{YOUR_AUTH0_DOMAIN}"
-        android:pathPrefix="/android/{YOUR_APP_PACKAGE_NAME}/callback"
+        android:host="@string/com_auth0_domain"
+        android:pathPrefix="/android/${applicationId}/email"
         android:scheme="https" />
     </intent-filter>
 </activity>
 ```
 
-Make sure the Activity's `launchMode` is declared as `"singleTask"` or the result won't come back after the authentication.
+The `data` attribute of the intent-filter defines which syntax of "Callback URI" your app is going to capture. In the above case it's going to capture calls from `email` passwordless connections. In case you're using the `sms` passwordless connection, the `pathPrefix` would end in `sms`. 
 
-Also, you'll need to add *Internet* permission to your application:
+> In versions 2.5.0 or lower of Lock.Android you had to define an **intent-filter** inside the `PasswordlessLockActivity` to make possible to the library to capture a Social provider's authentication result. This intent-filter declaration is no longer required for versions greater than 2.5.0 unless you need to use a custom scheme, as it's now done internally by the library for you.
+
+In case you are using an older version of Lock or require to use a custom scheme for Social Authentication, the **data** attribute inside the intent-filter must be added to the `PasswordlessLockActivity` by you. i.e. with a scheme value of `demo`.
+
 ```xml
-<uses-permission android:name="android.permission.INTERNET" />
+<activity
+  android:name="com.auth0.android.lock.PasswordlessLockActivity"
+  android:label="@string/app_name"
+  android:launchMode="singleTask"
+  android:screenOrientation="portrait"
+  android:theme="@style/Lock.Theme">
+    <intent-filter>
+      <action android:name="android.intent.action.VIEW" />
+
+      <category android:name="android.intent.category.DEFAULT" />
+      <category android:name="android.intent.category.BROWSABLE" />
+
+      <data
+        android:host="@string/com_auth0_domain"
+        android:pathPrefix="/android/${applicationId}/email"
+        android:scheme="https" />
+        
+      <data
+        android:host="@string/com_auth0_domain"
+        android:pathPrefix="/android/${applicationId}/callback"
+        android:scheme="demo" />
+    </intent-filter>
+</activity>
 ```
+
+Make sure the Activity's `launchMode` is declared as `singleTask` or the result won't come back in the authentication.
+
+When the Passwordless connection is SMS you must also add the `CountryCodeActivity` to allow the user to change the **Country Code** prefix of the phone number.
+
+```xml
+<activity
+  android:name="com.auth0.android.lock.CountryCodeActivity"
+  android:theme="@style/Lock.Theme.ActionBar" />
+```
+
 
 Then in any of your Activities you need to initialize **PasswordlessLock**
 
@@ -238,7 +315,7 @@ public class HomeActivity extends Activity {
 }
 ```
 
-Then just start `PasswordlessLockActivity` from inside your `Activity`
+And start `PasswordlessLockActivity` from inside your `Activity`.
 
 ```java
 startActivity(lock.newIntent(this));

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,7 @@ android {
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
+        manifestPlaceholders = ["auth0Domain": "@string/com_auth0_domain"]
     }
 
     signingConfigs {
@@ -22,9 +23,6 @@ android {
     }
 
     buildTypes {
-        debug {
-            minifyEnabled false
-        }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,19 +28,7 @@
             android:label="Classic Lock"
             android:launchMode="singleTask"
             android:screenOrientation="portrait"
-            android:theme="@style/MyLock.Theme">
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:host="@string/com_auth0_domain"
-                    android:pathPrefix="/android/${applicationId}/callback"
-                    android:scheme="https" />
-            </intent-filter>
-        </activity>
+            android:theme="@style/MyLock.Theme"/>
         <!--Auth0 Lock End-->
 
         <!--Auth0 PasswordlessLock-->
@@ -55,11 +43,6 @@
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:host="@string/com_auth0_domain"
-                    android:pathPrefix="/android/${applicationId}/callback"
-                    android:scheme="https" />
 
                 <data
                     android:host="@string/com_auth0_domain"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,8 +14,8 @@
 
         <activity
             android:name=".DemoActivity"
-            android:screenOrientation="portrait"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -37,7 +37,7 @@
 
                 <data
                     android:host="@string/com_auth0_domain"
-                    android:pathPrefix="/android/com.auth0.android.lock.app/callback"
+                    android:pathPrefix="/android/${applicationId}/callback"
                     android:scheme="https" />
             </intent-filter>
         </activity>
@@ -58,22 +58,16 @@
 
                 <data
                     android:host="@string/com_auth0_domain"
-                    android:pathPrefix="/android/com.auth0.android.lock.app/callback"
+                    android:pathPrefix="/android/${applicationId}/callback"
                     android:scheme="https" />
 
                 <data
                     android:host="@string/com_auth0_domain"
-                    android:pathPrefix="/android/com.auth0.android.lock.app/email"
+                    android:pathPrefix="/android/${applicationId}/email"
                     android:scheme="https" />
             </intent-filter>
         </activity>
         <!--Auth0 PasswordlessLock End-->
-
-        <!--Auth0 Lock Embedded WebView-->
-        <activity
-            android:name="com.auth0.android.provider.WebAuthActivity"
-            android:theme="@style/MyLock.Theme" />
-        <!--Auth0 Lock Embedded WebView End-->
 
         <!--Auth0 Lock Passwordless SMS Country Code Selection-->
         <activity

--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
@@ -24,7 +24,9 @@
 
 package com.auth0.android.lock.app;
 
+import android.app.Dialog;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
@@ -36,6 +38,7 @@ import android.widget.LinearLayout;
 import android.widget.RadioGroup;
 
 import com.auth0.android.Auth0;
+import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.lock.AuthButtonSize;
 import com.auth0.android.lock.AuthenticationCallback;
 import com.auth0.android.lock.InitialScreen;
@@ -44,6 +47,8 @@ import com.auth0.android.lock.LockCallback;
 import com.auth0.android.lock.PasswordlessLock;
 import com.auth0.android.lock.UsernameStyle;
 import com.auth0.android.lock.utils.LockException;
+import com.auth0.android.provider.AuthCallback;
+import com.auth0.android.provider.WebAuthProvider;
 import com.auth0.android.result.Credentials;
 
 import java.util.ArrayList;
@@ -130,6 +135,20 @@ public class DemoActivity extends AppCompatActivity {
                 showPasswordlessLock();
             }
         });
+
+        Button btnShowHostedLoginPage = (Button) findViewById(R.id.btn_show_hosted_login_age);
+        btnShowHostedLoginPage.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                showWebAuth();
+            }
+        });
+    }
+
+    private void showWebAuth() {
+        WebAuthProvider.init(getAccount())
+                .withAudience(String.format("https://%s/userinfo", getString(R.string.com_auth0_domain)))
+                .start(this, webCallback);
     }
 
     private void showClassicLock() {
@@ -262,7 +281,7 @@ public class DemoActivity extends AppCompatActivity {
     private LockCallback callback = new AuthenticationCallback() {
         @Override
         public void onAuthentication(Credentials credentials) {
-            showResult("OK > " + credentials.getIdToken());
+            showResult("OK > " + credentials.getAccessToken());
         }
 
         @Override
@@ -273,6 +292,23 @@ public class DemoActivity extends AppCompatActivity {
         @Override
         public void onError(LockException error) {
             showResult(error.getMessage());
+        }
+    };
+
+    private AuthCallback webCallback = new AuthCallback() {
+        @Override
+        public void onFailure(@NonNull Dialog dialog) {
+            dialog.show();
+        }
+
+        @Override
+        public void onFailure(AuthenticationException exception) {
+            showResult("Failed > " + exception.getDescription());
+        }
+
+        @Override
+        public void onSuccess(@NonNull Credentials credentials) {
+            showResult("OK > " + credentials.getAccessToken());
         }
     };
 }

--- a/app/src/main/res/layout/demo_activity.xml
+++ b/app/src/main/res/layout/demo_activity.xml
@@ -21,7 +21,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="5dp"
                 android:layout_weight="1"
-                android:text="Configuration"
+                android:text="Embedded Login"
                 android:textSize="20sp" />
 
             <CheckBox
@@ -203,7 +203,7 @@
                 android:layout_marginBottom="5dp"
                 android:layout_marginTop="10dp"
                 android:text="Advanced"
-                android:textSize="20sp" />
+                android:textSize="18sp" />
 
             <TextView
                 android:layout_width="match_parent"
@@ -423,7 +423,14 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="5dp"
             android:layout_marginTop="10dp"
-            android:text="Hosted Login Page: Above settings don't apply" />
+            android:text="Hosted Login"
+            android:textSize="20sp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="5dp"
+            android:text="Above settings don't apply" />
 
         <Button
             android:id="@+id/btn_show_hosted_login_age"

--- a/app/src/main/res/layout/demo_activity.xml
+++ b/app/src/main/res/layout/demo_activity.xml
@@ -399,7 +399,6 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="20dp"
             android:layout_marginTop="20dp"
             android:orientation="horizontal">
 
@@ -418,6 +417,20 @@
                 android:text="Show Passwordless" />
 
         </LinearLayout>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="5dp"
+            android:layout_marginTop="10dp"
+            android:text="Hosted Login Page: Above settings don't apply" />
+
+        <Button
+            android:id="@+id/btn_show_hosted_login_age"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="20dp"
+            android:text="Show Hosted Login Page" />
 
 
     </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Lock</string>
+    <string name="app_name">Lock Demo</string>
     <string name="native_provider_message_invalid_authorize_url">The authorize URL is invalid.</string>
     <string name="native_provider_message_canceled">Canceled</string>
     <string name="native_provider_title">Native Identity Provider</string>

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ allprojects {
     group = 'com.auth0.android'
     
     repositories {
+        mavenLocal()
         jcenter()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ allprojects {
     group = 'com.auth0.android'
     
     repositories {
-        mavenLocal()
         jcenter()
     }
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     compile 'com.android.support:design:25.3.1'
     compile 'com.google.code.gson:gson:2.8.0'
     compile 'com.squareup:otto:1.3.8'
-    compile 'com.auth0.android:auth0:1.8.0-SNAPSHOT'
+    compile 'com.auth0.android:auth0:1.9.0'
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     testCompile 'org.robolectric:robolectric:3.1.2'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     compile 'com.android.support:design:25.3.1'
     compile 'com.google.code.gson:gson:2.8.0'
     compile 'com.squareup:otto:1.3.8'
-    compile 'com.auth0.android:auth0:1.8.0'
+    compile 'com.auth0.android:auth0:1.8.0-SNAPSHOT'
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     testCompile 'org.robolectric:robolectric:3.1.2'

--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -1,1 +1,25 @@
-<manifest package="com.auth0.android.lock" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.auth0.android.lock">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application>
+        <activity
+            android:name="com.auth0.android.provider.RedirectActivity"
+            tools:node="replace">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="${auth0Domain}"
+                    android:pathPrefix="/android/${applicationId}/callback"
+                    android:scheme="https" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/lib/src/test/java/com/auth0/android/lock/WebProviderTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/WebProviderTest.java
@@ -7,6 +7,7 @@ import android.net.Uri;
 import com.auth0.android.Auth0;
 import com.auth0.android.lock.internal.configuration.Options;
 import com.auth0.android.provider.AuthCallback;
+import com.auth0.android.provider.AuthenticationActivity;
 import com.auth0.android.provider.WebAuthActivity;
 
 import org.junit.Before;
@@ -93,7 +94,7 @@ public class WebProviderTest {
         assertThat(intent.getData(), hasParamWithValue("client_id", "clientId"));
         assertThat(intent.getData(), hasParamWithValue("connection", "my-connection"));
         assertThat(intent.getData(), hasParamWithValue("audience", "https://me.auth0.com/myapi"));
-        assertThat(intent, hasAction(Intent.ACTION_VIEW));
+        assertThat(intent, hasComponent(AuthenticationActivity.class.getName()));
     }
 
     @Test
@@ -119,7 +120,7 @@ public class WebProviderTest {
         assertThat(intent.getData(), hasParamWithValue("client_id", "clientId"));
         assertThat(intent.getData(), hasParamWithValue("connection", "my-connection"));
         assertThat(intent.getData(), hasParamWithValue("audience", "https://me.auth0.com/myapi"));
-        assertThat(intent, hasAction(Intent.ACTION_VIEW));
+        assertThat(intent, hasComponent(AuthenticationActivity.class.getName()));
     }
 
     @Test
@@ -156,7 +157,9 @@ public class WebProviderTest {
         assertThat(intent.getData(), hasParamWithValue("custom-param-2", "value-2"));
         assertThat(intent.getData(), hasParamWithValue("scope", "email profile photos"));
         assertThat(intent.getData(), hasParamWithValue("connection_scope", "the connection scope"));
-        assertThat(intent, hasAction(Intent.ACTION_VIEW));
+        assertThat(intent.hasExtra("com.auth0.android.EXTRA_USE_BROWSER"), is(true));
+        assertThat(intent.getBooleanExtra("com.auth0.android.EXTRA_USE_BROWSER", false), is(true));
+        assertThat(intent, hasComponent(AuthenticationActivity.class.getName()));
     }
 
     @Test
@@ -193,7 +196,9 @@ public class WebProviderTest {
         assertThat(intent.getData(), hasParamWithValue("custom-param-2", "value-2"));
         assertThat(intent.getData(), hasParamWithValue("scope", "email profile photos"));
         assertThat(intent.getData(), hasParamWithValue("connection_scope", "the connection scope"));
-        assertThat(intent, hasComponent(WebAuthActivity.class.getName()));
+        assertThat(intent.hasExtra("com.auth0.android.EXTRA_USE_BROWSER"), is(true));
+        assertThat(intent.getBooleanExtra("com.auth0.android.EXTRA_USE_BROWSER", true), is(false));
+        assertThat(intent, hasComponent(AuthenticationActivity.class.getName()));
     }
 
     @Test


### PR DESCRIPTION
The Web Provider requests the `https://domain.auth0.com/userinfo` audience. 

Also, a few changes were required in order to use the (still not released) WebAuthProvider that uses Chrome Custom Tabs. 

![image](https://user-images.githubusercontent.com/3900123/28073893-8df2ea54-662d-11e7-9939-9342d1c5b4e9.png)
