### PR TITLE
Upgrade to API and Support Library 28

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.2'
 
     defaultConfig {
         applicationId "com.auth0.android.lock.app"
         minSdkVersion 15
-        targetSdkVersion 25
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         manifestPlaceholders = [auth0Domain: "@string/com_auth0_domain", auth0Scheme: "demo"]
@@ -37,9 +37,9 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:design:25.3.1'
-    compile project(':lock')
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
+    implementation project(':lock')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,10 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.1'
         classpath "gradle.plugin.com.auth0.gradle:oss-library:0.6.0"
     }
@@ -18,6 +19,7 @@ allprojects {
     group = 'com.auth0.android'
     
     repositories {
+        google()
         jcenter()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,16 +2,16 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
-        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.0'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.1'
-        classpath "gradle.plugin.com.auth0.gradle:oss-library:0.6.0"
+//        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.1'
+//        classpath "gradle.plugin.com.auth0.gradle:oss-library:0.6.0"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Apr 27 18:27:23 ART 2017
+#Wed Sep 26 16:07:45 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,32 +1,32 @@
-apply plugin: 'com.auth0.gradle.oss-library.android'
+apply plugin: 'com.android.library'
 
 logger.lifecycle("Using version ${version} for ${name}")
 
-oss {
-    name 'Lock.Android'
-    repository 'Lock.Android'
-    organization 'auth0'
-    description 'The easiest way of securing your Android mobile apps with Auth0 & Lock'
-
-    developers {
-        auth0 {
-            displayName = 'Auth0'
-            email = 'oss@auth0.com'
-        }
-        lbalmaceda {
-            displayName = 'Luciano Balmaceda'
-            email = 'luciano.balmaceda@auth0.com'
-        }
-    }
-}
+//oss {
+//    name 'Lock.Android'
+//    repository 'Lock.Android'
+//    organization 'auth0'
+//    description 'The easiest way of securing your Android mobile apps with Auth0 & Lock'
+//
+//    developers {
+//        auth0 {
+//            displayName = 'Auth0'
+//            email = 'oss@auth0.com'
+//        }
+//        lbalmaceda {
+//            displayName = 'Luciano Balmaceda'
+//            email = 'luciano.balmaceda@auth0.com'
+//        }
+//    }
+//}
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.2'
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 25
+        targetSdkVersion 28
         versionCode 1
         versionName project.version
         consumerProguardFiles '../proguard/proguard-gson.pro', '../proguard/proguard-otto.pro', '../proguard/proguard-lock-2.pro'
@@ -34,19 +34,22 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:recyclerview-v7:25.3.1'
-    compile 'com.android.support:support-v4:25.3.1'
-    compile 'com.android.support:design:25.3.1'
-    compile 'com.google.code.gson:gson:2.8.5'
-    compile 'com.squareup:otto:1.3.8'
-    compile 'com.auth0.android:auth0:1.13.2'
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.hamcrest:hamcrest-library:1.3'
-    testCompile 'org.robolectric:robolectric:3.1.2'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.1.2'
-    testCompile 'com.jayway.awaitility:awaitility:1.7.0'
-    testCompile 'com.android.support.test.espresso:espresso-intents:2.2.2'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:recyclerview-v7:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
+    implementation 'com.android.support:customtabs:28.0.0'
+    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.squareup:otto:1.3.8'
+    api ("com.auth0.android:auth0:1.13.2") {
+        exclude group: 'com.android.support'
+    }
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.hamcrest:hamcrest-library:1.3'
+    testImplementation 'org.robolectric:robolectric:3.1.2'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:3.1.2'
+    testImplementation 'com.jayway.awaitility:awaitility:1.7.0'
+    testImplementation 'com.android.support.test.espresso:espresso-intents:2.2.2'
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/ModeSelectionView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ModeSelectionView.java
@@ -54,7 +54,7 @@ public class ModeSelectionView extends LinearLayout implements TabLayout.OnTabSe
         tabLayout.addTab(tabLayout.newTab()
                 .setCustomView(R.layout.com_auth0_lock_tab)
                 .setText(R.string.com_auth0_lock_mode_sign_up));
-        tabLayout.setOnTabSelectedListener(this);
+        tabLayout.addOnTabSelectedListener(this);
     }
 
     public void setSelectedMode(@AuthMode int mode) {


### PR DESCRIPTION
I've upgraded the project to work on api 28 with the support library 28 to get it ready for AndroidX.
With the actual version Jetifier have a issue with the setOnTabSelectedListener who is now deprecated.

To make this change I needed to commet the oss section in gradle due to the plugin forcing a target api 25