### PR TITLE
Add Change Password screen

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -55,7 +55,7 @@ import com.auth0.android.callback.AuthenticationCallback;
 import com.auth0.android.lock.errors.AuthenticationError;
 import com.auth0.android.lock.errors.LoginErrorMessageBuilder;
 import com.auth0.android.lock.errors.SignUpErrorMessageBuilder;
-import com.auth0.android.lock.events.DatabaseChangePasswordEvent;
+import com.auth0.android.lock.events.DatabaseResetPasswordEvent;
 import com.auth0.android.lock.events.DatabaseLoginEvent;
 import com.auth0.android.lock.events.DatabaseSignUpEvent;
 import com.auth0.android.lock.events.FetchApplicationEvent;
@@ -424,7 +424,7 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
 
     @SuppressWarnings("unused")
     @Subscribe
-    public void onDatabaseAuthenticationRequest(DatabaseChangePasswordEvent event) {
+    public void onDatabaseAuthenticationRequest(DatabaseResetPasswordEvent event) {
         if (configuration.getDatabaseConnection() == null) {
             Log.w(TAG, "There is no default Database connection to authenticate with");
             return;
@@ -516,6 +516,10 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
                         lockView.showMFACodeForm(lastDatabaseLogin);
                         return;
                     }
+                    if (error.isPasswordExpired()) {
+                        lockView.showMFACodeForm(lastDatabaseLogin);
+                        return;
+                    }
                     String message = authError.getMessage(LockActivity.this);
                     showErrorMessage(message);
                 }
@@ -555,7 +559,7 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
                 public void run() {
                     showSuccessMessage(getString(R.string.com_auth0_lock_db_change_password_message_success));
                     if (options.allowLogIn() || options.allowSignUp()) {
-                        lockView.showChangePasswordForm(false);
+                        lockView.showResetPasswordForm(false);
                     }
                 }
             });

--- a/lib/src/main/java/com/auth0/android/lock/errors/LoginErrorMessageBuilder.java
+++ b/lib/src/main/java/com/auth0/android/lock/errors/LoginErrorMessageBuilder.java
@@ -38,11 +38,16 @@ public class LoginErrorMessageBuilder implements ErrorMessageBuilder<Authenticat
     private static final String USER_IS_BLOCKED_DESCRIPTION = "user is blocked";
     private static final String TOO_MANY_ATTEMPTS_ERROR = "too_many_attempts";
     private static final String WRONG_CLIENT_TYPE_ERROR = "Unauthorized";
+    private static final String INVALID_REQUEST = "invalid_request";
+    private static final String NEW_OLD_PASSWORD_DESCRIPTION = "new_password and old_password cannot be equal";
 
     private static final int userExistsResource = R.string.com_auth0_lock_db_signup_user_already_exists_error_message;
     private static final int unauthorizedResource = R.string.com_auth0_lock_db_login_error_unauthorized_message;
     private static final int invalidMFACodeResource = R.string.com_auth0_lock_db_login_error_invalid_mfa_code_message;
     private static final int tooManyAttemptsResource = R.string.com_auth0_lock_db_too_many_attempts_error_message;
+    private static final int passwordAlreadyUsedResource = R.string.com_auth0_lock_db_signup_password_already_used_error_message;
+    private static final int passwordNotStrongResource = R.string.com_auth0_lock_db_signup_password_not_strong_error_message;
+    private static final int passwordSameAsPreviousResource = R.string.com_auth0_lock_db_change_password_same_password_error_message;
 
     private int invalidCredentialsResource;
     private int defaultMessage;
@@ -65,6 +70,12 @@ public class LoginErrorMessageBuilder implements ErrorMessageBuilder<Authenticat
             messageRes = invalidCredentialsResource;
         } else if (exception.isMultifactorCodeInvalid()) {
             messageRes = invalidMFACodeResource;
+        } else if (exception.isPasswordAlreadyUsed()) {
+            messageRes = passwordAlreadyUsedResource;
+        } else if (exception.isPasswordNotStrongEnough()) {
+            messageRes = passwordNotStrongResource;
+        } else if (INVALID_REQUEST.equals(exception.getCode()) && NEW_OLD_PASSWORD_DESCRIPTION.equals(exception.getDescription())) {
+            messageRes = passwordSameAsPreviousResource;
         } else if (USER_EXISTS_ERROR.equals(exception.getCode()) || USERNAME_EXISTS_ERROR.equals(exception.getCode())) {
             messageRes = userExistsResource;
         } else if (exception.isRuleError()) {
@@ -80,7 +91,6 @@ public class LoginErrorMessageBuilder implements ErrorMessageBuilder<Authenticat
         } else {
             messageRes = defaultMessage;
         }
-        //TODO: Catch specific errors for the SelfChangePassword endpoint
         return new AuthenticationError(messageRes, description);
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/errors/LoginErrorMessageBuilder.java
+++ b/lib/src/main/java/com/auth0/android/lock/errors/LoginErrorMessageBuilder.java
@@ -80,6 +80,7 @@ public class LoginErrorMessageBuilder implements ErrorMessageBuilder<Authenticat
         } else {
             messageRes = defaultMessage;
         }
