### PR TITLE
Replaced a deprecated method call with recommended

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/views/ModeSelectionView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ModeSelectionView.java
@@ -54,7 +54,7 @@ public class ModeSelectionView extends LinearLayout implements TabLayout.OnTabSe
         tabLayout.addTab(tabLayout.newTab()
                 .setCustomView(R.layout.com_auth0_lock_tab)
                 .setText(R.string.com_auth0_lock_mode_sign_up));
-        tabLayout.setOnTabSelectedListener(this);
+        tabLayout.addOnTabSelectedListener(this);
     }
 
     public void setSelectedMode(@AuthMode int mode) {


### PR DESCRIPTION
A call of the method setOnTabSelectedListener in TabLayout doesn't work well with latest versions of Android support library as this method has been deprecated.