### PR TITLE
Allow to disable 'ActiveAuth' on enterprise Connections

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -437,6 +437,24 @@ public class Lock {
         }
 
         /**
+         * Set which enterprise connections should use Web Authentication instead of the Username
+         * and Password form.
+         * Enterprise connections based on 'ad', 'adfs' and 'waad' strategies can log their
+         * users in from within the Lock widget using their email and password. This is known as
+         * Active Authentication, and is not supported for MFA enabled identity providers.
+         * By whitelisting the connections here, the Universal Login Page is used instead and the
+         * log in is delegated to the browser application.
+         * Enterprise connections allowed for this client will use Active Authentication by default.
+         *
+         * @param connections the list of enterprise connections that will use Web Authentication.
+         * @return the current builder instance
+         */
+        public Builder enableEnterpriseWebAuthenticationFor(@NonNull List<String> connections) {
+            options.setEnterpriseConnectionsUsingWebForm(connections);
+            return this;
+        }
+
+        /**
          * Whether to login after a successful sign up callback. Defaults to true.
          *
          * @param login after sign up or not

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -437,16 +437,14 @@ public class Lock {
         }
 
         /**
-         * Set which enterprise connections should use Web Authentication instead of the Username
-         * and Password form.
          * Enterprise connections based on 'ad', 'adfs' and 'waad' strategies can log their
          * users in from within the Lock widget using their email and password. This is known as
-         * Active Authentication, and is not supported for MFA enabled identity providers.
+         * Active Authentication.
          * By whitelisting the connections here, the Universal Login Page is used instead and the
-         * log in is delegated to the browser application.
+         * login is delegated to the browser application.
          * Enterprise connections allowed for this client will use Active Authentication by default.
          *
-         * @param connections the list of enterprise connections that will use Web Authentication.
+         * @param connections the list of 'ad', 'adfs', or 'waad' enterprise connections that will use Web Authentication instead.
          * @return the current builder instance
          */
         public Builder enableEnterpriseWebAuthenticationFor(@NonNull List<String> connections) {

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Connection.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Connection.java
@@ -18,6 +18,7 @@ public class Connection implements BaseConnection, DatabaseConnection, OAuthConn
     private int minUsernameLength;
     private int maxUsernameLength;
     private boolean isCustomDatabase;
+    private boolean allowActiveFlow = true;
 
     private Connection(@NonNull String strategy, Map<String, Object> values) {
         checkArgument(values != null && values.size() > 0, "Must have at least one value");
@@ -83,6 +84,7 @@ public class Connection implements BaseConnection, DatabaseConnection, OAuthConn
         return value != null && value;
     }
 
+    @Override
     @PasswordStrength
     public int getPasswordPolicy() {
         String value = valueForKey("passwordPolicy", String.class);
@@ -133,7 +135,11 @@ public class Connection implements BaseConnection, DatabaseConnection, OAuthConn
 
     @Override
     public boolean isActiveFlowEnabled() {
-        return "ad".equals(getStrategy()) || "adfs".equals(getStrategy()) || "waad".equals(getStrategy());
+        return allowActiveFlow && ("ad".equals(getStrategy()) || "adfs".equals(getStrategy()) || "waad".equals(getStrategy()));
+    }
+
+    void disableActiveFlow() {
+        this.allowActiveFlow = false;
     }
 
     @Override

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
@@ -479,7 +479,7 @@ public class ConfigurationTest extends GsonBaseTest {
         configuration = new Configuration(connections, options);
 
         //Connections include 2 'ad' enterprise connections: "MyAD" and "mySecondAD"
-        //One of them is tell above to use Web Authentication
+        //'MyAD' is tell above to use Web Authentication instead of its default behavior
         for (OAuthConnection c : configuration.getEnterpriseConnections()) {
             if (c.getName().equals("mySecondAD")) {
                 assertThat(c.isActiveFlowEnabled(), is(true));

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConnectionTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConnectionTest.java
@@ -262,18 +262,39 @@ public class ConnectionTest {
         final Connection waad = connectionForStrategy("waad");
 
         assertThat(ad, hasType(AuthType.ENTERPRISE));
+        assertThat(ad.isActiveFlowEnabled(), is(true));
         assertThat(adfs, hasType(AuthType.ENTERPRISE));
+        assertThat(adfs.isActiveFlowEnabled(), is(true));
         assertThat(auth0Adldap, hasType(AuthType.ENTERPRISE));
+        assertThat(auth0Adldap.isActiveFlowEnabled(), is(false));
         assertThat(custom, hasType(AuthType.ENTERPRISE));
+        assertThat(custom.isActiveFlowEnabled(), is(false));
         assertThat(googleApps, hasType(AuthType.ENTERPRISE));
+        assertThat(googleApps.isActiveFlowEnabled(), is(false));
         assertThat(googleOpenid, hasType(AuthType.ENTERPRISE));
+        assertThat(googleOpenid.isActiveFlowEnabled(), is(false));
         assertThat(ip, hasType(AuthType.ENTERPRISE));
+        assertThat(ip.isActiveFlowEnabled(), is(false));
         assertThat(mscrm, hasType(AuthType.ENTERPRISE));
+        assertThat(mscrm.isActiveFlowEnabled(), is(false));
         assertThat(office365, hasType(AuthType.ENTERPRISE));
+        assertThat(office365.isActiveFlowEnabled(), is(false));
         assertThat(pingfederate, hasType(AuthType.ENTERPRISE));
+        assertThat(pingfederate.isActiveFlowEnabled(), is(false));
         assertThat(samlp, hasType(AuthType.ENTERPRISE));
+        assertThat(samlp.isActiveFlowEnabled(), is(false));
         assertThat(sharepoint, hasType(AuthType.ENTERPRISE));
+        assertThat(sharepoint.isActiveFlowEnabled(), is(false));
         assertThat(waad, hasType(AuthType.ENTERPRISE));
+        assertThat(waad.isActiveFlowEnabled(), is(true));
+    }
+
+    @Test
+    public void shouldDisableActiveFlowOnDemand() {
+        final Connection waad = connectionForStrategy("waad");
+        assertThat(waad.isActiveFlowEnabled(), is(true));
+        waad.disableActiveFlow();
+        assertThat(waad.isActiveFlowEnabled(), is(false));
     }
 
     private Connection connectionForStrategy(String connectionName) {

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -711,7 +711,6 @@ public class OptionsTest {
         assertThat(options.getTheme(), is(notNullValue()));
         assertThat(options.getAuthenticationParameters(), is(notNullValue()));
         assertThat(options.getAuthStyles(), is(notNullValue()));
-        assertThat(options.getEnterpriseConnectionsUsingWebForm(), is(notNullValue()));
     }
 
 

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -711,6 +711,7 @@ public class OptionsTest {
         assertThat(options.getTheme(), is(notNullValue()));
         assertThat(options.getAuthenticationParameters(), is(notNullValue()));
         assertThat(options.getAuthStyles(), is(notNullValue()));
+        assertThat(options.getEnterpriseConnectionsUsingWebForm(), is(notNullValue()));
     }
 
 


### PR DESCRIPTION
Some Enterprise Connections can use `Active Authentication` (username/ password) to log the user in from within Lock. This unfortunately, breaks scenarios where the SSO identity provider requires MFA. 

With this PR, users can now select which Enterprise connections of those which are...

1. [whitelisted](https://github.com/auth0/Lock.Android/blob/master/lib/src/main/java/com/auth0/android/lock/Lock.java#L306) to be shown in Lock and 
2. allowed to use ActiveAuth (enterprise strategies 'ad', 'adfs', 'waal') 

...and use the browser instead and perform Web Authentication. 

**The default behavior remains the same**: ActiveAuth will be used on those connections that fulfill what's stated in (2) above. The remainder (Connections without ActiveAuth enabled) will always use the Browser to authenticate.


#### Process for ActiveAuth enabled connection

1.  type the email and match the connection domain
2. SSO banner/message is shown and user clicks "next"
3. user types the password and clicks login


#### Process for ActiveAuth disabled connection

1.  type the email and match the connection domain
2. SSO banner/message is shown and user clicks "login"
3. browser is opened and the authentication is delegated