+        //TODO: Catch specific errors for the SelfChangePassword endpoint
         return new AuthenticationError(messageRes, description);
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/events/DatabaseChangePasswordEvent.java
+++ b/lib/src/main/java/com/auth0/android/lock/events/DatabaseChangePasswordEvent.java
@@ -27,11 +27,6 @@ package com.auth0.android.lock.events;
 
 import android.support.annotation.NonNull;
 
-import com.auth0.android.authentication.AuthenticationAPIClient;
-import com.auth0.android.authentication.AuthenticationException;
-import com.auth0.android.authentication.request.DatabaseConnectionRequest;
-import com.auth0.android.request.AuthenticationRequest;
-
 public class DatabaseChangePasswordEvent {
 
     private final String usernameOrEmail;
@@ -49,12 +44,16 @@ public class DatabaseChangePasswordEvent {
         this.newPassword = newPassword;
     }
 
-    public DatabaseConnectionRequest<Void, AuthenticationException> getChangePasswordRequest(AuthenticationAPIClient apiClient, String connection) {
-        return apiClient.changePassword(usernameOrEmail, oldPassword, newPassword, connection);
+    public String getUsernameOrEmail() {
+        return usernameOrEmail;
     }
 
-    public AuthenticationRequest getLogInRequest(AuthenticationAPIClient apiClient, String connection) {
-        return apiClient.login(usernameOrEmail, newPassword, connection);
+    public String getOldPassword() {
+        return oldPassword;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
     }
 
 }

--- a/lib/src/main/java/com/auth0/android/lock/events/DatabaseChangePasswordEvent.java
+++ b/lib/src/main/java/com/auth0/android/lock/events/DatabaseChangePasswordEvent.java
@@ -1,0 +1,60 @@
+/*
+ * DbChangePasswordEvent.java
+ *
+ * Copyright (c) 2016 Auth0 (http://auth0.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.auth0.android.lock.events;
+
+
+import android.support.annotation.NonNull;
+
+import com.auth0.android.authentication.AuthenticationAPIClient;
+import com.auth0.android.authentication.AuthenticationException;
+import com.auth0.android.authentication.request.DatabaseConnectionRequest;
+import com.auth0.android.request.AuthenticationRequest;
+
+public class DatabaseChangePasswordEvent {
+
+    private final String usernameOrEmail;
+    private final String oldPassword;
+    private final String newPassword;
+
+    /**
+     * Creates a new Database Change Password event with the given email.
+     *
+     * @param usernameOrEmail a valid email to request a password reset.
+     */
+    public DatabaseChangePasswordEvent(@NonNull String usernameOrEmail, @NonNull String oldPassword, @NonNull String newPassword) {
+        this.usernameOrEmail = usernameOrEmail;
+        this.oldPassword = oldPassword;
+        this.newPassword = newPassword;
+    }
+
+    public DatabaseConnectionRequest<Void, AuthenticationException> getChangePasswordRequest(AuthenticationAPIClient apiClient, String connection) {
+        return apiClient.changePassword(usernameOrEmail, oldPassword, newPassword, connection);
+    }
+
+    public AuthenticationRequest getLogInRequest(AuthenticationAPIClient apiClient, String connection) {
+        return apiClient.login(usernameOrEmail, newPassword, connection);
+    }
+
+}

--- a/lib/src/main/java/com/auth0/android/lock/events/DatabaseResetPasswordEvent.java
+++ b/lib/src/main/java/com/auth0/android/lock/events/DatabaseResetPasswordEvent.java
@@ -27,14 +27,14 @@ package com.auth0.android.lock.events;
 
 import android.support.annotation.NonNull;
 
-public class DatabaseChangePasswordEvent extends DatabaseEvent {
+public class DatabaseResetPasswordEvent extends DatabaseEvent {
 
     /**
-     * Creates a new Database Change Password event with the given email.
+     * Creates a new Database Reset Password event with the given email.
      *
-     * @param email a valid email to request a password change.
+     * @param email a valid email to request a password reset.
      */
-    public DatabaseChangePasswordEvent(@NonNull String email) {
+    public DatabaseResetPasswordEvent(@NonNull String email) {
         super(email);
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -342,14 +342,14 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
         showSignUpTerms(false);
     }
 
-    public void showMFACodeForm(DatabaseLoginEvent event) {
-        MFACodeFormView form = new MFACodeFormView(this, event.getUsernameOrEmail(), event.getPassword());
+    public void showMFACodeForm(String usernameOrEmail, String password) {
+        MFACodeFormView form = new MFACodeFormView(this, usernameOrEmail, password);
         updateHeaderTitle(R.string.com_auth0_lock_title_mfa_input_code);
         addSubForm(form);
     }
 
-    public void showPasswordExpiredForm(DatabaseLoginEvent event) {
-        PasswordExpiredFormView form = new PasswordExpiredFormView(this, event.getUsernameOrEmail(), event.getPassword());
+    public void showPasswordExpiredForm(String usernameOrEmail, String password) {
+        PasswordExpiredFormView form = new PasswordExpiredFormView(this, usernameOrEmail, password);
         updateHeaderTitle(R.string.com_auth0_lock_title_password_expired);
         updateButtonLabel(R.string.com_auth0_lock_action_change_password);
         addSubForm(form);

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -45,7 +45,6 @@ import android.widget.TextView;
 
 import com.auth0.android.lock.InitialScreen;
 import com.auth0.android.lock.R;
-import com.auth0.android.lock.events.DatabaseLoginEvent;
 import com.auth0.android.lock.events.DatabaseSignUpEvent;
 import com.auth0.android.lock.events.FetchApplicationEvent;
 import com.auth0.android.lock.events.OAuthLoginEvent;

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -160,7 +160,7 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
             showBottomBanner(true);
             updateButtonLabel(R.string.com_auth0_lock_action_sign_up);
         } else if (configuration.allowForgotPassword() && configuration.getInitialScreen() == InitialScreen.FORGOT_PASSWORD) {
-            showChangePasswordForm(true);
+            showResetPasswordForm(true);
         }
     }
 
@@ -217,9 +217,9 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
     }
 
     @Override
-    public void showChangePasswordForm(boolean show) {
+    public void showResetPasswordForm(boolean show) {
         if (show) {
-            ChangePasswordFormView form = new ChangePasswordFormView(this, lastEmailInput);
+            ResetPasswordFormView form = new ResetPasswordFormView(this, lastEmailInput);
             updateHeaderTitle(R.string.com_auth0_lock_title_change_password);
             addSubForm(form);
             updateButtonLabel(R.string.com_auth0_lock_action_send_email);

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -348,6 +348,13 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
         addSubForm(form);
     }
 
+    public void showPasswordExpiredForm(DatabaseLoginEvent event) {
+        PasswordExpiredFormView form = new PasswordExpiredFormView(this, event.getUsernameOrEmail(), event.getPassword());
+        updateHeaderTitle(R.string.com_auth0_lock_title_password_expired);
+        updateButtonLabel(R.string.com_auth0_lock_action_change_password);
+        addSubForm(form);
+    }
+
     @Override
     public void onOAuthLoginRequest(OAuthLoginEvent event) {
         bus.post(event);

--- a/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
@@ -56,14 +56,14 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
     private ValidatedUsernameInputView usernameInput;
     private ValidatedInputView passwordInput;
     private SocialButton enterpriseBtn;
-    private View changePasswordBtn;
+    private View resetPasswordBtn;
     private TextView topMessage;
     private OAuthConnection currentConnection;
     private String currentUsername;
     private EnterpriseConnectionMatcher domainParser;
     private boolean fallbackToDatabase;
     private boolean corporateSSO;
-    private boolean changePasswordEnabled;
+    private boolean resetPasswordEnabled;
 
     public LogInFormView(Context context) {
         super(context);
@@ -78,7 +78,7 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
 
     private void init() {
         inflate(getContext(), R.layout.com_auth0_lock_login_form_view, this);
-        changePasswordBtn = findViewById(R.id.com_auth0_lock_change_password_btn);
+        resetPasswordBtn = findViewById(R.id.com_auth0_lock_change_password_btn);
         enterpriseBtn = (SocialButton) findViewById(R.id.com_auth0_lock_enterprise_button);
         topMessage = (TextView) findViewById(R.id.com_auth0_lock_text);
         Configuration configuration = lockWidget.getConfiguration();
@@ -96,12 +96,12 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
         emailInput.setIdentityListener(this);
 
         fallbackToDatabase = configuration.getDatabaseConnection() != null;
-        changePasswordEnabled = fallbackToDatabase && configuration.allowForgotPassword();
-        changePasswordBtn.setVisibility(changePasswordEnabled ? VISIBLE : GONE);
-        changePasswordBtn.setOnClickListener(new OnClickListener() {
+        resetPasswordEnabled = fallbackToDatabase && configuration.allowForgotPassword();
+        resetPasswordBtn.setVisibility(resetPasswordEnabled ? VISIBLE : GONE);
+        resetPasswordBtn.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                lockWidget.showChangePasswordForm(true);
+                lockWidget.showResetPasswordForm(true);
             }
         });
         boolean socialAvailable = !configuration.getSocialConnections().isEmpty();
@@ -216,7 +216,7 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
         if (currentUsername != null && !currentUsername.isEmpty()) {
             usernameInput.setText(currentUsername);
         }
-        changePasswordBtn.setVisibility(GONE);
+        resetPasswordBtn.setVisibility(GONE);
         corporateSSO = true;
         usernameInput.clearFocus();
         InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
@@ -273,8 +273,8 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
 
     private void showSSOMessage(boolean show) {
         lockWidget.showTopBanner(show);
-        if (changePasswordEnabled) {
-            changePasswordBtn.setVisibility(show ? GONE : VISIBLE);
+        if (resetPasswordEnabled) {
+            resetPasswordBtn.setVisibility(show ? GONE : VISIBLE);
         }
     }
 

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordExpiredFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordExpiredFormView.java
@@ -1,0 +1,106 @@
+/*
+ * MFACodeFormView.java
+ *
+ * Copyright (c) 2016 Auth0 (http://auth0.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.auth0.android.lock.views;
+
+import android.support.annotation.Nullable;
+import android.view.KeyEvent;
+import android.view.inputmethod.EditorInfo;
+import android.widget.TextView;
+
+import com.auth0.android.lock.R;
+import com.auth0.android.lock.events.DatabaseChangePasswordEvent;
+import com.auth0.android.lock.views.interfaces.LockWidget;
+
+public class PasswordExpiredFormView extends FormView implements TextView.OnEditorActionListener {
+
+    private final String usernameOrEmail;
+    private final String oldPassword;
+    private final LockWidget lockWidget;
+
+    private ValidatedPasswordInputView passwordInput;
+    private ValidatedPasswordInputView confirmPasswordInput;
+
+
+    public PasswordExpiredFormView(LockWidget lockWidget, String usernameOrEmail, String oldPassword) {
+        super(lockWidget.getContext());
+        this.lockWidget = lockWidget;
+        this.usernameOrEmail = usernameOrEmail;
+        this.oldPassword = oldPassword;
+        init();
+    }
+
+    private void init() {
+        inflate(getContext(), R.layout.com_auth0_lock_pwdexpired_form_view, this);
+        passwordInput = (ValidatedPasswordInputView) findViewById(R.id.com_auth0_lock_input_password);
+        confirmPasswordInput = (ValidatedPasswordInputView) findViewById(R.id.com_auth0_lock_input_confirm_password);
+
+        passwordInput.setPasswordPolicy(lockWidget.getConfiguration().getPasswordPolicy());
+        if (lockWidget.getConfiguration().allowShowPassword()) {
+            passwordInput.setOnEditorActionListener(this);
+            return;
+        }
+
+        confirmPasswordInput.setVisibility(VISIBLE);
+        confirmPasswordInput.setOnEditorActionListener(this);
+        confirmPasswordInput.setHint(R.string.com_auth0_lock_hint_confirm_password);
+    }
+
+    @Override
+    public Object getActionEvent() {
+        return new DatabaseChangePasswordEvent(usernameOrEmail, oldPassword, getInputText());
+    }
+
+    private String getInputText() {
+        return passwordInput.getText();
+    }
+
+    @Override
+    public boolean validateForm() {
+        //Password must:
+        //Be the same as confirmPassword if allowShowPassword==false
+        //Be different from the oldPassword
+        //Comply with the password policy set for this connection
+//        boolean equalsToLast = oldPassword.equals(passwordInput.getText());
+        if (lockWidget.getConfiguration().allowShowPassword()) {
+            return passwordInput.validate();
+        } else {
+            return passwordInput.validate() && confirmPasswordInput.validate() && passwordInput.getText().equals(confirmPasswordInput.getText());
+        }
+    }
+
+    @Nullable
+    @Override
+    public Object submitForm() {
+        return validateForm() ? getActionEvent() : null;
+    }
+
+    @Override
+    public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+        if (actionId == EditorInfo.IME_ACTION_DONE) {
+            lockWidget.onFormSubmit();
+        }
+        return false;
+    }
+}

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordExpiredFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordExpiredFormView.java
@@ -40,7 +40,7 @@ public class PasswordExpiredFormView extends FormView implements TextView.OnEdit
     private final LockWidget lockWidget;
 
     private ValidatedPasswordInputView passwordInput;
-    private ValidatedPasswordInputView confirmPasswordInput;
+    private ValidatedConfirmationInputView confirmPasswordInput;
 
 
     public PasswordExpiredFormView(LockWidget lockWidget, String usernameOrEmail, String oldPassword) {
@@ -54,17 +54,20 @@ public class PasswordExpiredFormView extends FormView implements TextView.OnEdit
     private void init() {
         inflate(getContext(), R.layout.com_auth0_lock_pwdexpired_form_view, this);
         passwordInput = (ValidatedPasswordInputView) findViewById(R.id.com_auth0_lock_input_password);
-        confirmPasswordInput = (ValidatedPasswordInputView) findViewById(R.id.com_auth0_lock_input_confirm_password);
 
         passwordInput.setPasswordPolicy(lockWidget.getConfiguration().getPasswordPolicy());
         if (lockWidget.getConfiguration().allowShowPassword()) {
             passwordInput.setOnEditorActionListener(this);
             return;
         }
-
+        passwordInput.setAllowShowPassword(false);
+        confirmPasswordInput = (ValidatedConfirmationInputView) findViewById(R.id.com_auth0_lock_input_confirm_password);
+        confirmPasswordInput.attachToInput(passwordInput);
+        confirmPasswordInput.setAllowShowPassword(false);
         confirmPasswordInput.setVisibility(VISIBLE);
         confirmPasswordInput.setOnEditorActionListener(this);
         confirmPasswordInput.setHint(R.string.com_auth0_lock_hint_confirm_password);
+        confirmPasswordInput.setErrorDescription(getResources().getString(R.string.com_auth0_lock_input_error_password_do_not_match));
     }
 
     @Override
@@ -78,16 +81,14 @@ public class PasswordExpiredFormView extends FormView implements TextView.OnEdit
 
     @Override
     public boolean validateForm() {
-        //Password must:
-        //Be the same as confirmPassword if allowShowPassword==false
-        //Be different from the oldPassword
-        //Comply with the password policy set for this connection
-//        boolean equalsToLast = oldPassword.equals(passwordInput.getText());
-        if (lockWidget.getConfiguration().allowShowPassword()) {
+        //New password must:
+        //- Be the same as confirmPassword
+        //- Be different from the oldPassword
+        //- Comply with the password policy set for this connection
+        if (confirmPasswordInput.getVisibility() != VISIBLE) {
             return passwordInput.validate();
-        } else {
-            return passwordInput.validate() && confirmPasswordInput.validate() && passwordInput.getText().equals(confirmPasswordInput.getText());
         }
+        return passwordInput.validate() && confirmPasswordInput.validate();
     }
 
     @Nullable

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
@@ -88,13 +88,11 @@ public class PasswordStrengthView extends LinearLayout {
     /**
      * @see "https://auth0.com/docs/connections/database/password-strength"
      */
-    private void showPolicy() {
+    private void refreshPolicyUI() {
         if (strength == PasswordStrength.NONE) {
-            setEnabled(false);
             setVisibility(GONE);
             return;
         }
-        setEnabled(true);
         setVisibility(VISIBLE);
 
         optionLowercase.setMandatory(strength == PasswordStrength.FAIR);
@@ -179,12 +177,14 @@ public class PasswordStrengthView extends LinearLayout {
 
     /**
      * Sets the current level of Strength that this widget is going to validate.
+     * Updating the strength will hide the widget until {@link #isValid(String)} is called.
      *
      * @param strength the required strength level.
      */
     public void setStrength(@PasswordStrength int strength) {
         this.strength = strength;
-        showPolicy();
+        refreshPolicyUI();
+        setVisibility(GONE);
     }
 
     /**

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordStrengthView.java
@@ -90,9 +90,11 @@ public class PasswordStrengthView extends LinearLayout {
      */
     private void refreshPolicyUI() {
         if (strength == PasswordStrength.NONE) {
+            setEnabled(false);
             setVisibility(GONE);
             return;
         }
+        setEnabled(true);
         setVisibility(VISIBLE);
 
         optionLowercase.setMandatory(strength == PasswordStrength.FAIR);

--- a/lib/src/main/java/com/auth0/android/lock/views/ResetPasswordFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ResetPasswordFormView.java
@@ -28,34 +28,33 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.util.Log;
 import android.view.KeyEvent;
-import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.widget.TextView;
 
 import com.auth0.android.lock.R;
-import com.auth0.android.lock.events.DatabaseChangePasswordEvent;
+import com.auth0.android.lock.events.DatabaseResetPasswordEvent;
 import com.auth0.android.lock.views.interfaces.IdentityListener;
 import com.auth0.android.lock.views.interfaces.LockWidgetForm;
 
-public class ChangePasswordFormView extends FormView implements TextView.OnEditorActionListener, IdentityListener {
+public class ResetPasswordFormView extends FormView implements TextView.OnEditorActionListener, IdentityListener {
 
-    private static final String TAG = ChangePasswordFormView.class.getSimpleName();
+    private static final String TAG = ResetPasswordFormView.class.getSimpleName();
     private final LockWidgetForm lockWidget;
     private ValidatedInputView emailInput;
 
-    public ChangePasswordFormView(Context context) {
+    public ResetPasswordFormView(Context context) {
         super(context);
         lockWidget = null;
     }
 
-    public ChangePasswordFormView(LockWidgetForm lockWidget, String email) {
+    public ResetPasswordFormView(LockWidgetForm lockWidget, String email) {
         super(lockWidget.getContext());
         this.lockWidget = lockWidget;
         init(email);
     }
 
     private void init(String email) {
-        inflate(getContext(), R.layout.com_auth0_lock_changepwd_form_view, this);
+        inflate(getContext(), R.layout.com_auth0_lock_resetpwd_form_view, this);
         emailInput = (ValidatedInputView) findViewById(R.id.com_auth0_lock_input_email);
         emailInput.setText(email);
         emailInput.setIdentityListener(this);
@@ -64,7 +63,7 @@ public class ChangePasswordFormView extends FormView implements TextView.OnEdito
 
     @Override
     public Object getActionEvent() {
-        return new DatabaseChangePasswordEvent(getUsernameOrEmail());
+        return new DatabaseResetPasswordEvent(getUsernameOrEmail());
     }
 
     @NonNull

--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedConfirmationInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedConfirmationInputView.java
@@ -1,0 +1,70 @@
+/*
+ * EmailAndPasswordView.java
+ *
+ * Copyright (c) 2016 Auth0 (http://auth0.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.auth0.android.lock.views;
+
+import android.content.Context;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.util.AttributeSet;
+
+public class ValidatedConfirmationInputView extends ValidatedInputView {
+
+    private String externalInputText;
+
+    public ValidatedConfirmationInputView(Context context) {
+        super(context);
+    }
+
+    public ValidatedConfirmationInputView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public ValidatedConfirmationInputView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public void attachToInput(ValidatedInputView inputView) {
+        inputView.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                externalInputText = s.toString();
+            }
+        });
+    }
+
+    @Override
+    protected boolean validate(boolean validateEmptyFields) {
+        return super.validate(validateEmptyFields) && getText().equals(externalInputText);
+    }
+
+}

--- a/lib/src/main/java/com/auth0/android/lock/views/interfaces/LockWidgetForm.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/interfaces/LockWidgetForm.java
@@ -30,7 +30,7 @@ import com.auth0.android.lock.events.DatabaseSignUpEvent;
 
 public interface LockWidgetForm extends LockWidgetOAuth, IdentityListener {
 
-    void showChangePasswordForm(boolean show);
+    void showResetPasswordForm(boolean show);
 
     void showCustomFieldsForm(DatabaseSignUpEvent event);
 

--- a/lib/src/main/res/layout/com_auth0_lock_pwdexpired_form_view.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_pwdexpired_form_view.xml
@@ -35,7 +35,9 @@
     android:paddingRight="@dimen/com_auth0_lock_widget_horizontal_margin"
     android:paddingTop="@dimen/com_auth0_lock_widget_vertical_margin_field">
 
-    <com.auth0.android.lock.views.LineSpacingTextView
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:id="@+id/com_auth0_lock_text"
         style="@style/Lock.Theme.Text.Subtitle.ResetPassword"
         android:text="@string/com_auth0_lock_description_password_expired"
@@ -48,13 +50,13 @@
         android:layout_marginTop="@dimen/com_auth0_lock_widget_vertical_margin_passwordless"
         lock:Auth0.InputDataType="password" />
 
-    <com.auth0.android.lock.views.ValidatedPasswordInputView
+    <com.auth0.android.lock.views.ValidatedConfirmationInputView
         android:id="@+id/com_auth0_lock_input_confirm_password"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/com_auth0_lock_widget_vertical_margin_passwordless"
-        android:visibility="visible"
+        android:layout_marginTop="@dimen/com_auth0_lock_widget_vertical_margin_field"
+        android:visibility="gone"
         lock:Auth0.InputDataType="password"
-        tools:visibility="gone" />
+        tools:visibility="visible" />
 
 </LinearLayout>

--- a/lib/src/main/res/layout/com_auth0_lock_pwdexpired_form_view.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_pwdexpired_form_view.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ com_auth0_lock_mfa_input_code_form_view.xml
+  ~
+  ~ Copyright (c) 2016 Auth0 (http://auth0.com)
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:lock="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_gravity="center"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/com_auth0_lock_widget_vertical_margin_field"
+    android:paddingLeft="@dimen/com_auth0_lock_widget_horizontal_margin"
+    android:paddingRight="@dimen/com_auth0_lock_widget_horizontal_margin"
+    android:paddingTop="@dimen/com_auth0_lock_widget_vertical_margin_field">
+
+    <com.auth0.android.lock.views.LineSpacingTextView
+        android:id="@+id/com_auth0_lock_text"
+        style="@style/Lock.Theme.Text.Subtitle.ResetPassword"
+        android:text="@string/com_auth0_lock_description_password_expired"
+        android:textSize="@dimen/com_auth0_lock_title_text" />
+
+    <com.auth0.android.lock.views.ValidatedPasswordInputView
+        android:id="@+id/com_auth0_lock_input_password"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/com_auth0_lock_widget_vertical_margin_passwordless"
+        lock:Auth0.InputDataType="password" />
+
+    <com.auth0.android.lock.views.ValidatedPasswordInputView
+        android:id="@+id/com_auth0_lock_input_confirm_password"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/com_auth0_lock_widget_vertical_margin_passwordless"
+        android:visibility="visible"
+        lock:Auth0.InputDataType="password"
+        tools:visibility="gone" />
+
+</LinearLayout>

--- a/lib/src/main/res/layout/com_auth0_lock_resetpwd_form_view.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_resetpwd_form_view.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ com_auth0_lock_changepwd_form_view.xml
+  ~ com_auth0_lock_resetpwd_form_view.xml
   ~
   ~ Copyright (c) 2016 Auth0 (http://auth0.com)
   ~

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -76,6 +76,7 @@
     <string name="com_auth0_lock_input_error_code">Invalid Code</string>
     <string name="com_auth0_lock_input_error_phone_number">Invalid Phone Number</string>
     <string name="com_auth0_lock_input_error_empty">The value cannot be empty</string>
+    <string name="com_auth0_lock_input_error_password_do_not_match">Passwords do not match</string>
     <string name="com_auth0_lock_hint_email">Email</string>
     <string name="com_auth0_lock_hint_password">Password</string>
     <string name="com_auth0_lock_hint_confirm_password">Confirm password</string>

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -150,8 +150,8 @@
     <string name="com_auth0_lock_db_login_error_invalid_mfa_code_message">THE CODE IS INVALID OR HAS EXPIRED</string>
     <string name="com_auth0_lock_title_mfa_input_code">Two Step Verification</string>
     <string name="com_auth0_lock_description_mfa_input_code">Please enter a verification code from\n your code generator application.</string>
-    <string name="com_auth0_lock_title_password_expired">Change Password</string>
-    <string name="com_auth0_lock_description_password_expired">Your password has expired. Please change your password to continue logging in.</string>
+    <string name="com_auth0_lock_title_password_expired">Password Expired</string>
+    <string name="com_auth0_lock_description_password_expired">Please change your password</string>
 
     <!-- Password Strength/Policies -->
     <string name="com_auth0_lock_password_strength_identical_chars">No more than 2 identical characters in a row (e.g., "111" not allowed)</string>

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -78,6 +78,7 @@
     <string name="com_auth0_lock_input_error_empty">The value cannot be empty</string>
     <string name="com_auth0_lock_hint_email">Email</string>
     <string name="com_auth0_lock_hint_password">Password</string>
+    <string name="com_auth0_lock_hint_confirm_password">Confirm password</string>
     <string name="com_auth0_lock_hint_username">Username</string>
     <string name="com_auth0_lock_hint_username_or_email">Username/Email</string>
     <string name="com_auth0_lock_hint_code">Code</string>
@@ -89,6 +90,7 @@
     <string name="com_auth0_lock_mode_sign_up">Sign Up</string>
     <string name="com_auth0_lock_mode_log_in">Log In</string>
     <string name="com_auth0_lock_action_send_email">SEND EMAIL</string>
+    <string name="com_auth0_lock_action_change_password">CHANGE PASSWORD</string>
     <string name="com_auth0_lock_action_forgot_password">Don\'t remember your password?</string>
     <string name="com_auth0_lock_action_single_login_with_corporate">Login with your corporate credentials.</string>
     <string name="com_auth0_lock_action_login_with_corporate">Please enter your corporate credentials at %s</string>
@@ -135,6 +137,7 @@
     <string name="com_auth0_lock_db_sign_up_error_message">THERE WAS AN ERROR PROCESSING THE SIGN UP</string>
     <string name="com_auth0_lock_db_change_password_message_success">WE\'VE JUST SENT YOU AN EMAIL TO RESET YOUR PASSWORD</string>
     <string name="com_auth0_lock_db_message_change_password_error">COULDN\'T RESET YOUR PASSWORD</string>
+    <string name="com_auth0_lock_db_password_changed_message">YOUR PASSWORD HAS BEEN CHANGED. LOGGING IN…</string>
     <string name="com_auth0_lock_db_signup_user_already_exists_error_message">THE USER ALREADY EXISTS</string>
     <string name="com_auth0_lock_db_signup_password_already_used_error_message">THE PASSWORD WAS USED PREVIOUSLY</string>
     <string name="com_auth0_lock_db_signup_password_not_strong_error_message">THE PASSWORD IS NOT STRONG ENOUGH</string>
@@ -145,6 +148,8 @@
     <string name="com_auth0_lock_db_login_error_invalid_mfa_code_message">THE CODE IS INVALID OR HAS EXPIRED</string>
     <string name="com_auth0_lock_title_mfa_input_code">Two Step Verification</string>
     <string name="com_auth0_lock_description_mfa_input_code">Please enter a verification code from\n your code generator application.</string>
+    <string name="com_auth0_lock_title_password_expired">Change Password</string>
+    <string name="com_auth0_lock_description_password_expired">Your password has expired. Please change your password to continue logging in.</string>
 
     <!-- Password Strength/Policies -->
     <string name="com_auth0_lock_password_strength_identical_chars">No more than 2 identical characters in a row (e.g., "111" not allowed)</string>

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -151,7 +151,7 @@
     <string name="com_auth0_lock_title_mfa_input_code">Two Step Verification</string>
     <string name="com_auth0_lock_description_mfa_input_code">Please enter a verification code from\n your code generator application.</string>
     <string name="com_auth0_lock_title_password_expired">Password Expired</string>
-    <string name="com_auth0_lock_description_password_expired">Please change your password</string>
+    <string name="com_auth0_lock_description_password_expired">Please change your password to continue logging in.</string>
 
     <!-- Password Strength/Policies -->
     <string name="com_auth0_lock_password_strength_identical_chars">No more than 2 identical characters in a row (e.g., "111" not allowed)</string>

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -134,7 +134,7 @@
     <string name="com_auth0_lock_db_login_error_unauthorized_message">USER IS BLOCKED</string>
     <string name="com_auth0_lock_db_sign_up_error_message">THERE WAS AN ERROR PROCESSING THE SIGN UP</string>
     <string name="com_auth0_lock_db_change_password_message_success">WE\'VE JUST SENT YOU AN EMAIL TO RESET YOUR PASSWORD</string>
-    <string name="com_auth0_lock_db_message_change_password_error">COULDNT\'t RESET YOUR PASSWORD</string>
+    <string name="com_auth0_lock_db_message_change_password_error">COULDN\'T RESET YOUR PASSWORD</string>
     <string name="com_auth0_lock_db_signup_user_already_exists_error_message">THE USER ALREADY EXISTS</string>
     <string name="com_auth0_lock_db_signup_password_already_used_error_message">THE PASSWORD WAS USED PREVIOUSLY</string>
     <string name="com_auth0_lock_db_signup_password_not_strong_error_message">THE PASSWORD IS NOT STRONG ENOUGH</string>

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -137,6 +137,7 @@
     <string name="com_auth0_lock_db_login_error_unauthorized_message">USER IS BLOCKED</string>
     <string name="com_auth0_lock_db_sign_up_error_message">THERE WAS AN ERROR PROCESSING THE SIGN UP</string>
     <string name="com_auth0_lock_db_change_password_message_success">WE\'VE JUST SENT YOU AN EMAIL TO RESET YOUR PASSWORD</string>
+    <string name="com_auth0_lock_db_change_password_same_password_error_message">NEW PASSWORD MUST BE DIFFERENT FROM THE PREVIOUS ONE</string>
     <string name="com_auth0_lock_db_message_change_password_error">COULDN\'T RESET YOUR PASSWORD</string>
     <string name="com_auth0_lock_db_password_changed_message">YOUR PASSWORD HAS BEEN CHANGED. LOGGING IN…</string>
     <string name="com_auth0_lock_db_signup_user_already_exists_error_message">THE USER ALREADY EXISTS</string>

--- a/lib/src/test/java/com/auth0/android/lock/LockActivityTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/LockActivityTest.java
@@ -8,7 +8,7 @@ import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.authentication.request.DatabaseConnectionRequest;
 import com.auth0.android.authentication.request.SignUpRequest;
 import com.auth0.android.callback.BaseCallback;
-import com.auth0.android.lock.events.DatabaseChangePasswordEvent;
+import com.auth0.android.lock.events.DatabaseResetPasswordEvent;
 import com.auth0.android.lock.events.DatabaseLoginEvent;
 import com.auth0.android.lock.events.DatabaseSignUpEvent;
 import com.auth0.android.lock.events.OAuthLoginEvent;
@@ -320,7 +320,7 @@ public class LockActivityTest {
     @Test
     public void shouldFailDatabasePasswordResetOnNullConnection() throws Exception {
         when(configuration.getDatabaseConnection()).thenReturn(null);
-        DatabaseChangePasswordEvent event = new DatabaseChangePasswordEvent("email@domain.com");
+        DatabaseResetPasswordEvent event = new DatabaseResetPasswordEvent("email@domain.com");
         activity.onDatabaseAuthenticationRequest(event);
 
         verify(lockView, never()).showProgress(true);
@@ -333,7 +333,7 @@ public class LockActivityTest {
 
     @Test
     public void shouldCallDatabasePasswordReset() throws Exception {
-        DatabaseChangePasswordEvent event = new DatabaseChangePasswordEvent("email@domain.com");
+        DatabaseResetPasswordEvent event = new DatabaseResetPasswordEvent("email@domain.com");
         activity.onDatabaseAuthenticationRequest(event);
 
         verify(lockView).showProgress(true);


### PR DESCRIPTION
This PR adds support for the **Self Change Password** endpoint.


We need to tweak the copy/text of the description.
![image](https://user-images.githubusercontent.com/3900123/29290942-512bc266-8118-11e7-92f9-f55e1c616e7d.png)


![image](https://user-images.githubusercontent.com/3900123/29290960-5bb283be-8118-11e7-93ab-75be4562620c.png)

Both "new passwords" must match. Validation runs while typing the second field or when the form is submitted:
![image](https://user-images.githubusercontent.com/3900123/29290966-6138ef26-8118-11e7-8f4f-1d0534e238c9.png)

Focus on the green message and ignore the screen below. After a successful request, lock will auto login the user using the `identity` and the `newPassword` while showing the Login screen.
![image](https://user-images.githubusercontent.com/3900123/29290980-6a8c750c-8118-11e7-91e1-e79384a0cde9.png)

Password policy. We need to tweak the margin between the description and the password policy part of the widget. Also, because of the narrow description space, the form expands too much and it's made scrollable.
![image](https://user-images.githubusercontent.com/3900123/29291132-edcf3b0c-8118-11e7-93c1-6c68541b5369.png)


If allowShowPassword is `true` the password confirm field is hidden.
![image](https://user-images.githubusercontent.com/3900123/29291213-47779b86-8119-11e7-99ec-b9eb5d5758bf.png)

![image](https://user-images.githubusercontent.com/3900123/29291229-4f99fbe2-8119-11e7-801c-46d62b5ada01.png)
