### PR TITLE
Add Password Toggle enabler/disabler

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -391,6 +391,17 @@ public class Lock {
         }
 
         /**
+         * Whether to show the password visibility toggle or not. Defaults to true
+         *
+         * @param allow whether to allow the user to toggle between showing or hiding the password or not.
+         * @return the current builder instance
+         */
+        public Builder allowShowPassword(boolean allow) {
+            options.setAllowShowPassword(allow);
+            return this;
+        }
+
+        /**
          * Whether if the submit button will display a label or just an icon. By default it will use the label.
          * If {@link #hideMainScreenTitle(boolean)} is set to true this setting is ignored and the submit button will use label.
          *

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
@@ -57,6 +57,7 @@ public class Configuration {
     private boolean allowLogIn;
     private boolean allowSignUp;
     private boolean allowForgotPassword;
+    private boolean allowShowPassword;
     private boolean usernameRequired;
     private boolean mustAcceptTerms;
     private boolean useLabeledSubmitButton;
@@ -188,6 +189,7 @@ public class Configuration {
             initialScreen = options.initialScreen();
         }
 
+        allowShowPassword = options.allowShowPassword();
         passwordlessMode = parsePasswordlessMode(options.useCodePasswordless());
 
         this.termsURL = options.getTermsURL() == null ? "https://auth0.com/terms" : options.getTermsURL();
@@ -227,6 +229,10 @@ public class Configuration {
 
     public boolean allowForgotPassword() {
         return allowForgotPassword;
+    }
+
+    public boolean allowShowPassword() {
+        return allowShowPassword;
     }
 
     public boolean isUsernameRequired() {

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -70,6 +70,7 @@ public class Options implements Parcelable {
     private boolean allowLogIn;
     private boolean allowSignUp;
     private boolean allowForgotPassword;
+    private boolean allowShowPassword;
     private boolean loginAfterSignUp;
     private boolean mustAcceptTerms;
     private boolean useLabeledSubmitButton;
@@ -98,6 +99,7 @@ public class Options implements Parcelable {
         allowLogIn = true;
         allowSignUp = true;
         allowForgotPassword = true;
+        allowShowPassword = true;
         loginAfterSignUp = true;
         useCodePasswordless = true;
         usePKCE = true;
@@ -118,6 +120,7 @@ public class Options implements Parcelable {
         allowLogIn = in.readByte() != WITHOUT_DATA;
         allowSignUp = in.readByte() != WITHOUT_DATA;
         allowForgotPassword = in.readByte() != WITHOUT_DATA;
+        allowShowPassword = in.readByte() != WITHOUT_DATA;
         loginAfterSignUp = in.readByte() != WITHOUT_DATA;
         mustAcceptTerms = in.readByte() != WITHOUT_DATA;
         useCodePasswordless = in.readByte() != WITHOUT_DATA;
@@ -195,6 +198,7 @@ public class Options implements Parcelable {
         dest.writeByte((byte) (allowLogIn ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (allowSignUp ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (allowForgotPassword ? HAS_DATA : WITHOUT_DATA));
+        dest.writeByte((byte) (allowShowPassword ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (loginAfterSignUp ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (mustAcceptTerms ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (useCodePasswordless ? HAS_DATA : WITHOUT_DATA));
@@ -354,6 +358,14 @@ public class Options implements Parcelable {
 
     public boolean allowForgotPassword() {
         return allowForgotPassword;
+    }
+
+    public boolean allowShowPassword() {
+        return allowShowPassword;
+    }
+
+    public void setAllowShowPassword(boolean allow) {
+        allowShowPassword = allow;
     }
 
     public String getDefaultDatabaseConnection() {

--- a/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
@@ -87,6 +87,7 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
         usernameInput.setDataType(DataType.NON_EMPTY_USERNAME);
         passwordInput = (ValidatedInputView) findViewById(R.id.com_auth0_lock_input_password);
         passwordInput.setDataType(DataType.PASSWORD);
+        passwordInput.setAllowShowPassword(configuration.allowShowPassword());
         passwordInput.setOnEditorActionListener(this);
 
         emailInput = (ValidatedUsernameInputView) findViewById(R.id.com_auth0_lock_input_username_email);

--- a/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
@@ -86,6 +86,7 @@ public class SignUpFormView extends FormView implements TextView.OnEditorActionL
         emailInput.setOnEditorActionListener(this);
         passwordInput = (ValidatedPasswordInputView) findViewById(R.id.com_auth0_lock_input_password);
         passwordInput.setPasswordPolicy(configuration.getPasswordPolicy());
+        passwordInput.setAllowShowPassword(configuration.allowShowPassword());
         passwordInput.setOnEditorActionListener(this);
 
         usernameInput.setVisibility(configuration.isUsernameRequired() ? View.VISIBLE : View.GONE);

--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedInputView.java
@@ -87,6 +87,7 @@ public class ValidatedInputView extends LinearLayout {
     private IdentityListener identityListener;
     private int inputIcon;
     private boolean hasValidInput;
+    private boolean allowShowPassword = true;
 
     @IntDef({USERNAME, EMAIL, USERNAME_OR_EMAIL, MFA_CODE, PHONE_NUMBER, PASSWORD, MOBILE_PHONE, TEXT_NAME, NUMBER, NON_EMPTY_USERNAME})
     @Retention(RetentionPolicy.SOURCE)
@@ -283,7 +284,7 @@ public class ValidatedInputView extends LinearLayout {
                 error = getResources().getString(R.string.com_auth0_lock_input_error_phone_number);
                 break;
         }
-        showPasswordToggle.setVisibility(dataType == PASSWORD ? ViewGroup.VISIBLE : ViewGroup.GONE);
+        showPasswordToggle.setVisibility(dataType == PASSWORD && allowShowPassword ? ViewGroup.VISIBLE : ViewGroup.GONE);
         showPasswordToggle.setChecked(false);
         input.setHint(hint);
         errorDescription.setText(error);
@@ -443,6 +444,17 @@ public class ValidatedInputView extends LinearLayout {
     @Override
     public boolean isEnabled() {
         return input.isEnabled();
+    }
+
+    /**
+     * Whether to display the Show Password toggle or not.
+     * Only available for Password data type. Defaults to true.
+     *
+     * @param allow whether to display a button to toggle between showing or hiding the password or not.
+     */
+    public void setAllowShowPassword(boolean allow) {
+        this.allowShowPassword = allow;
+        setupInputValidation();
     }
 
     /**

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
@@ -24,6 +24,8 @@
 
 package com.auth0.android.lock.internal.configuration;
 
+import android.util.Log;
+
 import com.auth0.android.lock.AuthButtonSize;
 import com.auth0.android.lock.InitialScreen;
 import com.auth0.android.lock.R;
@@ -38,7 +40,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.io.FileReader;
@@ -63,7 +65,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
-@RunWith(RobolectricGradleTestRunner.class)
+@RunWith(RobolectricTestRunner.class)
 @Config(constants = com.auth0.android.lock.BuildConfig.class, sdk = 21, manifest = Config.NONE)
 public class ConfigurationTest extends GsonBaseTest {
 
@@ -97,6 +99,7 @@ public class ConfigurationTest extends GsonBaseTest {
         assertThat(configuration.allowLogIn(), is(true));
         assertThat(configuration.allowSignUp(), is(true));
         assertThat(configuration.allowForgotPassword(), is(true));
+        assertThat(configuration.allowShowPassword(), is(true));
         assertThat(configuration.loginAfterSignUp(), is(true));
         assertThat(configuration.getUsernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
         assertThat(configuration.getInitialScreen(), is(equalTo(InitialScreen.LOG_IN)));
@@ -129,6 +132,7 @@ public class ConfigurationTest extends GsonBaseTest {
         options.setAllowLogIn(false);
         options.setAllowSignUp(false);
         options.setAllowForgotPassword(false);
+        options.setAllowShowPassword(false);
         options.setLoginAfterSignUp(false);
         options.setUsernameStyle(UsernameStyle.USERNAME);
         options.setAuthButtonSize(AuthButtonSize.BIG);
@@ -137,6 +141,7 @@ public class ConfigurationTest extends GsonBaseTest {
         assertThat(configuration.allowLogIn(), is(false));
         assertThat(configuration.allowSignUp(), is(false));
         assertThat(configuration.allowForgotPassword(), is(false));
+        assertThat(configuration.allowShowPassword(), is(false));
         assertThat(configuration.loginAfterSignUp(), is(false));
         assertThat(configuration.getUsernameStyle(), is(equalTo(UsernameStyle.USERNAME)));
         assertThat(configuration.getSocialButtonStyle(), is(equalTo(AuthButtonSize.BIG)));

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -412,6 +412,19 @@ public class OptionsTest {
     }
 
     @Test
+    public void shouldAllowShowPassword() throws Exception {
+        options.setAllowShowPassword(true);
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.allowShowPassword(), is(equalTo(parceledOptions.allowShowPassword())));
+        assertThat(options.allowShowPassword(), is(true));
+    }
+
+    @Test
     public void shouldUsePasswordlessCode() throws Exception {
         options.setUseCodePasswordless(false);
 
@@ -683,6 +696,7 @@ public class OptionsTest {
         assertThat(options.allowLogIn(), is(true));
         assertThat(options.allowSignUp(), is(true));
         assertThat(options.allowForgotPassword(), is(true));
+        assertThat(options.allowShowPassword(), is(true));
         assertThat(options.loginAfterSignUp(), is(true));
         assertThat(options.useCodePasswordless(), is(true));
         assertThat(options.mustAcceptTerms(), is(false));
@@ -709,6 +723,7 @@ public class OptionsTest {
         options.setAllowLogIn(true);
         options.setAllowSignUp(true);
         options.setAllowForgotPassword(true);
+        options.setAllowShowPassword(true);
         options.setClosable(true);
         options.setMustAcceptTerms(true);
         options.setAuthButtonSize(AuthButtonSize.BIG);
@@ -732,6 +747,7 @@ public class OptionsTest {
         assertThat(options.allowLogIn(), is(equalTo(parceledOptions.allowLogIn())));
         assertThat(options.allowSignUp(), is(equalTo(parceledOptions.allowSignUp())));
         assertThat(options.allowForgotPassword(), is(equalTo(parceledOptions.allowForgotPassword())));
+        assertThat(options.allowShowPassword(), is(equalTo(parceledOptions.allowShowPassword())));
         assertThat(options.authButtonSize(), is(equalTo(parceledOptions.authButtonSize())));
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
         assertThat(options.useLabeledSubmitButton(), is(equalTo(parceledOptions.useLabeledSubmitButton())));
@@ -749,6 +765,7 @@ public class OptionsTest {
         options.setAllowLogIn(false);
         options.setAllowSignUp(false);
         options.setAllowForgotPassword(false);
+        options.setAllowShowPassword(false);
         options.setMustAcceptTerms(false);
         options.setAuthButtonSize(AuthButtonSize.SMALL);
         options.setLoginAfterSignUp(false);
@@ -771,6 +788,7 @@ public class OptionsTest {
         assertThat(options.allowLogIn(), is(equalTo(parceledOptions.allowLogIn())));
         assertThat(options.allowSignUp(), is(equalTo(parceledOptions.allowSignUp())));
         assertThat(options.allowForgotPassword(), is(equalTo(parceledOptions.allowForgotPassword())));
+        assertThat(options.allowShowPassword(), is(equalTo(parceledOptions.allowShowPassword())));
         assertThat(options.authButtonSize(), is(equalTo(parceledOptions.authButtonSize())));
         assertThat(options.loginAfterSignUp(), is(equalTo(parceledOptions.loginAfterSignUp())));
         assertThat(options.useLabeledSubmitButton(), is(equalTo(parceledOptions.useLabeledSubmitButton())));


### PR DESCRIPTION
This PR adds a method to show or hide the toggle **button** that allows to show or hide the password in a password field.
Name of the method is the same as in web and ios.

Usage:
On the `Lock.Builder` instance call `allowShowPassword(false)` to hide the button. By default, the button is shown.