### PR TITLE
Define custom email regex to validate emails

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/ValidatedInputView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ValidatedInputView.java
@@ -74,7 +74,7 @@ public class ValidatedInputView extends LinearLayout {
     public static final String USERNAME_REGEX = "^[a-zA-Z0-9_]+$";
     public static final String PHONE_NUMBER_REGEX = "^[0-9]{6,14}$";
     public static final String CODE_REGEX = "^[0-9]{4,12}$";
-    public static final String EMAIL_REGEX = Patterns.EMAIL_ADDRESS.pattern();
+    public static final String EMAIL_REGEX = "[a-zA-Z0-9-.!#$%&'*+–/=?^_`{|}~]{1,64}@[a-z0-9-.]{1,255}";
     private static final String TAG = ValidatedInputView.class.getSimpleName();
     private static final int VALIDATION_DELAY = 500;
 


### PR DESCRIPTION
### Changes

Define our own email regex to validate email addresses locally, and stop depending on the official android email regex as it's lacking some special characters (printable chars) for the local part of the email.

### References

The local part can be up to 64 characters in length and consist of any combination of alphabetic characters, digits, or any of the following special characters:

```
! # $ % & ‘ * + – / = ? ^ _ ` . { | } ~
```

The domain part cannot be more than 255 characters in length and must conform to the specification for hostnames which is a list of dot-separated DNS labels. Each DNS label must not exceed 63 characters and should consist of any combination of alphabetic characters, digits and hypens.

SRC: https://www.mailboxvalidator.com/resources/articles/acceptable-email-address-syntax-rfc/
RFC: https://tools.ietf.org/html/rfc5321
Will close https://github.com/auth0/Lock.Android/issues/531

### Testing

Manually tested on regexr.com. The only emails that are not accepted by this regex are those in which the local part is enclosed with double quotes.

- [ ] This change adds unit test coverage

- [ ] This change adds integration/UI test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors

- [x] The correct base branch is being used
