### PR TITLE
Don't show the signup terms banner if there is no terms string

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -33,6 +33,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.v7.app.AlertDialog;
 import android.text.Html;
+import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.util.Log;
 import android.view.Gravity;
@@ -73,12 +74,14 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
     private ProgressBar loadingProgressBar;
 
     private String lastEmailInput;
+    private boolean hasSignupTerms;
 
     public ClassicLockView(Context context, Bus lockBus, Theme lockTheme) {
         super(context);
         this.bus = lockBus;
         this.configuration = null;
         this.lockTheme = lockTheme;
+        this.hasSignupTerms = !TextUtils.isEmpty(context.getString(R.string.com_auth0_lock_sign_up_terms));
         showWaitForConfigurationLayout();
     }
 
@@ -297,7 +300,7 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
     }
 
     private void showSignUpTerms(boolean show) {
-        bottomBanner.setVisibility(show ? VISIBLE : GONE);
+        bottomBanner.setVisibility(this.hasSignupTerms && show ? VISIBLE : GONE);
     }
 
     /**
@@ -365,7 +368,7 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
     @Override
     public void showBottomBanner(boolean show) {
         if (bottomBanner != null) {
-            bottomBanner.setVisibility(show ? VISIBLE : GONE);
+            bottomBanner.setVisibility(this.hasSignupTerms && show ? VISIBLE : GONE);
         }
     }
 


### PR DESCRIPTION
We're making this change to make all Lock versions behave in the same way.

The idea here is that the Terms and Conditions banner will be always visible, unless the translated string `com_auth0_lock_sign_up_terms` is empty.

To hide it, just set `com_auth0_lock_sign_up_terms` to an empty string in the internationalization file.

Default:
![image](https://user-images.githubusercontent.com/941075/45823410-09deac00-bcc4-11e8-97a1-4a0c10b3faf1.png)

With an empty `com_auth0_lock_sign_up_terms` string:
![image](https://user-images.githubusercontent.com/941075/45823516-3f839500-bcc4-11e8-87d3-092237a3866e.png)

