### PR TITLE
Remove "Small" social button style

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -328,9 +328,11 @@ public class Lock {
          *
          * @param style a valid AuthButtonSize.
          * @return the current builder instance
+         * @deprecated Small button style is no longer offered since it is not compliant
+         * to some providers branding guidelines. e.g. google
          */
+        @Deprecated
         public Builder withAuthButtonSize(@AuthButtonSize int style) {
-            options.setAuthButtonSize(style);
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -317,9 +317,11 @@ public class PasswordlessLock {
          *
          * @param style a valid AuthButtonSize.
          * @return the current builder instance
+         * @deprecated Small button style is no longer offered since it is not compliant
+         * to some providers branding guidelines. e.g. google
          */
+        @Deprecated
         public Builder withAuthButtonSize(@AuthButtonSize int style) {
-            options.setAuthButtonSize(style);
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
@@ -260,6 +260,7 @@ public class Configuration {
         return initialScreen;
     }
 
+    @Deprecated
     @AuthButtonSize
     public int getSocialButtonStyle() {
         return socialButtonStyle;

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -64,7 +64,6 @@ public class Options implements Parcelable {
     private boolean useBrowser;
     private boolean usePKCE;
     private boolean closable;
-    private int authButtonSize;
     private int usernameStyle;
     private boolean useCodePasswordless;
     private boolean allowLogIn;
@@ -133,7 +132,6 @@ public class Options implements Parcelable {
         defaultDatabaseConnection = in.readString();
         usernameStyle = in.readInt();
         initialScreen = in.readInt();
-        authButtonSize = in.readInt();
         theme = in.readParcelable(Theme.class.getClassLoader());
         privacyURL = in.readString();
         termsURL = in.readString();
@@ -212,7 +210,6 @@ public class Options implements Parcelable {
         dest.writeString(defaultDatabaseConnection);
         dest.writeInt(usernameStyle);
         dest.writeInt(initialScreen);
-        dest.writeInt(authButtonSize);
         dest.writeParcelable(theme, flags);
         dest.writeString(privacyURL);
         dest.writeString(termsURL);
@@ -335,13 +332,14 @@ public class Options implements Parcelable {
         this.allowLogIn = allowLogIn;
     }
 
+    @Deprecated
     public void setAuthButtonSize(@AuthButtonSize int authButtonSize) {
-        this.authButtonSize = authButtonSize;
     }
 
+    @Deprecated
     @AuthButtonSize
     public int authButtonSize() {
-        return authButtonSize;
+        return AuthButtonSize.BIG;
     }
 
     public boolean allowLogIn() {

--- a/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
@@ -38,7 +38,6 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import com.auth0.android.lock.AuthButtonSize;
 import com.auth0.android.lock.InitialScreen;
 import com.auth0.android.lock.R;
 import com.auth0.android.lock.events.DatabaseSignUpEvent;
@@ -138,16 +137,7 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
     }
 
     private void addSocialLayout() {
-        int style = lockWidget.getConfiguration().getSocialButtonStyle();
-        boolean formContainsFields = showDatabase || showEnterprise;
-        boolean singleConnection = lockWidget.getConfiguration().getSocialConnections().size() == 1;
-
-        if (style == AuthButtonSize.UNSPECIFIED) {
-            socialLayout = new SocialView(lockWidget, formContainsFields && !singleConnection);
-        } else {
-            socialLayout = new SocialView(lockWidget, style == AuthButtonSize.SMALL);
-        }
-
+        socialLayout = new SocialView(lockWidget, true);
         formsHolder.addView(socialLayout);
     }
 

--- a/lib/src/main/java/com/auth0/android/lock/views/PasswordlessFormLayout.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/PasswordlessFormLayout.java
@@ -36,7 +36,6 @@ import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import com.auth0.android.lock.AuthButtonSize;
 import com.auth0.android.lock.R;
 import com.auth0.android.lock.adapters.Country;
 import com.auth0.android.lock.internal.configuration.PasswordlessMode;
@@ -71,7 +70,7 @@ public class PasswordlessFormLayout extends LinearLayout implements Passwordless
         boolean showPasswordless = lockWidget.getConfiguration().getPasswordlessConnection() != null;
 
         if (showSocial) {
-            addSocialLayout(showPasswordless);
+            addSocialLayout();
         }
         if (showPasswordless) {
             if (showSocial) {
@@ -86,16 +85,8 @@ public class PasswordlessFormLayout extends LinearLayout implements Passwordless
         }
     }
 
-    private void addSocialLayout(boolean passwordlessAvailable) {
-        int style = lockWidget.getConfiguration().getSocialButtonStyle();
-        boolean fewConnections = lockWidget.getConfiguration().getSocialConnections().size() <= MAX_SOCIAL_BIG_BUTTONS_WITH_PASSWORDLESS;
-
-        if (style == AuthButtonSize.UNSPECIFIED) {
-            socialLayout = new SocialView(lockWidget, passwordlessAvailable && !fewConnections);
-        } else {
-            socialLayout = new SocialView(lockWidget, style == AuthButtonSize.SMALL);
-        }
-
+    private void addSocialLayout() {
+        socialLayout = new SocialView(lockWidget, true);
         addView(socialLayout);
     }
 

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
@@ -101,7 +101,7 @@ public class ConfigurationTest extends GsonBaseTest {
         assertThat(configuration.loginAfterSignUp(), is(true));
         assertThat(configuration.getUsernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
         assertThat(configuration.getInitialScreen(), is(equalTo(InitialScreen.LOG_IN)));
-        assertThat(configuration.getSocialButtonStyle(), is(equalTo(AuthButtonSize.UNSPECIFIED)));
+        assertThat(configuration.getSocialButtonStyle(), is(equalTo(AuthButtonSize.BIG)));
         assertThat(configuration.hasExtraFields(), is(false));
         assertThat(configuration.getPasswordComplexity(), is(notNullValue()));
         assertThat(configuration.getPasswordComplexity().getPasswordPolicy(), is(PasswordStrength.NONE));

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -6,7 +6,6 @@ import android.os.Parcel;
 import com.auth0.android.Auth0;
 import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.lock.AuthButtonSize;
-import com.auth0.android.lock.BuildConfig;
 import com.auth0.android.lock.InitialScreen;
 import com.auth0.android.lock.R;
 import com.auth0.android.lock.UsernameStyle;
@@ -229,7 +228,7 @@ public class OptionsTest {
     }
 
     @Test
-    public void shouldUseSmallSocialButtonStyle() throws Exception {
+    public void shouldIgnoreSocialButtonStyleConfiguration() throws Exception {
         options.setAuthButtonSize(AuthButtonSize.SMALL);
 
         Parcel parcel = Parcel.obtain();
@@ -237,7 +236,7 @@ public class OptionsTest {
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(options.authButtonSize(), is(equalTo(AuthButtonSize.SMALL)));
+        assertThat(options.authButtonSize(), is(equalTo(AuthButtonSize.BIG)));
         assertThat(options.authButtonSize(), is(equalTo(parceledOptions.authButtonSize())));
     }
 
@@ -721,7 +720,7 @@ public class OptionsTest {
         assertThat(options.getAudience(), is(nullValue()));
         assertThat(options.getScheme(), is(nullValue()));
         assertThat(options.usernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
-        assertThat(options.authButtonSize(), is(equalTo(AuthButtonSize.UNSPECIFIED)));
+        assertThat(options.authButtonSize(), is(equalTo(AuthButtonSize.BIG)));
         assertThat(options.getTheme(), is(notNullValue()));
         assertThat(options.getAuthenticationParameters(), is(notNullValue()));
         assertThat(options.getAuthStyles(), is(notNullValue()));


### PR DESCRIPTION
### Changes

The small social button style is no longer offered since this. In this PR I'm removing the logic to change it, but keeping the methods in order to avoid any code breaking changes. There will be a visual change as from now on all social buttons will appear as large/big with their connection name rather than small without text.


### Testing

Tests have been updated to reflect the change. New default or value is always BIG.

- [x] This change adds unit test coverage
- [ ] This change adds integration/UI test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] The correct base branch is being used
