### PR TITLE
Use auth0.android 1.15.2

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.squareup:otto:1.3.8'
-    api 'com.auth0.android:auth0:1.15.1'
+    api 'com.auth0.android:auth0:1.15.2'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation 'org.robolectric:robolectric:4.0.2'


### PR DESCRIPTION
### Changes

Bump the auth0.android version. This would fix telemetry format for users of Lock.


