### PR TITLE
Allow to override the password minimum length

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
@@ -273,9 +273,9 @@ public class Configuration {
         return passwordlessMode;
     }
 
-    @PasswordStrength
-    public int getPasswordPolicy() {
-        return defaultDatabaseConnection == null ? PasswordStrength.NONE : defaultDatabaseConnection.getPasswordPolicy();
+    @NonNull
+    public PasswordComplexity getPasswordComplexity() {
+        return defaultDatabaseConnection == null ? new PasswordComplexity(PasswordStrength.NONE, null) : defaultDatabaseConnection.getPasswordComplexity();
     }
 
     public boolean loginAfterSignUp() {

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/DatabaseConnection.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/DatabaseConnection.java
@@ -1,17 +1,19 @@
 package com.auth0.android.lock.internal.configuration;
 
+import android.support.annotation.NonNull;
+
 public interface DatabaseConnection extends BaseConnection {
 
     int MIN_USERNAME_LENGTH = 1;
     int MAX_USERNAME_LENGTH = 15;
 
     /**
-     * Getter for the Password Policy associated to this connection.
+     * Getter for the Password Validation settings
      *
-     * @return The Password Policy level for this connection.
+     * @return The Password Validation for this connection.
      */
-    @PasswordStrength
-    int getPasswordPolicy();
+    @NonNull
+    PasswordComplexity getPasswordComplexity();
 
     /**
      * Whether this connection requires username or not.

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/PasswordComplexity.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/PasswordComplexity.java
@@ -15,7 +15,7 @@ public class PasswordComplexity {
     /**
      * Getter for the Password Policy associated to this connection.
      *
-     * @return The Password Policy level for this connection.
+     * @return the Password Policy level for this connection.
      */
     @PasswordStrength
     public int getPasswordPolicy() {

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/PasswordComplexity.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/PasswordComplexity.java
@@ -1,0 +1,34 @@
+package com.auth0.android.lock.internal.configuration;
+
+import android.support.annotation.Nullable;
+
+public class PasswordComplexity {
+
+    private final int policy;
+    private final Integer minLengthOverride;
+
+    public PasswordComplexity(@PasswordStrength int policy, @Nullable Integer minLengthOverride) {
+        this.policy = policy;
+        this.minLengthOverride = minLengthOverride;
+    }
+
+    /**
+     * Getter for the Password Policy associated to this connection.
+     *
+     * @return The Password Policy level for this connection.
+     */
+    @PasswordStrength
+    public int getPasswordPolicy() {
+        return policy;
+    }
+
+    /**
+     * Getter for the minimum length the password requires
+     *
+     * @return the minimum length the password requires
+     */
+    @Nullable
+    public Integer getMinLengthOverride() {
+        return minLengthOverride;
+    }
+}

--- a/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
@@ -86,7 +86,7 @@ public class SignUpFormView extends FormView implements TextView.OnEditorActionL
         emailInput.setIdentityListener(this);
         emailInput.setOnEditorActionListener(this);
         passwordInput = (ValidatedPasswordInputView) findViewById(R.id.com_auth0_lock_input_password);
-        passwordInput.setPasswordPolicy(configuration.getPasswordPolicy());
+        passwordInput.setPasswordComplexity(configuration.getPasswordComplexity());
         passwordInput.setAllowShowPassword(configuration.allowShowPassword());
         passwordInput.setOnEditorActionListener(this);
 

--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedPasswordInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedPasswordInputView.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.util.Log;
 
+import com.auth0.android.lock.internal.configuration.PasswordComplexity;
 import com.auth0.android.lock.internal.configuration.PasswordStrength;
 
 
@@ -53,8 +54,19 @@ public class ValidatedPasswordInputView extends ValidatedInputView {
      * Sets the Password Strength Policy level for this view.
      *
      * @param strength the new Policy level.
+     * @deprecated use {@link #setPasswordComplexity(PasswordComplexity)} method
      */
+    @Deprecated
     public void setPasswordPolicy(@PasswordStrength int strength) {
         strengthView.setStrength(strength);
+    }
+
+    /**
+     * Sets the Password Complexity for this view.
+     *
+     * @param complexity the new Password complexity to use
+     */
+    public void setPasswordComplexity(PasswordComplexity complexity) {
+        strengthView.setPasswordComplexity(complexity);
     }
 }

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
@@ -103,7 +103,8 @@ public class ConfigurationTest extends GsonBaseTest {
         assertThat(configuration.getInitialScreen(), is(equalTo(InitialScreen.LOG_IN)));
         assertThat(configuration.getSocialButtonStyle(), is(equalTo(AuthButtonSize.UNSPECIFIED)));
         assertThat(configuration.hasExtraFields(), is(false));
-        assertThat(configuration.getPasswordPolicy(), is(PasswordStrength.NONE));
+        assertThat(configuration.getPasswordComplexity(), is(notNullValue()));
+        assertThat(configuration.getPasswordComplexity().getPasswordPolicy(), is(PasswordStrength.NONE));
         assertThat(configuration.mustAcceptTerms(), is(false));
         assertThat(configuration.useLabeledSubmitButton(), is(true));
         assertThat(configuration.hideMainScreenTitle(), is(false));
@@ -575,7 +576,9 @@ public class ConfigurationTest extends GsonBaseTest {
     public void shouldGetPasswordPolicy() throws Exception {
         options.useDatabaseConnection("with-strength");
         configuration = new Configuration(connections, options);
-        assertThat(configuration.getPasswordPolicy(), is(PasswordStrength.EXCELLENT));
+        PasswordComplexity passwordComplexity = configuration.getPasswordComplexity();
+        assertThat(passwordComplexity, is(notNullValue()));
+        assertThat(passwordComplexity.getPasswordPolicy(), is(PasswordStrength.EXCELLENT));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/DatabaseConnectionTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/DatabaseConnectionTest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import static com.auth0.android.lock.internal.configuration.ConnectionMatcher.hasType;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -79,8 +80,9 @@ public class DatabaseConnectionTest {
         values.put("name", "Username-Password-Authentication");
         values.put("passwordPolicy", "excellent");
         DatabaseConnection connection = connectionFor(values);
-
-        assertThat(connection.getPasswordPolicy(), is(PasswordStrength.EXCELLENT));
+        PasswordComplexity passwordComplexity = connection.getPasswordComplexity();
+        assertThat(passwordComplexity.getPasswordPolicy(), is(PasswordStrength.EXCELLENT));
+        assertThat(passwordComplexity.getMinLengthOverride(), is(nullValue()));
     }
 
     @Test
@@ -90,7 +92,9 @@ public class DatabaseConnectionTest {
         values.put("passwordPolicy", "fair");
         DatabaseConnection connection = connectionFor(values);
 
-        assertThat(connection.getPasswordPolicy(), is(PasswordStrength.FAIR));
+        PasswordComplexity passwordComplexity = connection.getPasswordComplexity();
+        assertThat(passwordComplexity.getPasswordPolicy(), is(PasswordStrength.FAIR));
+        assertThat(passwordComplexity.getMinLengthOverride(), is(nullValue()));
     }
 
     @Test
@@ -100,7 +104,9 @@ public class DatabaseConnectionTest {
         values.put("passwordPolicy", "good");
         DatabaseConnection connection = connectionFor(values);
 
-        assertThat(connection.getPasswordPolicy(), is(PasswordStrength.GOOD));
+        PasswordComplexity passwordComplexity = connection.getPasswordComplexity();
+        assertThat(passwordComplexity.getPasswordPolicy(), is(PasswordStrength.GOOD));
+        assertThat(passwordComplexity.getMinLengthOverride(), is(nullValue()));
     }
 
     @Test
@@ -110,7 +116,9 @@ public class DatabaseConnectionTest {
         values.put("passwordPolicy", "low");
         DatabaseConnection connection = connectionFor(values);
 
-        assertThat(connection.getPasswordPolicy(), is(PasswordStrength.LOW));
+        PasswordComplexity passwordComplexity = connection.getPasswordComplexity();
+        assertThat(passwordComplexity.getPasswordPolicy(), is(PasswordStrength.LOW));
+        assertThat(passwordComplexity.getMinLengthOverride(), is(nullValue()));
     }
 
     @Test
@@ -119,7 +127,23 @@ public class DatabaseConnectionTest {
         values.put("name", "Username-Password-Authentication");
         DatabaseConnection connection = connectionFor(values);
 
-        assertThat(connection.getPasswordPolicy(), is(PasswordStrength.NONE));
+        PasswordComplexity passwordComplexity = connection.getPasswordComplexity();
+        assertThat(passwordComplexity.getPasswordPolicy(), is(PasswordStrength.NONE));
+        assertThat(passwordComplexity.getMinLengthOverride(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldGetMinPasswordLength() throws Exception {
+        Map<String, Object> values = new HashMap<>();
+        values.put("name", "Username-Password-Authentication");
+        Map<String, Object> options = new HashMap<>();
+        options.put("min_length", 123);
+        values.put("password_complexity_options", options);
+        DatabaseConnection connection = connectionFor(values);
+
+        PasswordComplexity passwordComplexity = connection.getPasswordComplexity();
+        assertThat(passwordComplexity.getPasswordPolicy(), is(PasswordStrength.NONE));
+        assertThat(passwordComplexity.getMinLengthOverride(), is(123));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/android/lock/views/PasswordStrengthViewTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/views/PasswordStrengthViewTest.java
@@ -3,6 +3,7 @@ package com.auth0.android.lock.views;
 import android.app.Activity;
 
 import com.auth0.android.lock.BuildConfig;
+import com.auth0.android.lock.internal.configuration.PasswordComplexity;
 import com.auth0.android.lock.internal.configuration.PasswordStrength;
 
 import org.junit.Before;
@@ -185,6 +186,61 @@ public class PasswordStrengthViewTest {
         assertFalse(view.isValid(PASSWORD_6_LONG));
         assertFalse(view.isValid(PASSWORD_1_LONG));
 
+        assertFalse(view.isValid(PASSWORD_EMPTY));
+        assertFalse(view.isValid(PASSWORD_TOO_LONG));
+        assertFalse(view.isValid(null));
+    }
+
+    @Test
+    public void shouldOverrideMinLength() throws Exception {
+        PasswordComplexity passwordComplexity;
+
+        // NONE is normally >= 1
+        passwordComplexity = new PasswordComplexity(PasswordStrength.NONE, 3);
+        view.setPasswordComplexity(passwordComplexity);
+
+        assertFalse(view.isValid("a"));
+        assertTrue(view.isValid("abc"));
+        assertFalse(view.isValid(PASSWORD_EMPTY));
+        assertFalse(view.isValid(PASSWORD_TOO_LONG));
+        assertFalse(view.isValid(null));
+
+        // LOW is normally >= 6
+        passwordComplexity = new PasswordComplexity(PasswordStrength.LOW, 8);
+        view.setPasswordComplexity(passwordComplexity);
+
+        assertFalse(view.isValid("abcdef"));
+        assertTrue(view.isValid("abcdefgh"));
+        assertFalse(view.isValid(PASSWORD_EMPTY));
+        assertFalse(view.isValid(PASSWORD_TOO_LONG));
+        assertFalse(view.isValid(null));
+
+        // FAIR is normally >= 8
+        passwordComplexity = new PasswordComplexity(PasswordStrength.FAIR, 10);
+        view.setPasswordComplexity(passwordComplexity);
+
+        assertFalse(view.isValid("ABCdefg9"));
+        assertTrue(view.isValid("ABCdefghi9"));
+        assertFalse(view.isValid(PASSWORD_EMPTY));
+        assertFalse(view.isValid(PASSWORD_TOO_LONG));
+        assertFalse(view.isValid(null));
+
+        // GOOD is normally >= 8
+        passwordComplexity = new PasswordComplexity(PasswordStrength.GOOD, 11);
+        view.setPasswordComplexity(passwordComplexity);
+
+        assertFalse(view.isValid("ABCdefg9"));
+        assertTrue(view.isValid("ABCdefghij9"));
+        assertFalse(view.isValid(PASSWORD_EMPTY));
+        assertFalse(view.isValid(PASSWORD_TOO_LONG));
+        assertFalse(view.isValid(null));
+
+        // EXCELLENT is normally >= 10
+        passwordComplexity = new PasswordComplexity(PasswordStrength.EXCELLENT, 15);
+        view.setPasswordComplexity(passwordComplexity);
+
+        assertFalse(view.isValid("ABCdefgh9!"));
+        assertTrue(view.isValid("ABCdefghijklm9!"));
         assertFalse(view.isValid(PASSWORD_EMPTY));
         assertFalse(view.isValid(PASSWORD_TOO_LONG));
         assertFalse(view.isValid(null));

--- a/lib/src/test/resources/db_connection_with_complexity.json
+++ b/lib/src/test/resources/db_connection_with_complexity.json
@@ -1,0 +1,22 @@
+{
+  "id": "CBBlULbbyQHSVWj5EqZSTMhUrJAS3UFA",
+  "tenant": "samples",
+  "authorize": "https://samples.auth0.com/authorize",
+  "callback": "http://localhost:3000/",
+  "strategies": [{
+      "name": "auth0",
+      "connections": [{
+          "name": "Username-Password-Authentication",
+          "domain": null,
+          "forgot_password_url": "https://login.auth0.com/lo/forgot?wtrealm=urn:auth0:samples:Username-Password-Authentication",
+          "signup_url": "https://login.auth0.com/lo/signup?wtrealm=urn:auth0:samples:Username-Password-Authentication",
+          "passwordPolicy": "fair",
+          "password_complexity_options": {
+            "min_length": 12
+          },
+          "showSignup": true,
+          "showForgot": true,
+          "requires_username": false
+      }]
+  }]
+}


### PR DESCRIPTION
Each database connection can specify a password policy to apply to the password field validation (e.g. on sign up). Additionally, a minimum password length can be specified to override the policy's minimum. This information arrives from the CDN file (see `ApplicationFetcher` class).

**Note to the reviewer:** Classes inside the `internal` package can contain breaking changes. I've created a new class `PasswordComplexity` to store this new value and any other future values that are introduced for password validation. I've kept the classes inside the `view` package without breaking changes just in case 🙆‍♂️ 

#### Screenshots
Using Policy "Low" (min 3 chars) and changing the minimum to 4 and 8

![image](https://user-images.githubusercontent.com/3900123/44603796-611f5880-a7ba-11e8-9dcc-2165786d4fd7.png)
![image](https://user-images.githubusercontent.com/3900123/44603813-6d0b1a80-a7ba-11e8-9684-433575b3292a.png)

![image](https://user-images.githubusercontent.com/3900123/44603809-68defd00-a7ba-11e8-9d21-a14903bf2a99.png)

![image](https://user-images.githubusercontent.com/3900123/44603881-9af05f00-a7ba-11e8-8ffa-e24feb43c568.png)

