### PR TITLE
Add Root Attributes on sign up or user creation

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/events/DatabaseSignUpEvent.java
+++ b/lib/src/main/java/com/auth0/android/lock/events/DatabaseSignUpEvent.java
@@ -34,16 +34,13 @@ import com.auth0.android.authentication.request.DatabaseConnectionRequest;
 import com.auth0.android.authentication.request.SignUpRequest;
 import com.auth0.android.result.DatabaseUser;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class DatabaseSignUpEvent extends DatabaseEvent {
 
-    private static final String KEY_USER_METADATA = "user_metadata";
-
     @NonNull
     private String password;
-    private Map<String, String> extraFields;
+    private Map<String, Object> extraFields;
 
     public DatabaseSignUpEvent(@NonNull String email, @NonNull String password, @Nullable String username) {
         super(email, username);
@@ -55,7 +52,7 @@ public class DatabaseSignUpEvent extends DatabaseEvent {
         return password;
     }
 
-    public void setExtraFields(@NonNull Map<String, String> customFields) {
+    public void setExtraFields(@NonNull Map<String, Object> customFields) {
         this.extraFields = customFields;
     }
 
@@ -67,9 +64,7 @@ public class DatabaseSignUpEvent extends DatabaseEvent {
             request = apiClient.signUp(getEmail(), getPassword(), connection);
         }
         if (extraFields != null) {
-            Map<String, Object> params = new HashMap<>();
-            params.put(KEY_USER_METADATA, extraFields);
-            request.addSignUpParameters(params);
+            request.addSignUpParameters(extraFields);
         }
         return request;
     }
@@ -82,7 +77,7 @@ public class DatabaseSignUpEvent extends DatabaseEvent {
             request = apiClient.createUser(getEmail(), getPassword(), connection);
         }
         if (extraFields != null) {
-            request.addParameter(KEY_USER_METADATA, extraFields);
+            request.addParameters(extraFields);
         }
         return request;
     }

--- a/lib/src/main/java/com/auth0/android/lock/events/DatabaseSignUpEvent.java
+++ b/lib/src/main/java/com/auth0/android/lock/events/DatabaseSignUpEvent.java
@@ -34,17 +34,21 @@ import com.auth0.android.authentication.request.DatabaseConnectionRequest;
 import com.auth0.android.authentication.request.SignUpRequest;
 import com.auth0.android.result.DatabaseUser;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class DatabaseSignUpEvent extends DatabaseEvent {
 
+    private static final String KEY_USER_METADATA = "user_metadata";
+
     @NonNull
     private String password;
-    private Map<String, Object> extraFields;
+    private Map<String, Object> rootAttributes;
 
     public DatabaseSignUpEvent(@NonNull String email, @NonNull String password, @Nullable String username) {
         super(email, username);
         this.password = password;
+        this.rootAttributes = new HashMap<>();
     }
 
     @NonNull
@@ -52,9 +56,19 @@ public class DatabaseSignUpEvent extends DatabaseEvent {
         return password;
     }
 
-    public void setExtraFields(@NonNull Map<String, Object> customFields) {
-        this.extraFields = customFields;
+    public void setRootAttributes(@NonNull Map<String, Object> attributes) {
+        this.rootAttributes.putAll(attributes);
     }
+
+    /**
+     * Set the fields to set as user_metadata
+     *
+     * @param customFields user_metadata fields to set
+     */
+    public void setExtraFields(@NonNull Map<String, String> customFields) {
+        this.rootAttributes.put(KEY_USER_METADATA, customFields);
+    }
+
 
     public SignUpRequest getSignUpRequest(AuthenticationAPIClient apiClient, String connection) {
         SignUpRequest request;
@@ -63,8 +77,8 @@ public class DatabaseSignUpEvent extends DatabaseEvent {
         } else {
             request = apiClient.signUp(getEmail(), getPassword(), connection);
         }
-        if (extraFields != null) {
-            request.addSignUpParameters(extraFields);
+        if (!rootAttributes.isEmpty()) {
+            request.addSignUpParameters(rootAttributes);
         }
         return request;
     }
@@ -76,8 +90,8 @@ public class DatabaseSignUpEvent extends DatabaseEvent {
         } else {
             request = apiClient.createUser(getEmail(), getPassword(), connection);
         }
-        if (extraFields != null) {
-            request.addParameters(extraFields);
+        if (!rootAttributes.isEmpty()) {
+            request.addParameters(rootAttributes);
         }
         return request;
     }

--- a/lib/src/main/java/com/auth0/android/lock/utils/CustomField.java
+++ b/lib/src/main/java/com/auth0/android/lock/utils/CustomField.java
@@ -44,6 +44,8 @@ import static com.auth0.android.lock.utils.CustomField.FieldType.TYPE_EMAIL;
 import static com.auth0.android.lock.utils.CustomField.FieldType.TYPE_NAME;
 import static com.auth0.android.lock.utils.CustomField.FieldType.TYPE_NUMBER;
 import static com.auth0.android.lock.utils.CustomField.FieldType.TYPE_PHONE_NUMBER;
+import static com.auth0.android.lock.utils.CustomField.Storage.PROFILE_ROOT;
+import static com.auth0.android.lock.utils.CustomField.Storage.USER_METADATA;
 
 public class CustomField implements Parcelable {
 
@@ -56,15 +58,58 @@ public class CustomField implements Parcelable {
         int TYPE_EMAIL = 3;
     }
 
+    /**
+     * Location to store the field into.
+     */
+    @IntDef({PROFILE_ROOT, USER_METADATA})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface Storage {
+        /**
+         * Store the field into the user profile root.
+         * The list of attributes that can be added to your root profile is here https://auth0.com/docs/api/management/v2#!/Users/patch_users_by_id.
+         */
+        int PROFILE_ROOT = 0;
+
+        /**
+         * Store the field into the user_metadata object.
+         * The list of attributes that can be added to your root profile is here https://auth0.com/docs/api/management/v2#!/Users/patch_users_by_id.
+         */
+        int USER_METADATA = 1;
+    }
+
     @DrawableRes
-    private int icon;
+    private final int icon;
     @FieldType
     private final int type;
     private final String key;
     @StringRes
     private final int hint;
+    @Storage
+    private final int storage;
 
+
+    /**
+     * Constructor for CustomField instance
+     *
+     * @param icon the icon resource to display next to the field.
+     * @param type the type of input this field will receive. Used to determine the applied validation.
+     * @param key  the key to store this field as.
+     * @param hint the placeholder to display when this field is empty.
+     */
     public CustomField(@DrawableRes int icon, @FieldType int type, @NonNull String key, @StringRes int hint) {
+        this(icon, type, key, hint, PROFILE_ROOT);
+    }
+
+    /**
+     * Constructor for CustomField instance
+     *
+     * @param icon    the icon resource to display next to the field.
+     * @param type    the type of input this field will receive. Used to determine the applied validation.
+     * @param key     the key to store this field as.
+     * @param hint    the placeholder to display when this field is empty.
+     * @param storage the location to store this value into. Defaults to {@link Storage#USER_METADATA}.
+     */
+    public CustomField(@DrawableRes int icon, @FieldType int type, @NonNull String key, @StringRes int hint, @Storage int storage) {
         if (key.isEmpty()) {
             throw new IllegalArgumentException("The key cannot be empty!");
         }
@@ -72,6 +117,7 @@ public class CustomField implements Parcelable {
         this.type = type;
         this.key = key;
         this.hint = hint;
+        this.storage = storage;
     }
 
     public void configureField(@NonNull ValidatedInputView field) {
@@ -123,12 +169,17 @@ public class CustomField implements Parcelable {
         return type;
     }
 
+    @Storage
+    public int getStorage() {
+        return storage;
+    }
+
     protected CustomField(Parcel in) {
         icon = in.readInt();
-        //noinspection WrongConstant
         type = in.readInt();
         key = in.readString();
         hint = in.readInt();
+        storage = in.readInt();
     }
 
     @Override
@@ -142,6 +193,7 @@ public class CustomField implements Parcelable {
         dest.writeInt(type);
         dest.writeString(key);
         dest.writeInt(hint);
+        dest.writeInt(storage);
     }
 
     @SuppressWarnings("unused")

--- a/lib/src/main/java/com/auth0/android/lock/utils/CustomField.java
+++ b/lib/src/main/java/com/auth0/android/lock/utils/CustomField.java
@@ -89,6 +89,8 @@ public class CustomField implements Parcelable {
 
     /**
      * Constructor for CustomField instance
+     * When this constructor is used the field will be stored under the {@link Storage#USER_METADATA} attribute. 
+     * If you want to change the storage location use the constructor that accepts a {@link Storage} value.
      *
      * @param icon the icon resource to display next to the field.
      * @param type the type of input this field will receive. Used to determine the applied validation.
@@ -106,7 +108,7 @@ public class CustomField implements Parcelable {
      * @param type    the type of input this field will receive. Used to determine the applied validation.
      * @param key     the key to store this field as.
      * @param hint    the placeholder to display when this field is empty.
-     * @param storage the location to store this value into. Defaults to {@link Storage#USER_METADATA}.
+     * @param storage the location to store this value into.
      */
     public CustomField(@DrawableRes int icon, @FieldType int type, @NonNull String key, @StringRes int hint, @Storage int storage) {
         if (key.isEmpty()) {

--- a/lib/src/main/java/com/auth0/android/lock/utils/CustomField.java
+++ b/lib/src/main/java/com/auth0/android/lock/utils/CustomField.java
@@ -72,7 +72,6 @@ public class CustomField implements Parcelable {
 
         /**
          * Store the field into the user_metadata object.
-         * The list of attributes that can be added to your root profile is here https://auth0.com/docs/api/management/v2#!/Users/patch_users_by_id.
          */
         int USER_METADATA = 1;
     }
@@ -97,7 +96,7 @@ public class CustomField implements Parcelable {
      * @param hint the placeholder to display when this field is empty.
      */
     public CustomField(@DrawableRes int icon, @FieldType int type, @NonNull String key, @StringRes int hint) {
-        this(icon, type, key, hint, PROFILE_ROOT);
+        this(icon, type, key, hint, USER_METADATA);
     }
 
     /**

--- a/lib/src/main/java/com/auth0/android/lock/utils/CustomField.java
+++ b/lib/src/main/java/com/auth0/android/lock/utils/CustomField.java
@@ -66,7 +66,7 @@ public class CustomField implements Parcelable {
     public @interface Storage {
         /**
          * Store the field into the user profile root.
-         * The list of attributes that can be added to your root profile is here https://auth0.com/docs/api/management/v2#!/Users/patch_users_by_id.
+         * The list of attributes that can be added to your root profile is here https://auth0.com/docs/api/authentication#signup.
          */
         int PROFILE_ROOT = 0;
 
@@ -111,6 +111,9 @@ public class CustomField implements Parcelable {
     public CustomField(@DrawableRes int icon, @FieldType int type, @NonNull String key, @StringRes int hint, @Storage int storage) {
         if (key.isEmpty()) {
             throw new IllegalArgumentException("The key cannot be empty!");
+        }
+        if (key.equalsIgnoreCase("user_metadata") && storage == PROFILE_ROOT){
+            throw new IllegalArgumentException("Update the user_metadata root profile attributes by using Storage.USER_METADATA as storage location.");
         }
         this.icon = icon;
         this.type = type;

--- a/lib/src/main/java/com/auth0/android/lock/views/CustomFieldsFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/CustomFieldsFormView.java
@@ -49,7 +49,6 @@ import static com.auth0.android.lock.utils.CustomField.Storage;
 
 public class CustomFieldsFormView extends FormView implements TextView.OnEditorActionListener {
 
-    private static final String KEY_USER_METADATA = "user_metadata";
     private static final String TAG = CustomFieldsFormView.class.getSimpleName();
 
     @NonNull
@@ -109,7 +108,7 @@ public class CustomFieldsFormView extends FormView implements TextView.OnEditorA
         }
     }
 
-    public static Map<String, Object> convertFieldsToMap(List<CustomField> fields, ViewGroup container) {
+    static void setEventRootProfileAttributes(DatabaseSignUpEvent event, List<CustomField> fields, ViewGroup container) {
         Map<String, Object> rootMap = new HashMap<>();
         Map<String, String> userMetadataMap = new HashMap<>();
 
@@ -121,18 +120,18 @@ public class CustomFieldsFormView extends FormView implements TextView.OnEditorA
                 rootMap.put(data.getKey(), value);
             }
         }
-        if (!userMetadataMap.isEmpty()) {
-            rootMap.put(KEY_USER_METADATA, userMetadataMap);
+        if (!rootMap.isEmpty()) {
+            event.setRootAttributes(rootMap);
         }
-        return rootMap;
+        if (!userMetadataMap.isEmpty()) {
+            event.setExtraFields(userMetadataMap);
+        }
     }
 
     @Override
     public Object getActionEvent() {
         DatabaseSignUpEvent event = new DatabaseSignUpEvent(email, password, username);
-        Map<String, Object> extraFields = convertFieldsToMap(fieldsData, fieldContainer);
-        Log.d(TAG, "Custom field values are" + extraFields.values().toString());
-        event.setExtraFields(extraFields);
+        setEventRootProfileAttributes(event, fieldsData, fieldContainer);
         return event;
     }
 

--- a/lib/src/main/java/com/auth0/android/lock/views/CustomFieldsFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/CustomFieldsFormView.java
@@ -45,8 +45,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.auth0.android.lock.utils.CustomField.Storage;
+
 public class CustomFieldsFormView extends FormView implements TextView.OnEditorActionListener {
 
+    private static final String KEY_USER_METADATA = "user_metadata";
     private static final String TAG = CustomFieldsFormView.class.getSimpleName();
 
     @NonNull
@@ -106,20 +109,30 @@ public class CustomFieldsFormView extends FormView implements TextView.OnEditorA
         }
     }
 
-    private Map<String, String> getCustomFieldValues() {
-        Map<String, String> map = new HashMap<>();
-        for (CustomField data : fieldsData) {
-            map.put(data.getKey(), data.findValue(fieldContainer));
-        }
-        Log.d(TAG, "Custom field values are" + map.values().toString());
+    public static Map<String, Object> convertFieldsToMap(List<CustomField> fields, ViewGroup container) {
+        Map<String, Object> rootMap = new HashMap<>();
+        Map<String, String> userMetadataMap = new HashMap<>();
 
-        return map;
+        for (CustomField data : fields) {
+            String value = data.findValue(container);
+            if (data.getStorage() == Storage.USER_METADATA) {
+                userMetadataMap.put(data.getKey(), value);
+            } else {
+                rootMap.put(data.getKey(), value);
+            }
+        }
+        if (!userMetadataMap.isEmpty()) {
+            rootMap.put(KEY_USER_METADATA, userMetadataMap);
+        }
+        return rootMap;
     }
 
     @Override
     public Object getActionEvent() {
         DatabaseSignUpEvent event = new DatabaseSignUpEvent(email, password, username);
-        event.setExtraFields(getCustomFieldValues());
+        Map<String, Object> extraFields = convertFieldsToMap(fieldsData, fieldContainer);
+        Log.d(TAG, "Custom field values are" + extraFields.values().toString());
+        event.setExtraFields(extraFields);
         return event;
     }
 

--- a/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
@@ -45,7 +45,6 @@ import com.auth0.android.lock.utils.CustomField;
 import com.auth0.android.lock.views.interfaces.IdentityListener;
 import com.auth0.android.lock.views.interfaces.LockWidgetForm;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -111,15 +110,6 @@ public class SignUpFormView extends FormView implements TextView.OnEditorActionL
         }
     }
 
-    private Map<String, String> getCustomFieldValues() {
-        Map<String, String> map = new HashMap<>();
-        for (CustomField data : lockWidget.getConfiguration().getExtraSignUpFields()) {
-            map.put(data.getKey(), data.findValue(fieldContainer));
-        }
-        Log.d(TAG, "Custom field values are" + map.values().toString());
-
-        return map;
-    }
 
     private LinearLayout.LayoutParams defineFieldParams() {
         int verticalMargin = getResources().getDimensionPixelSize(R.dimen.com_auth0_lock_widget_vertical_margin_field);
@@ -180,7 +170,10 @@ public class SignUpFormView extends FormView implements TextView.OnEditorActionL
         if (validateForm()) {
             DatabaseSignUpEvent event = (DatabaseSignUpEvent) getActionEvent();
             if (displayFewCustomFields) {
-                event.setExtraFields(getCustomFieldValues());
+                List<CustomField> fields = lockWidget.getConfiguration().getExtraSignUpFields();
+                Map<String, Object> extraFields = CustomFieldsFormView.convertFieldsToMap(fields, fieldContainer);
+                Log.d(TAG, "Custom field values are" + extraFields.values().toString());
+                event.setExtraFields(extraFields);
                 return event;
             }
             if (lockWidget.getConfiguration().hasExtraFields()) {

--- a/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
@@ -46,7 +46,8 @@ import com.auth0.android.lock.views.interfaces.IdentityListener;
 import com.auth0.android.lock.views.interfaces.LockWidgetForm;
 
 import java.util.List;
-import java.util.Map;
+
+import static com.auth0.android.lock.views.CustomFieldsFormView.setEventRootProfileAttributes;
 
 public class SignUpFormView extends FormView implements TextView.OnEditorActionListener, IdentityListener {
 
@@ -171,9 +172,7 @@ public class SignUpFormView extends FormView implements TextView.OnEditorActionL
             DatabaseSignUpEvent event = (DatabaseSignUpEvent) getActionEvent();
             if (displayFewCustomFields) {
                 List<CustomField> fields = lockWidget.getConfiguration().getExtraSignUpFields();
-                Map<String, Object> extraFields = CustomFieldsFormView.convertFieldsToMap(fields, fieldContainer);
-                Log.d(TAG, "Custom field values are" + extraFields.values().toString());
-                event.setExtraFields(extraFields);
+                setEventRootProfileAttributes(event, fields, fieldContainer);
                 return event;
             }
             if (lockWidget.getConfiguration().hasExtraFields()) {

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -33,7 +33,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 
 @RunWith(RobolectricTestRunner.class)

--- a/lib/src/test/java/com/auth0/android/lock/utils/CustomFieldTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/utils/CustomFieldTest.java
@@ -51,21 +51,21 @@ public class CustomFieldTest {
     private static final String KEY = "key";
     private static final int HINT = R.string.com_auth0_lock_hint_email;
     private static final String CUSTOM_FIELD_KEY = "custom_field";
-    private static final int STORAGE = Storage.USER_METADATA;
+    private static final int STORAGE = Storage.PROFILE_ROOT;
 
     @Test
-    public void shouldCreateWithDefaultValues() throws Exception {
+    public void shouldCreateWithDefaultValues() {
         CustomField field = new CustomField(ICON, TYPE, KEY, HINT);
         assertThat(field.getIcon(), is(ICON));
         assertThat(field.getType(), is(TYPE));
         assertThat(field.getKey(), is(KEY));
         assertThat(field.getHint(), is(HINT));
         //Default values
-        assertThat(field.getStorage(), is(Storage.PROFILE_ROOT));
+        assertThat(field.getStorage(), is(Storage.USER_METADATA));
     }
 
     @Test
-    public void shouldCreate() throws Exception {
+    public void shouldCreate()  {
         CustomField field = new CustomField(ICON, TYPE, KEY, HINT, STORAGE);
         assertThat(field.getIcon(), is(ICON));
         assertThat(field.getType(), is(TYPE));
@@ -75,7 +75,7 @@ public class CustomFieldTest {
     }
 
     @Test
-    public void shouldBeParcelable() throws Exception {
+    public void shouldBeParcelable() {
         CustomField field = new CustomField(ICON, TYPE, KEY, HINT, STORAGE);
         Bundle bundle = new Bundle();
         bundle.putParcelable(CUSTOM_FIELD_KEY, field);

--- a/lib/src/test/java/com/auth0/android/lock/utils/CustomFieldTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/utils/CustomFieldTest.java
@@ -31,7 +31,9 @@ import com.auth0.android.lock.utils.CustomField.FieldType;
 import com.auth0.android.lock.views.ValidatedInputView;
 import com.auth0.android.lock.views.ValidatedInputView.DataType;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
@@ -53,6 +55,23 @@ public class CustomFieldTest {
     private static final String CUSTOM_FIELD_KEY = "custom_field";
     private static final int STORAGE = Storage.PROFILE_ROOT;
 
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void shouldThrowIfKeyIsEmpty() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("The key cannot be empty!");
+        new CustomField(ICON, TYPE, "", HINT, STORAGE);
+    }
+
+    @Test
+    public void shouldThrowIfKeyIsUserMetadataAndStorageIsRoot() {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("Update the user_metadata root profile attributes by using Storage.USER_METADATA as storage location.");
+        new CustomField(ICON, TYPE, "user_metadata", HINT, Storage.PROFILE_ROOT);
+    }
+
     @Test
     public void shouldCreateWithDefaultValues() {
         CustomField field = new CustomField(ICON, TYPE, KEY, HINT);
@@ -65,7 +84,7 @@ public class CustomFieldTest {
     }
 
     @Test
-    public void shouldCreate()  {
+    public void shouldCreate() {
         CustomField field = new CustomField(ICON, TYPE, KEY, HINT, STORAGE);
         assertThat(field.getIcon(), is(ICON));
         assertThat(field.getType(), is(TYPE));

--- a/lib/src/test/java/com/auth0/android/lock/utils/CustomFieldTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/utils/CustomFieldTest.java
@@ -37,7 +37,7 @@ import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import static org.hamcrest.Matchers.equalTo;
+import static com.auth0.android.lock.utils.CustomField.Storage;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -51,19 +51,42 @@ public class CustomFieldTest {
     private static final String KEY = "key";
     private static final int HINT = R.string.com_auth0_lock_hint_email;
     private static final String CUSTOM_FIELD_KEY = "custom_field";
+    private static final int STORAGE = Storage.USER_METADATA;
 
     @Test
-    public void testParcelable() {
+    public void shouldCreateWithDefaultValues() throws Exception {
         CustomField field = new CustomField(ICON, TYPE, KEY, HINT);
+        assertThat(field.getIcon(), is(ICON));
+        assertThat(field.getType(), is(TYPE));
+        assertThat(field.getKey(), is(KEY));
+        assertThat(field.getHint(), is(HINT));
+        //Default values
+        assertThat(field.getStorage(), is(Storage.PROFILE_ROOT));
+    }
+
+    @Test
+    public void shouldCreate() throws Exception {
+        CustomField field = new CustomField(ICON, TYPE, KEY, HINT, STORAGE);
+        assertThat(field.getIcon(), is(ICON));
+        assertThat(field.getType(), is(TYPE));
+        assertThat(field.getKey(), is(KEY));
+        assertThat(field.getHint(), is(HINT));
+        assertThat(field.getStorage(), is(STORAGE));
+    }
+
+    @Test
+    public void shouldBeParcelable() throws Exception {
+        CustomField field = new CustomField(ICON, TYPE, KEY, HINT, STORAGE);
         Bundle bundle = new Bundle();
         bundle.putParcelable(CUSTOM_FIELD_KEY, field);
 
         CustomField parcelableCustomField = bundle.getParcelable(CUSTOM_FIELD_KEY);
         assertThat(parcelableCustomField, is(notNullValue()));
-        assertThat(parcelableCustomField.getIcon(), is(equalTo(ICON)));
-        assertThat(parcelableCustomField.getType(), is(equalTo(TYPE)));
-        assertThat(parcelableCustomField.getKey(), is(equalTo(KEY)));
-        assertThat(parcelableCustomField.getHint(), is(equalTo(HINT)));
+        assertThat(parcelableCustomField.getIcon(), is(ICON));
+        assertThat(parcelableCustomField.getType(), is(TYPE));
+        assertThat(parcelableCustomField.getKey(), is(KEY));
+        assertThat(parcelableCustomField.getHint(), is(HINT));
+        assertThat(parcelableCustomField.getStorage(), is(STORAGE));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/android/lock/views/CustomFieldsFormViewTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/views/CustomFieldsFormViewTest.java
@@ -1,0 +1,66 @@
+package com.auth0.android.lock.views;
+
+import android.view.ViewGroup;
+
+import com.auth0.android.lock.utils.CustomField;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.hamcrest.collection.IsMapContaining.hasKey;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CustomFieldsFormViewTest {
+
+    @Test
+    public void shouldConvertCustomFieldsToMap() {
+        ViewGroup container = mock(ViewGroup.class);
+
+        //user_metadata attributes
+        CustomField fieldMetadata = mock(CustomField.class);
+        when(fieldMetadata.getKey()).thenReturn("company");
+        when(fieldMetadata.findValue(container)).thenReturn("Auth0 INC");
+        when(fieldMetadata.getStorage()).thenReturn(CustomField.Storage.USER_METADATA);
+
+
+        //Root profile attributes
+        CustomField fieldFamilyName = mock(CustomField.class);
+        when(fieldFamilyName.getKey()).thenReturn("family_name");
+        when(fieldFamilyName.findValue(container)).thenReturn("John");
+        when(fieldFamilyName.getStorage()).thenReturn(CustomField.Storage.PROFILE_ROOT);
+
+        CustomField fieldNickname = mock(CustomField.class);
+        when(fieldNickname.getKey()).thenReturn("nickname");
+        when(fieldNickname.findValue(container)).thenReturn("Johnnnny");
+        when(fieldNickname.getStorage()).thenReturn(CustomField.Storage.PROFILE_ROOT);
+
+
+        ArrayList<CustomField> list = new ArrayList<>();
+        list.add(fieldMetadata);
+        list.add(fieldFamilyName);
+        list.add(fieldNickname);
+
+
+        //Method under test
+        Map<String, Object> map = CustomFieldsFormView.convertFieldsToMap(list, container);
+
+
+        //Assertions
+        assertThat(map, is(notNullValue()));
+
+        assertThat(map, hasKey("user_metadata"));
+        assertThat(map, hasEntry("family_name", (Object) "John"));
+        assertThat(map, hasEntry("nickname", (Object) "Johnnnny"));
+
+        Map<String, Object> resultMetadata = (Map<String, Object>) map.get("user_metadata");
+        assertThat(resultMetadata, hasEntry("company", (Object) "Auth0 INC"));
+
+    }
+}

--- a/lib/src/test/java/com/auth0/android/lock/views/CustomFieldsFormViewTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/views/CustomFieldsFormViewTest.java
@@ -2,9 +2,11 @@ package com.auth0.android.lock.views;
 
 import android.view.ViewGroup;
 
+import com.auth0.android.lock.events.DatabaseSignUpEvent;
 import com.auth0.android.lock.utils.CustomField;
 
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -12,15 +14,16 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
-import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class CustomFieldsFormViewTest {
 
     @Test
     public void shouldConvertCustomFieldsToMap() {
+        DatabaseSignUpEvent event = mock(DatabaseSignUpEvent.class);
         ViewGroup container = mock(ViewGroup.class);
 
         //user_metadata attributes
@@ -49,18 +52,22 @@ public class CustomFieldsFormViewTest {
 
 
         //Method under test
-        Map<String, Object> map = CustomFieldsFormView.convertFieldsToMap(list, container);
+        CustomFieldsFormView.setEventRootProfileAttributes(event, list, container);
 
 
         //Assertions
-        assertThat(map, is(notNullValue()));
+        ArgumentCaptor<Map> mapCaptor = ArgumentCaptor.forClass(Map.class);
 
-        assertThat(map, hasKey("user_metadata"));
-        assertThat(map, hasEntry("family_name", (Object) "John"));
-        assertThat(map, hasEntry("nickname", (Object) "Johnnnny"));
+        verify(event).setExtraFields(mapCaptor.capture());
+        Map<String, String> metadataFields = mapCaptor.getValue();
+        assertThat(metadataFields, is(notNullValue()));
+        assertThat(metadataFields, hasEntry("company", "Auth0 INC"));
 
-        Map<String, Object> resultMetadata = (Map<String, Object>) map.get("user_metadata");
-        assertThat(resultMetadata, hasEntry("company", (Object) "Auth0 INC"));
+        verify(event).setRootAttributes(mapCaptor.capture());
+        Map<String, Object> rootAttributes = mapCaptor.getValue();
+        assertThat(rootAttributes, is(notNullValue()));
+        assertThat(rootAttributes, hasEntry("family_name", (Object) "John"));
+        assertThat(rootAttributes, hasEntry("nickname", (Object) "Johnnnny"));
 
     }
 }


### PR DESCRIPTION
### Changes

Allow to send user root profile attributes on sign up or user creation. 
Users can now choose when they want to store the custom fields. This still conserves the default of using the `user_metadata` key when not specified.

Docs PR: https://github.com/auth0/docs/pull/7954

### Testing

Pending manual testing. Added tests to the new static helper method that was used from 2 classes. The name can be changed, though. But people shouldn't be using our internal views in a standalone way anyway.

- [x] This change adds unit test coverage

- [ ] This change adds integration/UI test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors

- [x] The correct base branch is being used
