### PR TITLE
Update build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    compile fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.12'
     implementation 'com.android.support:appcompat-v7:25.3.1'
     implementation 'com.android.support:design:25.3.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,9 +37,9 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:design:25.3.1'
-    compile project(':lock')
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:25.3.1'
+    implementation 'com.android.support:design:25.3.1'
+    implementation project(':lock')
 }


### PR DESCRIPTION
Replaced:
`compile `with `implementation`
`testCompile `with `testImplementation`

The compile configuration is now deprecated and should be replaced by implementation or api.
From [Gradle Documentation](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation)