### PR TITLE
Avoid registering multiple broadcast receiver instances

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -66,7 +66,7 @@ public class Lock {
 
         @Override
         public void onReceive(Context context, Intent data) {
-            processEvent(data);
+            processEvent(context, data);
         }
     };
 
@@ -144,7 +144,8 @@ public class Lock {
         LocalBroadcastManager.getInstance(context).registerReceiver(this.receiver, filter);
     }
 
-    private void processEvent(Intent data) {
+    private void processEvent(Context context, Intent data) {
+        LocalBroadcastManager.getInstance(context).unregisterReceiver(this.receiver);
         String action = data.getAction();
         switch (action) {
             case Constants.AUTHENTICATION_ACTION:

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -62,7 +62,7 @@ public class PasswordlessLock {
 
         @Override
         public void onReceive(Context context, Intent data) {
-            processEvent(data);
+            processEvent(context, data);
         }
     };
 
@@ -143,7 +143,8 @@ public class PasswordlessLock {
         LocalBroadcastManager.getInstance(context).registerReceiver(this.receiver, filter);
     }
 
-    private void processEvent(Intent data) {
+    private void processEvent(Context context, Intent data) {
+        LocalBroadcastManager.getInstance(context).unregisterReceiver(this.receiver);
         String action = data.getAction();
         switch (action) {
             case Constants.AUTHENTICATION_ACTION:


### PR DESCRIPTION
### Changes

When Lock is launched multiple times, each time a new receiver instance was being registered. This caused repeated callbacks with the same result to be delivered. 

This change is to make sure no receiver remains registered after delivering the result. In addition, users should still call `lock#onDestroy()` to clear the state of the Lock instance.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. This library has unit testing, tests should be added for new logic and functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage

- [ ] This change adds integration/UI test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

Tested with APIs 15 and 28.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors

- [x] The correct base branch is being used
