### PR TITLE
Parse 'password_leaked' error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Android API Level 15+ is required in order to use Lock's UI.
 Lock is available both in [Maven Central](http://search.maven.org) and [JCenter](https://bintray.com/bintray/jcenter). To start using *Lock* add these lines to your `build.gradle` dependencies file:
 
 ```gradle
-implementation 'com.auth0.android:lock:2.11.1'
+implementation 'com.auth0.android:lock:2.12.0'
 ```
 
 #### Android SDK Versions Troubleshooting

--- a/lib/src/main/java/com/auth0/android/lock/errors/LoginErrorMessageBuilder.java
+++ b/lib/src/main/java/com/auth0/android/lock/errors/LoginErrorMessageBuilder.java
@@ -44,6 +44,7 @@ public class LoginErrorMessageBuilder implements ErrorMessageBuilder<Authenticat
     private static final int invalidMFACodeResource = R.string.com_auth0_lock_db_login_error_invalid_mfa_code_message;
     private static final int mfaEnrollRequiredResource = R.string.com_auth0_lock_db_login_error_mfa_enroll_required;
     private static final int tooManyAttemptsResource = R.string.com_auth0_lock_db_too_many_attempts_error_message;
+    private static final int passwordLeakedResource = R.string.com_auth0_lock_db_password_leaked_error_message;
 
     private int invalidCredentialsResource;
     private int defaultMessage;
@@ -70,6 +71,8 @@ public class LoginErrorMessageBuilder implements ErrorMessageBuilder<Authenticat
             messageRes = mfaEnrollRequiredResource;
         } else if (USER_EXISTS_ERROR.equals(exception.getCode()) || USERNAME_EXISTS_ERROR.equals(exception.getCode())) {
             messageRes = userExistsResource;
+        } else if (exception.isPasswordLeaked()) {
+            messageRes = passwordLeakedResource;
         } else if (exception.isRuleError()) {
             messageRes = unauthorizedResource;
             if (!USER_IS_BLOCKED_DESCRIPTION.equals(exception.getDescription())) {

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -141,7 +141,7 @@
     <string name="com_auth0_lock_db_signup_password_already_used_error_message">THE PASSWORD WAS USED PREVIOUSLY</string>
     <string name="com_auth0_lock_db_signup_password_not_strong_error_message">THE PASSWORD IS NOT STRONG ENOUGH</string>
     <string name="com_auth0_lock_db_too_many_attempts_error_message">YOUR ACCOUNT HAS BEEN BLOCKED AFTER MULTIPLE CONSECUTIVE LOGIN ATTEMPTS</string>
-    <string name="com_auth0_lock_db_password_leaked_error_message">YOUR PASSWORD HAS BEEN LEAKED EXTERNALLY. PLEASE RESET YOUR PASSWORD</string>
+    <string name="com_auth0_lock_db_password_leaked_error_message">THIS PASSWORD WAS FOUND IN A 3RD PARTY DATA BREACH. PLEASE CHANGE YOUR PASSWORD.</string>
     <string name="com_auth0_lock_passwordless_code_request_error_message">THERE WAS AN ERROR SENDING THE CODE</string>
     <string name="com_auth0_lock_passwordless_link_request_error_message">THERE WAS AN ERROR SENDING THE LINK</string>
     <string name="com_auth0_lock_passwordless_login_error_invalid_credentials_message">WRONG IDENTITY OR PASSCODE</string>

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -141,6 +141,7 @@
     <string name="com_auth0_lock_db_signup_password_already_used_error_message">THE PASSWORD WAS USED PREVIOUSLY</string>
     <string name="com_auth0_lock_db_signup_password_not_strong_error_message">THE PASSWORD IS NOT STRONG ENOUGH</string>
     <string name="com_auth0_lock_db_too_many_attempts_error_message">YOUR ACCOUNT HAS BEEN BLOCKED AFTER MULTIPLE CONSECUTIVE LOGIN ATTEMPTS</string>
+    <string name="com_auth0_lock_db_password_leaked_error_message">YOUR PASSWORD HAS BEEN LEAKED EXTERNALLY. PLEASE RESET YOUR PASSWORD</string>
     <string name="com_auth0_lock_passwordless_code_request_error_message">THERE WAS AN ERROR SENDING THE CODE</string>
     <string name="com_auth0_lock_passwordless_link_request_error_message">THERE WAS AN ERROR SENDING THE LINK</string>
     <string name="com_auth0_lock_passwordless_login_error_invalid_credentials_message">WRONG IDENTITY OR PASSCODE</string>

--- a/lib/src/test/java/com/auth0/android/lock/errors/LoginErrorMessageBuilderTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/errors/LoginErrorMessageBuilderTest.java
@@ -56,6 +56,13 @@ public class LoginErrorMessageBuilderTest {
     }
 
     @Test
+    public void shouldHaveCustomMessageIfPasswordLeaked() throws Exception {
+        Mockito.when(exception.isPasswordLeaked()).thenReturn(true);
+        final AuthenticationError error = builder.buildFrom(exception);
+        assertThat(error.getMessageRes(), is(equalTo(R.string.com_auth0_lock_db_password_leaked_error_message)));
+    }
+
+    @Test
     public void shouldHaveCustomMessageIfMultifactorCodeInvalid() throws Exception {
         Mockito.when(exception.isMultifactorCodeInvalid()).thenReturn(true);
         final AuthenticationError error = builder.buildFrom(exception);


### PR DESCRIPTION
Add the ability to parse `password_leaked` errors returned by the backend. This is currently handled in a generic way, displaying a default error message when this case happens. 

If this PR gets merged, the error would look like this instead:
![image](https://user-images.githubusercontent.com/3900123/53248014-7efb4680-3693-11e9-853c-459b99b0d1a7.png)


Copy subject to change and open to suggestions :) 


> The string resource can be overwritten by defining your own string resource using the very same key.