### PR TITLE
Options now pass additional user meta data

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -492,6 +492,17 @@ public class Lock {
         }
 
         /**
+         * Additional user metadata for Database Sign Up. Empty by default.
+         *
+         * @param userMetadata a non-null Map containing the parameters as Key-Values
+         * @return the current builder instance
+         */
+        public Builder withSignUpUserMetadata(HashMap<String, String> userMetadata) {
+            options.setCustomSignUpUserMetadata(userMetadata);
+            return this;
+        }
+
+        /**
          * Sets the Scope to request when performing the Authentication.
          *
          * @param scope to use in the Authentication.

--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -413,6 +413,8 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
             return;
         }
 
+        event.setExtraFields(options.getCustomSignUpUserMetadata());
+
         AuthenticationAPIClient apiClient = options.getAuthenticationAPIClient();
         final String connection = configuration.getDatabaseConnection().getName();
         lockView.showProgress(true);

--- a/lib/src/main/java/com/auth0/android/lock/events/DatabaseSignUpEvent.java
+++ b/lib/src/main/java/com/auth0/android/lock/events/DatabaseSignUpEvent.java
@@ -44,11 +44,13 @@ public class DatabaseSignUpEvent extends DatabaseEvent {
     @NonNull
     private String password;
     private Map<String, Object> rootAttributes;
+    private Map<String, Object> userMetadata;
 
     public DatabaseSignUpEvent(@NonNull String email, @NonNull String password, @Nullable String username) {
         super(email, username);
         this.password = password;
         this.rootAttributes = new HashMap<>();
+        this.userMetadata = new HashMap<>();
     }
 
     @NonNull
@@ -66,9 +68,8 @@ public class DatabaseSignUpEvent extends DatabaseEvent {
      * @param customFields user_metadata fields to set
      */
     public void setExtraFields(@NonNull Map<String, String> customFields) {
-        this.rootAttributes.put(KEY_USER_METADATA, customFields);
+        this.userMetadata.putAll(customFields);
     }
