### PR TITLE
updated minSdkVersion to 26

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "com.auth0.android.lock.app"
-        minSdkVersion 15
+        minSdkVersion 26
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Google has instructed that all the new Android apps on Google Play should target API Level 26 (Android Oreo) in order to be published.