### PR TITLE
Added showTerms feature flag

### DIFF
--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
@@ -193,6 +193,7 @@ public class DemoActivity extends AppCompatActivity {
                 builder.setDefaultDatabaseConnection("Username-Password-Authentication");
             }
         }
+
         builder.hideMainScreenTitle(checkboxHideMainScreenTitle.isChecked());
         lock = builder.build(this);
 

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -568,8 +568,8 @@ public class Lock {
         }
 
         /**
-         * Displays the Privacy Policy and Terms of Service dialog.
-         * Note: The dialog will always be shown if the mustAcceptTerms flag has been enabled.
+         * Displays the Privacy Policy and Terms of Service footer on the Sign Up screen.
+         * Note: The footer will always be shown if the mustAcceptTerms flag has been enabled.
          * The default value is true.
          *
          * @param showTerms whether the Terms of Service are displayed.

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -568,6 +568,19 @@ public class Lock {
         }
 
         /**
+         * Displays the Privacy Policy and Terms of Service dialog.
+         * Note: The dialog will always be shown if the mustAcceptTerms flag has been enabled.
+         * The default value is true.
+         *
+         * @param showTerms whether the Terms of Service are displayed.
+         * @return the current builder instance
+         */
+        public Builder setShowTerms(boolean showTerms) {
+            options.setShowTerms(showTerms);
+            return this;
+        }
+
+        /**
          * Sets the Connection Scope to request when performing an Authentication with the given Connection.
          *
          * @param connectionName to which specify the scopes.

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
@@ -60,6 +60,7 @@ public class Configuration {
     private boolean allowShowPassword;
     private boolean usernameRequired;
     private boolean mustAcceptTerms;
+    private boolean showTerms;
     private boolean useLabeledSubmitButton;
     private boolean hideMainScreenTitle;
     private boolean passwordlessAutoSubmit;
@@ -186,6 +187,7 @@ public class Configuration {
         socialButtonStyle = options.authButtonSize();
         loginAfterSignUp = options.loginAfterSignUp();
         mustAcceptTerms = options.mustAcceptTerms();
+        showTerms = options.showTerms();
         useLabeledSubmitButton = options.useLabeledSubmitButton();
         hideMainScreenTitle = options.hideMainScreenTitle();
         passwordlessAutoSubmit = options.rememberLastPasswordlessAccount();
@@ -311,6 +313,10 @@ public class Configuration {
 
     public boolean mustAcceptTerms() {
         return mustAcceptTerms;
+    }
+
+    public boolean showTerms() {
+        return showTerms;
     }
 
     public boolean useLabeledSubmitButton() {

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -73,6 +73,7 @@ public class Options implements Parcelable {
     private boolean allowShowPassword;
     private boolean loginAfterSignUp;
     private boolean mustAcceptTerms;
+    private boolean showTerms;
     private boolean useLabeledSubmitButton;
     private boolean hideMainScreenTitle;
     private boolean rememberLastPasswordlessLogin;
@@ -101,6 +102,7 @@ public class Options implements Parcelable {
         allowForgotPassword = true;
         allowShowPassword = true;
         loginAfterSignUp = true;
+        showTerms = true;
         useCodePasswordless = true;
         usePKCE = true;
         useLabeledSubmitButton = true;
@@ -123,6 +125,7 @@ public class Options implements Parcelable {
         allowShowPassword = in.readByte() != WITHOUT_DATA;
         loginAfterSignUp = in.readByte() != WITHOUT_DATA;
         mustAcceptTerms = in.readByte() != WITHOUT_DATA;
+        showTerms = in.readByte() != WITHOUT_DATA;
         useCodePasswordless = in.readByte() != WITHOUT_DATA;
         useLabeledSubmitButton = in.readByte() != WITHOUT_DATA;
         hideMainScreenTitle = in.readByte() != WITHOUT_DATA;
@@ -201,6 +204,7 @@ public class Options implements Parcelable {
         dest.writeByte((byte) (allowShowPassword ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (loginAfterSignUp ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (mustAcceptTerms ? HAS_DATA : WITHOUT_DATA));
+        dest.writeByte((byte) (showTerms ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (useCodePasswordless ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (useLabeledSubmitButton ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (hideMainScreenTitle ? HAS_DATA : WITHOUT_DATA));
@@ -484,6 +488,14 @@ public class Options implements Parcelable {
 
     public boolean mustAcceptTerms() {
         return mustAcceptTerms;
+    }
+
+    public void setShowTerms(boolean showTerms) {
+        this.showTerms = showTerms;
+    }
+
+    public boolean showTerms() {
+        return showTerms;
     }
 
     public void withAuthStyle(@NonNull String connectionName, @StyleRes int style) {

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -301,7 +301,9 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
     }
 
     private void showSignUpTerms(boolean show) {
-        bottomBanner.setVisibility(show ? VISIBLE : GONE);
+        if (bottomBanner != null) {
+            bottomBanner.setVisibility(show ? VISIBLE : GONE);
+        }
     }
 
     /**

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -105,6 +105,8 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
         LayoutParams wrapHeightParams = new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         LayoutParams formLayoutParams = new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT, 1);
 
+        boolean displayTerms = configuration.showTerms() || configuration.mustAcceptTerms();
+
         headerView = new HeaderView(getContext(), lockTheme);
         resetHeaderTitle();
         addView(headerView, wrapHeightParams);
@@ -116,15 +118,17 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
         formLayout = new FormLayout(this);
         addView(formLayout, formLayoutParams);
 
-        bottomBanner = inflate(getContext(), R.layout.com_auth0_lock_terms_layout, null);
-        bottomBanner.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                showSignUpTermsDialog(null);
-            }
-        });
-        bottomBanner.setVisibility(GONE);
-        addView(bottomBanner, wrapHeightParams);
+        if (displayTerms) {
+            bottomBanner = inflate(getContext(), R.layout.com_auth0_lock_terms_layout, null);
+            bottomBanner.setOnClickListener(new OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    showSignUpTermsDialog(null);
+                }
+            });
+            bottomBanner.setVisibility(GONE);
+            addView(bottomBanner, wrapHeightParams);
+        }
 
         actionButton = new ActionButton(getContext(), lockTheme);
         actionButton.setOnClickListener(new OnClickListener() {
@@ -157,7 +161,7 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
         }
 
         if (configuration.getInitialScreen() == InitialScreen.SIGN_UP) {
-            showBottomBanner(true);
+            showBottomBanner(displayTerms);
             updateButtonLabel(R.string.com_auth0_lock_action_sign_up);
         } else if (configuration.allowForgotPassword() && configuration.getInitialScreen() == InitialScreen.FORGOT_PASSWORD) {
             showChangePasswordForm(true);

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
@@ -106,6 +106,7 @@ public class ConfigurationTest extends GsonBaseTest {
         assertThat(configuration.getPasswordComplexity(), is(notNullValue()));
         assertThat(configuration.getPasswordComplexity().getPasswordPolicy(), is(PasswordStrength.NONE));
         assertThat(configuration.mustAcceptTerms(), is(false));
+        assertThat(configuration.showTerms(), is(true));
         assertThat(configuration.useLabeledSubmitButton(), is(true));
         assertThat(configuration.hideMainScreenTitle(), is(false));
         assertThat(configuration.usePasswordlessAutoSubmit(), is(false));
@@ -563,6 +564,13 @@ public class ConfigurationTest extends GsonBaseTest {
         options.setMustAcceptTerms(true);
         configuration = new Configuration(connections, options);
         assertThat(configuration.mustAcceptTerms(), is(true));
+    }
+
+    @Test
+    public void shouldHaveShowTermsDisabled() throws Exception {
+        options.setShowTerms(false);
+        configuration = new Configuration(connections, options);
+        assertThat(configuration.showTerms(), is(false));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -90,6 +90,19 @@ public class OptionsTest {
     }
 
     @Test
+    public void shouldSetShowTerms() throws Exception {
+        options.setShowTerms(false);
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.showTerms(), is(false));
+        assertThat(options.showTerms(), is(equalTo(parceledOptions.showTerms())));
+    }
+
+    @Test
     public void shouldSetPrivacyPolicyURL() throws Exception {
         options.setPrivacyURL("https://valid.url/privacy");
 
@@ -700,6 +713,7 @@ public class OptionsTest {
         assertThat(options.loginAfterSignUp(), is(true));
         assertThat(options.useCodePasswordless(), is(true));
         assertThat(options.mustAcceptTerms(), is(false));
+        assertThat(options.showTerms(), is(true));
         assertThat(options.useLabeledSubmitButton(), is(true));
         assertThat(options.hideMainScreenTitle(), is(false));
         assertThat(options.rememberLastPasswordlessAccount(), is(false));
@@ -726,6 +740,7 @@ public class OptionsTest {
         options.setAllowShowPassword(true);
         options.setClosable(true);
         options.setMustAcceptTerms(true);
+        options.setShowTerms(true);
         options.setAuthButtonSize(AuthButtonSize.BIG);
         options.setLoginAfterSignUp(true);
         options.setUseLabeledSubmitButton(true);
@@ -739,6 +754,7 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options.mustAcceptTerms(), is(equalTo(parceledOptions.mustAcceptTerms())));
+        assertThat(options.showTerms(), is(equalTo(parceledOptions.showTerms())));
         assertThat(options.isClosable(), is(equalTo(parceledOptions.isClosable())));
         assertThat(options.useBrowser(), is(equalTo(parceledOptions.useBrowser())));
         assertThat(options.usePKCE(), is(equalTo(parceledOptions.usePKCE())));
@@ -767,6 +783,7 @@ public class OptionsTest {
         options.setAllowForgotPassword(false);
         options.setAllowShowPassword(false);
         options.setMustAcceptTerms(false);
+        options.setShowTerms(false);
         options.setAuthButtonSize(AuthButtonSize.SMALL);
         options.setLoginAfterSignUp(false);
         options.setUseLabeledSubmitButton(false);
@@ -780,6 +797,7 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options.mustAcceptTerms(), is(equalTo(parceledOptions.mustAcceptTerms())));
+        assertThat(options.showTerms(), is(equalTo(parceledOptions.showTerms())));
         assertThat(options.isClosable(), is(equalTo(parceledOptions.isClosable())));
         assertThat(options.useBrowser(), is(equalTo(parceledOptions.useBrowser())));
         assertThat(options.usePKCE(), is(equalTo(parceledOptions.usePKCE())));


### PR DESCRIPTION
**Description**

Added a `showTerms` feature flag to disable the display of the terms of service dialog. Displayed in the Sign Up Screen for Database connections.
Note: If `mustAcceptTerms` is enabled, terms will always be shown.

![screenshot_1538661279](https://user-images.githubusercontent.com/928115/46478756-8ce42400-c7e5-11e8-89f6-803c2a0cb911.png)