-
 
     public SignUpRequest getSignUpRequest(AuthenticationAPIClient apiClient, String connection) {
         SignUpRequest request;
@@ -76,6 +77,9 @@ public class DatabaseSignUpEvent extends DatabaseEvent {
             request = apiClient.signUp(getEmail(), getPassword(), getUsername(), connection);
         } else {
             request = apiClient.signUp(getEmail(), getPassword(), connection);
+        }
+        if (!userMetadata.isEmpty()) {
+            rootAttributes.put(KEY_USER_METADATA, userMetadata);
         }
         if (!rootAttributes.isEmpty()) {
             request.addSignUpParameters(rootAttributes);
@@ -89,6 +93,9 @@ public class DatabaseSignUpEvent extends DatabaseEvent {
             request = apiClient.createUser(getEmail(), getPassword(), getUsername(), connection);
         } else {
             request = apiClient.createUser(getEmail(), getPassword(), connection);
+        }
+        if (!userMetadata.isEmpty()) {
+            rootAttributes.put(KEY_USER_METADATA, userMetadata);
         }
         if (!rootAttributes.isEmpty()) {
             request.addParameters(rootAttributes);

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -56,6 +56,7 @@ public class Options implements Parcelable {
     private static final int HAS_DATA = 0x01;
     private static final String KEY_AUTHENTICATION_PARAMETERS = "authenticationParameters";
     private static final String KEY_CONNECTIONS_SCOPE = "connectionsScope";
+    private static final String KEY_CUSTOM_USER_METADATA = "withSignUpUserMetadata";
     private static final String SCOPE_KEY = "scope";
     private static final String DEVICE_KEY = "device";
     private static final String SCOPE_OFFLINE_ACCESS = "offline_access";
@@ -83,6 +84,7 @@ public class Options implements Parcelable {
     private HashMap<String, Object> authenticationParameters;
     private HashMap<String, String> connectionsScope;
     private List<CustomField> customFields;
+    private HashMap<String, String> customSignUpUserMetadata;
     private int initialScreen;
     private Theme theme;
     private String privacyURL;
@@ -109,6 +111,7 @@ public class Options implements Parcelable {
         authStyles = new HashMap<>();
         connectionsScope = new HashMap<>();
         customFields = new ArrayList<>();
+        customSignUpUserMetadata = new HashMap<>();
         theme = Theme.newBuilder().build();
     }
 
@@ -184,6 +187,13 @@ public class Options implements Parcelable {
             in.readList(customFields, CustomField.class.getClassLoader());
         } else {
             customFields = null;
+        }
+        if (in.readByte() == HAS_DATA) {
+            @SuppressLint("ParcelClassLoader")
+            Bundle mapBundle = in.readBundle();
+            customSignUpUserMetadata = (HashMap<String, String>) mapBundle.getSerializable(KEY_CUSTOM_USER_METADATA);
+        } else {
+            customSignUpUserMetadata = null;
         }
     }
 
@@ -261,6 +271,15 @@ public class Options implements Parcelable {
         } else {
             dest.writeByte((byte) (HAS_DATA));
             dest.writeList(customFields);
+        }
+        if (customSignUpUserMetadata == null) {
+            dest.writeByte((byte) (WITHOUT_DATA));
+        } else {
+            dest.writeByte((byte) (HAS_DATA));
+            // FIXME this is something to improve
+            Bundle mapBundle = new Bundle();
+            mapBundle.putSerializable(KEY_CUSTOM_USER_METADATA, customSignUpUserMetadata);
+            dest.writeBundle(mapBundle);
         }
     }
 
@@ -428,6 +447,15 @@ public class Options implements Parcelable {
     @NonNull
     public List<CustomField> getCustomFields() {
         return customFields;
+    }
+
+    @NonNull
+    public HashMap<String, String> getCustomSignUpUserMetadata() {
+        return customSignUpUserMetadata;
+    }
+
+    public void setCustomSignUpUserMetadata(@NonNull HashMap<String, String> customSignUpUserMetadata) {
+        this.customSignUpUserMetadata = customSignUpUserMetadata;
     }
 
     public void setInitialScreen(@InitialScreen int screen) {

--- a/lib/src/test/java/com/auth0/android/lock/LockActivityTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/LockActivityTest.java
@@ -276,6 +276,21 @@ public class LockActivityTest {
     }
 
     @Test
+    public void shouldCreateDatabaseSignUpEventWithAdditionalUserMetadata() {
+        HashMap<String, String> userMetadata = new HashMap<>();
+        userMetadata.put("hobby", "fishing");
+        when(configuration.loginAfterSignUp()).thenReturn(true);
+        when(options.getCustomSignUpUserMetadata()).thenReturn(userMetadata);
+
+        DatabaseSignUpEvent event = mock(DatabaseSignUpEvent.class);
+        when(event.getSignUpRequest(any(AuthenticationAPIClient.class), any(String.class))).thenReturn(signUpRequest);
+        activity.onDatabaseAuthenticationRequest(event);
+
+        verify(options).getCustomSignUpUserMetadata();
+        verify(event).setExtraFields(userMetadata);
+    }
+
+    @Test
     public void shouldCallOIDCDatabaseSignInWithCustomAudience() {
         Auth0 account = new Auth0("cliendId", "domain");
         account.setOIDCConformant(true);

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -668,6 +668,33 @@ public class OptionsTest {
     }
 
     @Test
+    public void shouldSetUserMetadata() {
+        HashMap<String, String> userMetadata = new HashMap<>();
+        userMetadata.put("key", "value");
+        options.setCustomSignUpUserMetadata(userMetadata);
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(parceledOptions.getCustomSignUpUserMetadata(), is(equalTo(options.getCustomSignUpUserMetadata())));
+    }
+
+    @Test
+    public void shouldGetEmptyUserMetadaIfNotSet() {
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.getCustomSignUpUserMetadata(), is(notNullValue()));
+        assertThat(options.getCustomSignUpUserMetadata().size(), is(0));
+        assertThat(parceledOptions.getCustomSignUpUserMetadata(), is(notNullValue()));
+        assertThat(parceledOptions.getCustomSignUpUserMetadata().size(), is(0));
+    }
+
+    @Test
     public void shouldSetDefaultValues() {
         Parcel parcel = Parcel.obtain();
         options.writeToParcel(parcel, 0);
@@ -694,6 +721,7 @@ public class OptionsTest {
         assertThat(options.usernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
         assertThat(options.getTheme(), is(notNullValue()));
         assertThat(options.getAuthenticationParameters(), is(notNullValue()));
+        assertThat(options.getCustomSignUpUserMetadata(), is(notNullValue()));
         assertThat(options.getAuthStyles(), is(notNullValue()));
     }
 


### PR DESCRIPTION
### Changes

This adds the option to pass-through ~~custom root attributes and~~ user metadata to the database sign up event. This enables apps to assign values to the new user that should not be displayed as user-editable `CustomField`s.

- Adds ~~`customSignUpRootAttributes` and~~ `customSignUpUserMetadata` properties on the Lock Options type.
- Passes the ~~`customSignUpRootAttributes` and~~ `customSignUpUserMetadata` values to the `DatabaseSignUpEvent` in `LockActivity#onDatabaseAuthenticationRequest`.

### References

- [Set Metadata Properties on Creation](https://auth0.com/docs/users/guides/set-metadata-properties-on-creation)
- Auth0 SDK's [`createUser` documentation](https://auth0.com/docs/libraries/auth0-swift/database-authentication#signing-up-with-a-database-connection)

### Testing

- [x] This change adds unit test coverage

- [x] This change adds integration/UI test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors

- [x] The correct base branch is being used
