### PR TITLE
Draw background and borders on programmatically created fields

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedInputView.java
@@ -134,14 +134,17 @@ public class ValidatedInputView extends LinearLayout {
         showPasswordToggle = (ImageCheckbox) findViewById(R.id.com_auth0_lock_show_password_toggle);
         setOrientation(VERTICAL);
 
-        if (attrs == null || isInEditMode()) {
+        if (isInEditMode()) {
             return;
         }
 
-        TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.Lock_ValidatedInput);
-        //noinspection WrongConstant
-        dataType = a.getInt(R.styleable.Lock_ValidatedInput_Auth0_InputDataType, 0);
-        a.recycle();
+        if (attrs != null) {
+            TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.Lock_ValidatedInput);
+            //noinspection WrongConstant
+            dataType = a.getInt(R.styleable.Lock_ValidatedInput_Auth0_InputDataType, 0);
+            a.recycle();
+        }
+
         createBackground();
 
         setupInputValidation();


### PR DESCRIPTION
Background and Border styles application was skipped when the view was instantiated programmatically.
Fixes #454 

#### Empty field
![image](https://user-images.githubusercontent.com/3900123/36676989-d33cbe28-1aeb-11e8-82e4-2c81064ae1ce.png)

#### Error validation
![image](https://user-images.githubusercontent.com/3900123/36677035-f32496fc-1aeb-11e8-914b-052824552682.png)

