### PR TITLE
Enable MFA support for OIDC conformant clients

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/errors/LoginErrorMessageBuilder.java
+++ b/lib/src/main/java/com/auth0/android/lock/errors/LoginErrorMessageBuilder.java
@@ -42,6 +42,7 @@ public class LoginErrorMessageBuilder implements ErrorMessageBuilder<Authenticat
     private static final int userExistsResource = R.string.com_auth0_lock_db_signup_user_already_exists_error_message;
     private static final int unauthorizedResource = R.string.com_auth0_lock_db_login_error_unauthorized_message;
     private static final int invalidMFACodeResource = R.string.com_auth0_lock_db_login_error_invalid_mfa_code_message;
+    private static final int mfaEnrollRequiredResource = R.string.com_auth0_lock_db_login_error_mfa_enroll_required;
     private static final int tooManyAttemptsResource = R.string.com_auth0_lock_db_too_many_attempts_error_message;
 
     private int invalidCredentialsResource;
@@ -63,8 +64,10 @@ public class LoginErrorMessageBuilder implements ErrorMessageBuilder<Authenticat
 
         if (exception.isInvalidCredentials()) {
             messageRes = invalidCredentialsResource;
-        } else if (exception.isMultifactorCodeInvalid()) {
+        } else if (exception.isMultifactorCodeInvalid() || exception.isMultifactorTokenInvalid()) {
             messageRes = invalidMFACodeResource;
+        } else if (exception.isMultifactorEnrollRequired()) {
+            messageRes = mfaEnrollRequiredResource;
         } else if (USER_EXISTS_ERROR.equals(exception.getCode()) || USERNAME_EXISTS_ERROR.equals(exception.getCode())) {
             messageRes = userExistsResource;
         } else if (exception.isRuleError()) {

--- a/lib/src/main/java/com/auth0/android/lock/events/DatabaseLoginEvent.java
+++ b/lib/src/main/java/com/auth0/android/lock/events/DatabaseLoginEvent.java
@@ -32,6 +32,7 @@ public class DatabaseLoginEvent extends DatabaseEvent {
 
     private String password;
     private String verificationCode;
+    private String mfaToken;
 
     public DatabaseLoginEvent(@NonNull String usernameOrEmail, @NonNull String password) {
         super(usernameOrEmail);
@@ -55,5 +56,14 @@ public class DatabaseLoginEvent extends DatabaseEvent {
     @Nullable
     public String getVerificationCode() {
         return verificationCode;
+    }
+
+    public void setMFAToken(@NonNull String mfaToken) {
+        this.mfaToken = mfaToken;
+    }
+
+    @Nullable
+    public String getMFAToken() {
+        return mfaToken;
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -344,7 +344,7 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
     }
 
     public void showMFACodeForm(DatabaseLoginEvent event) {
-        MFACodeFormView form = new MFACodeFormView(this, event.getUsernameOrEmail(), event.getPassword());
+        MFACodeFormView form = new MFACodeFormView(this, event.getUsernameOrEmail(), event.getPassword(), event.getMFAToken());
         updateHeaderTitle(R.string.com_auth0_lock_title_mfa_input_code);
         addSubForm(form);
     }

--- a/lib/src/main/java/com/auth0/android/lock/views/MFACodeFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/MFACodeFormView.java
@@ -24,9 +24,9 @@
 
 package com.auth0.android.lock.views;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.KeyEvent;
-import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.widget.TextView;
 
@@ -38,16 +38,18 @@ public class MFACodeFormView extends FormView implements TextView.OnEditorAction
 
     private final String usernameOrEmail;
     private final String password;
+    private final String mfaToken;
 
     private LockWidget lockWidget;
     private ValidatedInputView codeInput;
 
 
-    public MFACodeFormView(LockWidget lockWidget, String usernameOrEmail, String password) {
+    public MFACodeFormView(@NonNull LockWidget lockWidget, @Nullable String usernameOrEmail, @Nullable String password, @Nullable String mfaToken) {
         super(lockWidget.getContext());
         this.lockWidget = lockWidget;
         this.usernameOrEmail = usernameOrEmail;
         this.password = password;
+        this.mfaToken = mfaToken;
         init();
     }
 
@@ -62,6 +64,7 @@ public class MFACodeFormView extends FormView implements TextView.OnEditorAction
     public Object getActionEvent() {
         DatabaseLoginEvent event = new DatabaseLoginEvent(usernameOrEmail, password);
         event.setVerificationCode(getInputText());
+        event.setMFAToken(mfaToken);
         return event;
     }
 

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -131,6 +131,8 @@
     <string name="com_auth0_lock_enterprise_no_connection_message">THERE WAS NO CONNECTION CONFIGURED FOR THE DOMAIN</string>
     <string name="com_auth0_lock_db_login_error_message">THERE WAS AN ERROR PROCESSING THE SIGN IN</string>
     <string name="com_auth0_lock_db_login_error_invalid_credentials_message">WRONG EMAIL OR PASSWORD</string>
+    <string name="com_auth0_lock_db_login_error_mfa_enroll_required">THE USER HAS NOT ENROLLED MULTIFACTOR AUTHENTICATION</string>
+    <string name="com_auth0_lock_db_login_error_invalid_mfa_code_message">THE CODE IS INVALID OR HAS EXPIRED</string>
     <string name="com_auth0_lock_db_login_error_unauthorized_message">USER IS BLOCKED</string>
     <string name="com_auth0_lock_db_sign_up_error_message">THERE WAS AN ERROR PROCESSING THE SIGN UP</string>
     <string name="com_auth0_lock_db_change_password_message_success">WE\'VE JUST SENT YOU AN EMAIL TO RESET YOUR PASSWORD</string>
@@ -142,7 +144,6 @@
     <string name="com_auth0_lock_passwordless_code_request_error_message">THERE WAS AN ERROR SENDING THE CODE</string>
     <string name="com_auth0_lock_passwordless_link_request_error_message">THERE WAS AN ERROR SENDING THE LINK</string>
     <string name="com_auth0_lock_passwordless_login_error_invalid_credentials_message">WRONG IDENTITY OR PASSCODE</string>
-    <string name="com_auth0_lock_db_login_error_invalid_mfa_code_message">THE CODE IS INVALID OR HAS EXPIRED</string>
     <string name="com_auth0_lock_title_mfa_input_code">Two Step Verification</string>
     <string name="com_auth0_lock_description_mfa_input_code">Please enter a verification code from\n your code generator application.</string>
 

--- a/lib/src/test/java/com/auth0/android/lock/errors/LoginErrorMessageBuilderTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/errors/LoginErrorMessageBuilderTest.java
@@ -73,7 +73,7 @@ public class LoginErrorMessageBuilderTest {
     public void shouldHaveDefaultMessageIfMultifactorEnrollRequired() throws Exception {
         Mockito.when(exception.isMultifactorEnrollRequired()).thenReturn(true);
         final AuthenticationError error = builder.buildFrom(exception);
-        assertThat(error.getMessageRes(), is(equalTo(R.string.com_auth0_lock_db_login_error_message)));
+        assertThat(error.getMessageRes(), is(equalTo(R.string.com_auth0_lock_db_login_error_mfa_enroll_required)));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/android/lock/events/DatabaseLoginEventTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/events/DatabaseLoginEventTest.java
@@ -41,4 +41,15 @@ public class DatabaseLoginEventTest {
         event.setVerificationCode("code");
         assertThat(event.getVerificationCode(), is("code"));
     }
+
+    @Test
+    public void shouldNotHaveMFAToken() throws Exception {
+        assertThat(event.getMFAToken(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldSetMFAToken() throws Exception {
+        event.setMFAToken("mfatoken");
+        assertThat(event.getMFAToken(), is("mfatoken"));
+    }
 }


### PR DESCRIPTION
OIDC conformant clients were not able to authenticate after an mfa challenge was requested. This PR adds support for them. I also enhanced the errors that we display in the widget.

### For legacy mode:
- Requiring MFA (when already enrolled) will take the user to the "input MFA code" form.
- Requiring enrollment will now keep the user in the "username / password" form instead of taking them to the "input MFA code" form from which they wouldn't be able to do anything, as enrollment is not supported currently from Lock. Users will see a "THE USER HAS NOT ENROLLED MULTIFACTOR AUTHENTICATION" message.
- An invalid/expired OTP value will show a "THE CODE IS INVALID OR HAS EXPIRED" message.

### For OIDC mode:
- Requiring MFA (doesn't care if the user is enrolled) will take the user to the "input MFA code" form.
- Requiring enrollment will only be known once the user attempts to send the OTP code, so they are already on this form. ~This **might** change once the `association_required` error is introduced to the API.~ Users will see a "THE USER HAS NOT ENROLLED MULTIFACTOR AUTHENTICATION" message.
- Invalid OTP will show a "THE CODE IS INVALID OR HAS EXPIRED" message.
- `mfa_token` lasts 10 minutes. If it expires, the user needs to retry the authentication from the beginning. So an expired MFA token will take the user back to the "username / password" form and display a "THE CODE IS INVALID OR HAS EXPIRED" message.


### General notes about this PR:

~- It's based on a still not released library, so tests will fail 💃~ -> https://github.com/auth0/Auth0.Android/pull/146
- Legacy MFA flow required a 2nd call to `/ro` sending again the `email/username`, `password` and `mfa_code` (the OTP) values. 
- The new flow requires a call to `/oauth/token` first with the password grant, which will fail due to "mfa_required" and will include an `mfa_token` value. A second call is required on `/oauth/token` this time with mfa-otp grant and the previous `mfa_token` value along with the `otp` code given by the user obtained from the 2FA/MFA app.
- Method names and default english message resources are subject to review and change