### PR TITLE
Add hidden extra sign up fields

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -487,7 +487,7 @@ public class Lock {
          * @param customFields the custom fields to display in the sign up flow.
          * @return the current builder instance
          */
-        public Builder withSignUpFields(List<SignUpField> customFields) {
+        public Builder withSignUpFields(List<? extends SignUpField> customFields) {
             final List<SignUpField> withoutDuplicates = removeDuplicatedKeys(customFields);
             options.setSignUpFields(withoutDuplicates);
             return this;
@@ -605,7 +605,7 @@ public class Lock {
             return this;
         }
 
-        private List<SignUpField> removeDuplicatedKeys(List<SignUpField> customFields) {
+        private List<SignUpField> removeDuplicatedKeys(List<? extends SignUpField> customFields) {
             int originalSize = customFields.size();
             final List<SignUpField> withoutDuplicates = new ArrayList<>();
 

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -40,8 +40,8 @@ import com.auth0.android.lock.LockCallback.LockEvent;
 import com.auth0.android.lock.internal.configuration.Options;
 import com.auth0.android.lock.internal.configuration.Theme;
 import com.auth0.android.lock.provider.AuthResolver;
-import com.auth0.android.lock.utils.CustomField;
 import com.auth0.android.lock.utils.LockException;
+import com.auth0.android.lock.utils.SignUpField;
 import com.auth0.android.provider.AuthHandler;
 import com.auth0.android.util.Telemetry;
 
@@ -479,15 +479,17 @@ public class Lock {
         }
 
         /**
-         * Displays a second screen with the specified custom fields during sign up.
-         * Each field must have a unique key.
+         * Displays the specified custom fields during sign up. If the amount of visible fields
+         * is greater than {@link com.auth0.android.lock.views.SignUpFormView#MAX_FEW_CUSTOM_FIELDS}
+         * they will be shown on a separate screen.
+         * Each field must have a unique key. Fields with repeated keys will be removed.
          *
          * @param customFields the custom fields to display in the sign up flow.
          * @return the current builder instance
          */
-        public Builder withSignUpFields(List<CustomField> customFields) {
-            final List<CustomField> withoutDuplicates = removeDuplicatedKeys(customFields);
-            options.setCustomFields(withoutDuplicates);
+        public Builder withSignUpFields(List<SignUpField> customFields) {
+            final List<SignUpField> withoutDuplicates = removeDuplicatedKeys(customFields);
+            options.setSignUpFields(withoutDuplicates);
             return this;
         }
 
@@ -603,12 +605,12 @@ public class Lock {
             return this;
         }
 
-        private List<CustomField> removeDuplicatedKeys(List<CustomField> customFields) {
+        private List<SignUpField> removeDuplicatedKeys(List<SignUpField> customFields) {
             int originalSize = customFields.size();
-            final List<CustomField> withoutDuplicates = new ArrayList<>();
+            final List<SignUpField> withoutDuplicates = new ArrayList<>();
 
             Set<String> keySet = new HashSet<>();
-            for (CustomField field : customFields) {
+            for (SignUpField field : customFields) {
                 if (!keySet.contains(field.getKey())) {
                     withoutDuplicates.add(field);
                 }

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Configuration.java
@@ -32,6 +32,8 @@ import android.util.Log;
 import com.auth0.android.lock.InitialScreen;
 import com.auth0.android.lock.UsernameStyle;
 import com.auth0.android.lock.utils.CustomField;
+import com.auth0.android.lock.utils.HiddenField;
+import com.auth0.android.lock.utils.SignUpField;
 import com.auth0.android.lock.views.AuthConfig;
 
 import java.util.ArrayList;
@@ -73,8 +75,10 @@ public class Configuration {
     private String termsURL;
     private String privacyURL;
     private String supportURL;
-    private List<CustomField> extraSignUpFields;
+    private List<HiddenField> extraHiddenSignUpFields;
+    private List<CustomField> extraVisibleSignUpFields;
     private Map<String, Integer> authStyles;
+    private Object sf;
 
     public Configuration(List<Connection> connections, Options options) {
         List<String> allowedConnections = options.getConnections();
@@ -93,8 +97,13 @@ public class Configuration {
     }
 
     @NonNull
-    public List<CustomField> getExtraSignUpFields() {
-        return extraSignUpFields;
+    public List<CustomField> getVisibleSignUpFields() {
+        return extraVisibleSignUpFields;
+    }
+
+    @NonNull
+    public List<HiddenField> getHiddenSignUpFields() {
+        return extraHiddenSignUpFields;
     }
 
     @Nullable
@@ -189,7 +198,15 @@ public class Configuration {
         passwordlessAutoSubmit = options.rememberLastPasswordlessAccount();
 
         authStyles = options.getAuthStyles();
-        extraSignUpFields = options.getCustomFields();
+        extraHiddenSignUpFields = new ArrayList<>();
+        extraVisibleSignUpFields = new ArrayList<>();
+        for (SignUpField sf : options.getSignUpFields()) {
+            if (sf instanceof HiddenField) {
+                extraHiddenSignUpFields.add((HiddenField) sf);
+            } else {
+                extraVisibleSignUpFields.add((CustomField) sf);
+            }
+        }
 
         if (getDatabaseConnection() != null) {
             allowLogIn = options.allowLogIn();
@@ -273,10 +290,6 @@ public class Configuration {
 
     public boolean loginAfterSignUp() {
         return loginAfterSignUp;
-    }
-
-    public boolean hasExtraFields() {
-        return !extraSignUpFields.isEmpty();
     }
 
     public boolean hasClassicConnections() {

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -39,7 +39,7 @@ import com.auth0.android.authentication.AuthenticationAPIClient;
 import com.auth0.android.lock.Auth0Parcelable;
 import com.auth0.android.lock.InitialScreen;
 import com.auth0.android.lock.UsernameStyle;
-import com.auth0.android.lock.utils.CustomField;
+import com.auth0.android.lock.utils.SignUpField;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -82,7 +82,7 @@ public class Options implements Parcelable {
     private HashMap<String, Integer> authStyles;
     private HashMap<String, Object> authenticationParameters;
     private HashMap<String, String> connectionsScope;
-    private List<CustomField> customFields;
+    private List<SignUpField> signUpFields;
     private int initialScreen;
     private Theme theme;
     private String privacyURL;
@@ -108,7 +108,7 @@ public class Options implements Parcelable {
         authenticationParameters = new HashMap<>();
         authStyles = new HashMap<>();
         connectionsScope = new HashMap<>();
-        customFields = new ArrayList<>();
+        signUpFields = new ArrayList<>();
         theme = Theme.newBuilder().build();
     }
 
@@ -180,10 +180,10 @@ public class Options implements Parcelable {
             connectionsScope = null;
         }
         if (in.readByte() == HAS_DATA) {
-            customFields = new ArrayList<>();
-            in.readList(customFields, CustomField.class.getClassLoader());
+            signUpFields = new ArrayList<>();
+            in.readList(signUpFields, SignUpField.class.getClassLoader());
         } else {
-            customFields = null;
+            signUpFields = null;
         }
     }
 
@@ -256,11 +256,11 @@ public class Options implements Parcelable {
             mapBundle.putSerializable(KEY_CONNECTIONS_SCOPE, connectionsScope);
             dest.writeBundle(mapBundle);
         }
-        if (customFields == null) {
+        if (signUpFields == null) {
             dest.writeByte((byte) (WITHOUT_DATA));
         } else {
             dest.writeByte((byte) (HAS_DATA));
-            dest.writeList(customFields);
+            dest.writeList(signUpFields);
         }
     }
 
@@ -421,13 +421,13 @@ public class Options implements Parcelable {
         return this.useCodePasswordless;
     }
 
-    public void setCustomFields(@NonNull List<CustomField> customFields) {
-        this.customFields = customFields;
+    public void setSignUpFields(@NonNull List<SignUpField> signUpFields) {
+        this.signUpFields = signUpFields;
     }
 
     @NonNull
-    public List<CustomField> getCustomFields() {
-        return customFields;
+    public List<SignUpField> getSignUpFields() {
+        return signUpFields;
     }
 
     public void setInitialScreen(@InitialScreen int screen) {

--- a/lib/src/main/java/com/auth0/android/lock/utils/CustomField.java
+++ b/lib/src/main/java/com/auth0/android/lock/utils/CustomField.java
@@ -47,7 +47,7 @@ import static com.auth0.android.lock.utils.CustomField.FieldType.TYPE_PHONE_NUMB
 import static com.auth0.android.lock.utils.CustomField.Storage.PROFILE_ROOT;
 import static com.auth0.android.lock.utils.CustomField.Storage.USER_METADATA;
 
-public class CustomField implements Parcelable {
+public class CustomField extends SignUpField {
 
     @IntDef({TYPE_NAME, TYPE_NUMBER, TYPE_PHONE_NUMBER, TYPE_EMAIL})
     @Retention(RetentionPolicy.SOURCE)
@@ -80,16 +80,12 @@ public class CustomField implements Parcelable {
     private final int icon;
     @FieldType
     private final int type;
-    private final String key;
     @StringRes
     private final int hint;
-    @Storage
-    private final int storage;
-
 
     /**
      * Constructor for CustomField instance
-     * When this constructor is used the field will be stored under the {@link Storage#USER_METADATA} attribute. 
+     * When this constructor is used the field will be stored under the {@link Storage#USER_METADATA} attribute.
      * If you want to change the storage location use the constructor that accepts a {@link Storage} value.
      *
      * @param icon the icon resource to display next to the field.
@@ -111,17 +107,10 @@ public class CustomField implements Parcelable {
      * @param storage the location to store this value into.
      */
     public CustomField(@DrawableRes int icon, @FieldType int type, @NonNull String key, @StringRes int hint, @Storage int storage) {
-        if (key.isEmpty()) {
-            throw new IllegalArgumentException("The key cannot be empty!");
-        }
-        if (key.equalsIgnoreCase("user_metadata") && storage == PROFILE_ROOT){
-            throw new IllegalArgumentException("Update the user_metadata root profile attributes by using Storage.USER_METADATA as storage location.");
-        }
+        super(key, storage);
         this.icon = icon;
         this.type = type;
-        this.key = key;
         this.hint = hint;
-        this.storage = storage;
     }
 
     public void configureField(@NonNull ValidatedInputView field) {
@@ -141,21 +130,17 @@ public class CustomField implements Parcelable {
         }
         field.setHint(hint);
         field.setIcon(icon);
-        field.setTag(key);
+        field.setTag(getKey());
     }
 
     @Nullable
     public String findValue(@NonNull ViewGroup container) {
         String value = null;
-        View view = container.findViewWithTag(key);
+        View view = container.findViewWithTag(getKey());
         if (view != null) {
             value = ((ValidatedInputView) view).getText();
         }
         return value;
-    }
-
-    public String getKey() {
-        return key;
     }
 
     @StringRes
@@ -173,31 +158,19 @@ public class CustomField implements Parcelable {
         return type;
     }
 
-    @Storage
-    public int getStorage() {
-        return storage;
-    }
-
     protected CustomField(Parcel in) {
+        super(in);
         icon = in.readInt();
         type = in.readInt();
-        key = in.readString();
         hint = in.readInt();
-        storage = in.readInt();
-    }
-
-    @Override
-    public int describeContents() {
-        return 0;
     }
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
+        super.writeToParcel(dest, flags);
         dest.writeInt(icon);
         dest.writeInt(type);
-        dest.writeString(key);
         dest.writeInt(hint);
-        dest.writeInt(storage);
     }
 
     @SuppressWarnings("unused")

--- a/lib/src/main/java/com/auth0/android/lock/utils/HiddenField.java
+++ b/lib/src/main/java/com/auth0/android/lock/utils/HiddenField.java
@@ -1,0 +1,51 @@
+package com.auth0.android.lock.utils;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+
+public class HiddenField extends SignUpField {
+
+    private final String value;
+
+    /**
+     * Constructor for HiddenField instance
+     *
+     * @param key     the key to store this field as.
+     * @param value   the fixed value to set for this field
+     * @param storage the location to store this value into.
+     */
+    public HiddenField(@NonNull String key, @NonNull String value, @CustomField.Storage int storage) {
+        super(key, storage);
+        this.value = value;
+    }
+
+    @NonNull
+    public String getValue() {
+        return value;
+    }
+
+    protected HiddenField(Parcel in) {
+        super(in);
+        value = in.readString();
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeString(value);
+    }
+
+    @SuppressWarnings("unused")
+    public static final Parcelable.Creator<HiddenField> CREATOR = new Parcelable.Creator<HiddenField>() {
+        @Override
+        public HiddenField createFromParcel(Parcel in) {
+            return new HiddenField(in);
+        }
+
+        @Override
+        public HiddenField[] newArray(int size) {
+            return new HiddenField[size];
+        }
+    };
+}

--- a/lib/src/main/java/com/auth0/android/lock/utils/SignUpField.java
+++ b/lib/src/main/java/com/auth0/android/lock/utils/SignUpField.java
@@ -1,0 +1,52 @@
+package com.auth0.android.lock.utils;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.CallSuper;
+import android.support.annotation.NonNull;
+
+import static com.auth0.android.lock.utils.CustomField.Storage.PROFILE_ROOT;
+
+public abstract class SignUpField implements Parcelable {
+
+    private final String key;
+    private final int storage;
+
+    SignUpField(@NonNull String key, @CustomField.Storage int storage) {
+        if (key.isEmpty()) {
+            throw new IllegalArgumentException("The key cannot be empty!");
+        }
+        if (key.equalsIgnoreCase("user_metadata") && storage == PROFILE_ROOT) {
+            throw new IllegalArgumentException("Update the user_metadata root profile attributes by using Storage.USER_METADATA as storage location.");
+        }
+        this.key = key;
+        this.storage = storage;
+    }
+
+    @CustomField.Storage
+    public int getStorage() {
+        return storage;
+    }
+
+    @NonNull
+    public String getKey() {
+        return key;
+    }
+
+    SignUpField(Parcel in) {
+        key = in.readString();
+        storage = in.readInt();
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    @CallSuper
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(key);
+        dest.writeInt(storage);
+    }
+}

--- a/lib/src/main/java/com/auth0/android/lock/utils/SignUpField.java
+++ b/lib/src/main/java/com/auth0/android/lock/utils/SignUpField.java
@@ -14,7 +14,7 @@ public abstract class SignUpField implements Parcelable {
 
     SignUpField(@NonNull String key, @CustomField.Storage int storage) {
         if (key.isEmpty()) {
-            throw new IllegalArgumentException("The key cannot be empty!");
+            throw new IllegalArgumentException("The key cannot be empty.");
         }
         if (key.equalsIgnoreCase("user_metadata") && storage == PROFILE_ROOT) {
             throw new IllegalArgumentException("Update the user_metadata root profile attributes by using Storage.USER_METADATA as storage location.");

--- a/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/FormLayout.java
@@ -267,7 +267,7 @@ public class FormLayout extends RelativeLayout implements ModeSelectionView.Mode
 
         FormView form = (FormView) existingForm;
         Object ev = form.submitForm();
-        if (ev == null || lockWidget.getConfiguration().getExtraSignUpFields().size() <= SignUpFormView.MAX_FEW_CUSTOM_FIELDS) {
+        if (ev == null || lockWidget.getConfiguration().getVisibleSignUpFields().size() <= SignUpFormView.MAX_FEW_CUSTOM_FIELDS) {
             return ev;
         } else if (existingForm == signUpForm) {
             //User has configured some extra SignUp custom fields.

--- a/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
@@ -42,6 +42,7 @@ import com.auth0.android.lock.UsernameStyle;
 import com.auth0.android.lock.events.DatabaseSignUpEvent;
 import com.auth0.android.lock.internal.configuration.Configuration;
 import com.auth0.android.lock.utils.CustomField;
+import com.auth0.android.lock.utils.HiddenField;
 import com.auth0.android.lock.views.interfaces.IdentityListener;
 import com.auth0.android.lock.views.interfaces.LockWidgetForm;
 
@@ -92,9 +93,9 @@ public class SignUpFormView extends FormView implements TextView.OnEditorActionL
 
         usernameInput.setVisibility(configuration.isUsernameRequired() ? View.VISIBLE : View.GONE);
 
-        displayFewCustomFields = lockWidget.getConfiguration().getExtraSignUpFields().size() <= MAX_FEW_CUSTOM_FIELDS;
+        displayFewCustomFields = lockWidget.getConfiguration().getVisibleSignUpFields().size() <= MAX_FEW_CUSTOM_FIELDS;
         if (displayFewCustomFields) {
-            addCustomFields(configuration.getExtraSignUpFields());
+            addCustomFields(configuration.getVisibleSignUpFields());
         }
     }
 
@@ -170,12 +171,13 @@ public class SignUpFormView extends FormView implements TextView.OnEditorActionL
     public Object submitForm() {
         if (validateForm()) {
             DatabaseSignUpEvent event = (DatabaseSignUpEvent) getActionEvent();
+            List<CustomField> visibleFields = lockWidget.getConfiguration().getVisibleSignUpFields();
             if (displayFewCustomFields) {
-                List<CustomField> fields = lockWidget.getConfiguration().getExtraSignUpFields();
-                setEventRootProfileAttributes(event, fields, fieldContainer);
+                List<HiddenField> hiddenFields = lockWidget.getConfiguration().getHiddenSignUpFields();
+                setEventRootProfileAttributes(event, visibleFields, hiddenFields, fieldContainer);
                 return event;
             }
-            if (lockWidget.getConfiguration().hasExtraFields()) {
+            if (!visibleFields.isEmpty()) {
                 lockWidget.showCustomFieldsForm(event);
             }
         }

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
@@ -29,6 +29,8 @@ import com.auth0.android.lock.R;
 import com.auth0.android.lock.UsernameStyle;
 import com.auth0.android.lock.utils.CustomField;
 import com.auth0.android.lock.utils.CustomField.FieldType;
+import com.auth0.android.lock.utils.HiddenField;
+import com.auth0.android.lock.utils.SignUpField;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 
@@ -216,11 +218,11 @@ public class ConfigurationTest extends GsonBaseTest {
 
     @Test
     public void shouldSetExtraSignUpFields() {
-        options.setCustomFields(createCustomFields());
+        options.setSignUpFields(createSignUpFields());
         configuration = new Configuration(connections, options);
 
         assertThat(configuration.hasExtraFields(), is(true));
-        assertThat(configuration.getExtraSignUpFields(), contains(options.getCustomFields().toArray()));
+        assertThat(configuration.getExtraSignUpFields(), contains(options.getSignUpFields().toArray()));
     }
 
     @Test
@@ -608,13 +610,15 @@ public class ConfigurationTest extends GsonBaseTest {
         return new Configuration(connections, options);
     }
 
-    private List<CustomField> createCustomFields() {
+    private List<SignUpField> createSignUpFields() {
         CustomField fieldNumber = new CustomField(R.drawable.com_auth0_lock_ic_phone, FieldType.TYPE_PHONE_NUMBER, "number", R.string.com_auth0_lock_hint_phone_number);
         CustomField fieldSurname = new CustomField(R.drawable.com_auth0_lock_ic_username, FieldType.TYPE_NAME, "surname", R.string.com_auth0_lock_hint_username);
+        HiddenField fieldHidden = new HiddenField("referral_id", "0009912BBA", CustomField.Storage.PROFILE_ROOT);
 
-        List<CustomField> customFields = new ArrayList<>();
-        customFields.add(fieldNumber);
-        customFields.add(fieldSurname);
-        return customFields;
+        List<SignUpField> signUpFields = new ArrayList<>();
+        signUpFields.add(fieldNumber);
+        signUpFields.add(fieldSurname);
+        signUpFields.add(fieldHidden);
+        return signUpFields;
     }
 }

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/ConfigurationTest.java
@@ -102,7 +102,6 @@ public class ConfigurationTest extends GsonBaseTest {
         assertThat(configuration.loginAfterSignUp(), is(true));
         assertThat(configuration.getUsernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
         assertThat(configuration.getInitialScreen(), is(equalTo(InitialScreen.LOG_IN)));
-        assertThat(configuration.hasExtraFields(), is(false));
         assertThat(configuration.getPasswordComplexity(), is(notNullValue()));
         assertThat(configuration.getPasswordComplexity().getPasswordPolicy(), is(PasswordStrength.NONE));
         assertThat(configuration.mustAcceptTerms(), is(false));
@@ -143,7 +142,6 @@ public class ConfigurationTest extends GsonBaseTest {
         assertThat(configuration.allowShowPassword(), is(false));
         assertThat(configuration.loginAfterSignUp(), is(false));
         assertThat(configuration.getUsernameStyle(), is(equalTo(UsernameStyle.USERNAME)));
-        assertThat(configuration.hasExtraFields(), is(false));
     }
 
     @Test
@@ -218,11 +216,17 @@ public class ConfigurationTest extends GsonBaseTest {
 
     @Test
     public void shouldSetExtraSignUpFields() {
-        options.setSignUpFields(createSignUpFields());
+        List<SignUpField> fields = new ArrayList<>();
+        List<SignUpField> hiddenSignUpFields = createHiddenSignUpFields();
+        List<SignUpField> visibleSignUpFields = createVisibleSignUpFields();
+        fields.addAll(hiddenSignUpFields);
+        fields.addAll(visibleSignUpFields);
+
+        options.setSignUpFields(fields);
         configuration = new Configuration(connections, options);
 
-        assertThat(configuration.hasExtraFields(), is(true));
-        assertThat(configuration.getExtraSignUpFields(), contains(options.getSignUpFields().toArray()));
+        assertThat(configuration.getHiddenSignUpFields(), contains(hiddenSignUpFields.toArray()));
+        assertThat(configuration.getVisibleSignUpFields(), contains(visibleSignUpFields.toArray()));
     }
 
     @Test
@@ -610,15 +614,23 @@ public class ConfigurationTest extends GsonBaseTest {
         return new Configuration(connections, options);
     }
 
-    private List<SignUpField> createSignUpFields() {
+    private List<SignUpField> createVisibleSignUpFields() {
         CustomField fieldNumber = new CustomField(R.drawable.com_auth0_lock_ic_phone, FieldType.TYPE_PHONE_NUMBER, "number", R.string.com_auth0_lock_hint_phone_number);
         CustomField fieldSurname = new CustomField(R.drawable.com_auth0_lock_ic_username, FieldType.TYPE_NAME, "surname", R.string.com_auth0_lock_hint_username);
-        HiddenField fieldHidden = new HiddenField("referral_id", "0009912BBA", CustomField.Storage.PROFILE_ROOT);
 
         List<SignUpField> signUpFields = new ArrayList<>();
         signUpFields.add(fieldNumber);
         signUpFields.add(fieldSurname);
-        signUpFields.add(fieldHidden);
+        return signUpFields;
+    }
+
+    private List<SignUpField> createHiddenSignUpFields() {
+        HiddenField fieldHidden1 = new HiddenField("referral_id", "0009912BBA", CustomField.Storage.PROFILE_ROOT);
+        HiddenField fieldHidden2 = new HiddenField("ad_reference", "mmmaba", CustomField.Storage.PROFILE_ROOT);
+
+        List<SignUpField> signUpFields = new ArrayList<>();
+        signUpFields.add(fieldHidden1);
+        signUpFields.add(fieldHidden2);
         return signUpFields;
     }
 }

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -10,6 +10,7 @@ import com.auth0.android.lock.R;
 import com.auth0.android.lock.UsernameStyle;
 import com.auth0.android.lock.utils.CustomField;
 import com.auth0.android.lock.utils.CustomField.FieldType;
+import com.auth0.android.lock.utils.SignUpField;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -613,8 +614,8 @@ public class OptionsTest {
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(parceledOptions.getSignUpFields(), hasSize(options.getSignUpFields().size()));
         for (int i = 0; i < options.getSignUpFields().size(); i++) {
-            CustomField fieldA = options.getSignUpFields().get(i);
-            CustomField fieldB = parceledOptions.getSignUpFields().get(i);
+            SignUpField fieldA = options.getSignUpFields().get(i);
+            SignUpField fieldB = parceledOptions.getSignUpFields().get(i);
             assertThat(fieldA.getKey(), is(equalTo(fieldB.getKey())));
         }
     }
@@ -799,11 +800,11 @@ public class OptionsTest {
         assertThat(client, is(notNullValue()));
     }
 
-    private List<CustomField> createCustomFields() {
+    private List<SignUpField> createCustomFields() {
         CustomField fieldNumber = new CustomField(R.drawable.com_auth0_lock_ic_phone, FieldType.TYPE_PHONE_NUMBER, "number", R.string.com_auth0_lock_hint_phone_number);
         CustomField fieldSurname = new CustomField(R.drawable.com_auth0_lock_ic_username, FieldType.TYPE_NAME, "surname", R.string.com_auth0_lock_hint_username);
 
-        List<CustomField> customFields = new ArrayList<>();
+        List<SignUpField> customFields = new ArrayList<>();
         customFields.add(fieldNumber);
         customFields.add(fieldSurname);
         return customFields;

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -604,17 +604,17 @@ public class OptionsTest {
 
     @Test
     public void shouldSetCustomFields() {
-        options.setCustomFields(createCustomFields());
+        options.setSignUpFields(createCustomFields());
 
         Parcel parcel = Parcel.obtain();
         options.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(parceledOptions.getCustomFields(), hasSize(options.getCustomFields().size()));
-        for (int i = 0; i < options.getCustomFields().size(); i++) {
-            CustomField fieldA = options.getCustomFields().get(i);
-            CustomField fieldB = parceledOptions.getCustomFields().get(i);
+        assertThat(parceledOptions.getSignUpFields(), hasSize(options.getSignUpFields().size()));
+        for (int i = 0; i < options.getSignUpFields().size(); i++) {
+            CustomField fieldA = options.getSignUpFields().get(i);
+            CustomField fieldB = parceledOptions.getSignUpFields().get(i);
             assertThat(fieldA.getKey(), is(equalTo(fieldB.getKey())));
         }
     }
@@ -626,10 +626,10 @@ public class OptionsTest {
         parcel.setDataPosition(0);
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(options.getCustomFields(), is(notNullValue()));
-        assertThat(options.getCustomFields().size(), is(0));
-        assertThat(parceledOptions.getCustomFields(), is(notNullValue()));
-        assertThat(parceledOptions.getCustomFields().size(), is(0));
+        assertThat(options.getSignUpFields(), is(notNullValue()));
+        assertThat(options.getSignUpFields().size(), is(0));
+        assertThat(parceledOptions.getSignUpFields(), is(notNullValue()));
+        assertThat(parceledOptions.getSignUpFields().size(), is(0));
     }
 
     @Test

--- a/lib/src/test/java/com/auth0/android/lock/utils/CustomFieldTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/utils/CustomFieldTest.java
@@ -25,6 +25,8 @@
 package com.auth0.android.lock.utils;
 
 import android.os.Bundle;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
 
 import com.auth0.android.lock.R;
 import com.auth0.android.lock.utils.CustomField.FieldType;
@@ -43,6 +45,8 @@ import static com.auth0.android.lock.utils.CustomField.Storage;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 21)
@@ -109,15 +113,68 @@ public class CustomFieldTest {
     }
 
     @Test
-    public void shouldConfigureTheField() {
+    public void shouldConfigureTheEmailField() {
         ValidatedInputView input = Mockito.mock(ValidatedInputView.class);
 
-        CustomField field = new CustomField(ICON, TYPE, KEY, HINT);
+        CustomField field = new CustomField(ICON, FieldType.TYPE_EMAIL, KEY, HINT);
         field.configureField(input);
 
         Mockito.verify(input).setIcon(ICON);
         Mockito.verify(input).setDataType(DataType.EMAIL);
         Mockito.verify(input).setHint(HINT);
         Mockito.verify(input).setTag(KEY);
+    }
+
+    @Test
+    public void shouldConfigureTheNameField() {
+        ValidatedInputView input = Mockito.mock(ValidatedInputView.class);
+
+        CustomField field = new CustomField(ICON, FieldType.TYPE_NAME, KEY, HINT);
+        field.configureField(input);
+
+        Mockito.verify(input).setIcon(ICON);
+        Mockito.verify(input).setDataType(DataType.TEXT_NAME);
+        Mockito.verify(input).setHint(HINT);
+        Mockito.verify(input).setTag(KEY);
+    }
+
+    @Test
+    public void shouldConfigureThePhoneNumberField() {
+        ValidatedInputView input = Mockito.mock(ValidatedInputView.class);
+
+        CustomField field = new CustomField(ICON, FieldType.TYPE_PHONE_NUMBER, KEY, HINT);
+        field.configureField(input);
+
+        Mockito.verify(input).setIcon(ICON);
+        Mockito.verify(input).setDataType(DataType.PHONE_NUMBER);
+        Mockito.verify(input).setHint(HINT);
+        Mockito.verify(input).setTag(KEY);
+    }
+
+    @Test
+    public void shouldConfigureTheNumberField() {
+        ValidatedInputView input = Mockito.mock(ValidatedInputView.class);
+
+        CustomField field = new CustomField(ICON, FieldType.TYPE_NUMBER, KEY, HINT);
+        field.configureField(input);
+
+        Mockito.verify(input).setIcon(ICON);
+        Mockito.verify(input).setDataType(DataType.NUMBER);
+        Mockito.verify(input).setHint(HINT);
+        Mockito.verify(input).setTag(KEY);
+    }
+
+    @Test
+    public void shouldObtainTheValue() {
+        ViewGroup container = Mockito.mock(LinearLayout.class);
+        ValidatedInputView input = Mockito.mock(ValidatedInputView.class);
+
+        when(input.getText()).thenReturn("user defined value");
+        when(container.findViewWithTag(eq(KEY))).thenReturn(input);
+
+        CustomField field = new CustomField(ICON, TYPE, KEY, HINT);
+        String value = field.findValue(container);
+
+        assertThat(value, is("user defined value"));
     }
 }

--- a/lib/src/test/java/com/auth0/android/lock/utils/CustomFieldTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/utils/CustomFieldTest.java
@@ -65,7 +65,7 @@ public class CustomFieldTest {
     @Test
     public void shouldThrowIfKeyIsEmpty() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("The key cannot be empty!");
+        exception.expectMessage("The key cannot be empty.");
         new CustomField(ICON, TYPE, "", HINT, STORAGE);
     }
 

--- a/lib/src/test/java/com/auth0/android/lock/utils/HiddenFieldTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/utils/HiddenFieldTest.java
@@ -1,0 +1,34 @@
+package com.auth0.android.lock.utils;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class HiddenFieldTest {
+    private static final String KEY = "key";
+    private static final String VALUE = "fixed value";
+    private static final int STORAGE = CustomField.Storage.PROFILE_ROOT;
+    private HiddenField field;
+
+    @Before
+    public void setUp() throws Exception {
+        field = new HiddenField(KEY, VALUE, STORAGE);
+    }
+
+    @Test
+    public void shouldGetKey() {
+        assertThat(field.getKey(), is(KEY));
+    }
+
+    @Test
+    public void shouldGetStorage() {
+        assertThat(field.getStorage(), is(CustomField.Storage.PROFILE_ROOT));
+    }
+
+    @Test
+    public void shouldGetValue() {
+        assertThat(field.getValue(), is(VALUE));
+    }
+}

--- a/lib/src/test/java/com/auth0/android/lock/views/CustomFieldsFormViewTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/views/CustomFieldsFormViewTest.java
@@ -4,6 +4,7 @@ import android.view.ViewGroup;
 
 import com.auth0.android.lock.events.DatabaseSignUpEvent;
 import com.auth0.android.lock.utils.CustomField;
+import com.auth0.android.lock.utils.HiddenField;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -32,6 +33,11 @@ public class CustomFieldsFormViewTest {
         when(fieldMetadata.findValue(container)).thenReturn("Auth0 INC");
         when(fieldMetadata.getStorage()).thenReturn(CustomField.Storage.USER_METADATA);
 
+        HiddenField fieldHidden1 = mock(HiddenField.class);
+        when(fieldHidden1.getKey()).thenReturn("referral_id");
+        when(fieldHidden1.getValue()).thenReturn("123456789");
+        when(fieldHidden1.getStorage()).thenReturn(CustomField.Storage.USER_METADATA);
+
 
         //Root profile attributes
         CustomField fieldFamilyName = mock(CustomField.class);
@@ -44,15 +50,23 @@ public class CustomFieldsFormViewTest {
         when(fieldNickname.findValue(container)).thenReturn("Johnnnny");
         when(fieldNickname.getStorage()).thenReturn(CustomField.Storage.PROFILE_ROOT);
 
+        HiddenField fieldHidden2 = mock(HiddenField.class);
+        when(fieldHidden2.getKey()).thenReturn("partnership");
+        when(fieldHidden2.getValue()).thenReturn("bookar");
+        when(fieldHidden2.getStorage()).thenReturn(CustomField.Storage.PROFILE_ROOT);
 
-        ArrayList<CustomField> list = new ArrayList<>();
-        list.add(fieldMetadata);
-        list.add(fieldFamilyName);
-        list.add(fieldNickname);
 
+        ArrayList<CustomField> visibleList = new ArrayList<>();
+        visibleList.add(fieldMetadata);
+        visibleList.add(fieldFamilyName);
+        visibleList.add(fieldNickname);
+
+        ArrayList<HiddenField> hiddenList = new ArrayList<>();
+        hiddenList.add(fieldHidden1);
+        hiddenList.add(fieldHidden2);
 
         //Method under test
-        CustomFieldsFormView.setEventRootProfileAttributes(event, list, container);
+        CustomFieldsFormView.setEventRootProfileAttributes(event, visibleList, hiddenList, container);
 
 
         //Assertions
@@ -62,12 +76,13 @@ public class CustomFieldsFormViewTest {
         Map<String, String> metadataFields = mapCaptor.getValue();
         assertThat(metadataFields, is(notNullValue()));
         assertThat(metadataFields, hasEntry("company", "Auth0 INC"));
+        assertThat(metadataFields, hasEntry("referral_id", "123456789"));
 
         verify(event).setRootAttributes(mapCaptor.capture());
         Map<String, Object> rootAttributes = mapCaptor.getValue();
         assertThat(rootAttributes, is(notNullValue()));
         assertThat(rootAttributes, hasEntry("family_name", (Object) "John"));
         assertThat(rootAttributes, hasEntry("nickname", (Object) "Johnnnny"));
-
+        assertThat(rootAttributes, hasEntry("partnership", (Object) "bookar"));
     }
 }


### PR DESCRIPTION
### Changes

Previously the extra sign up fields were limited to **visible** fields of type: name, email, phone number and number. This PR extends the support to **hidden** fields that are not being displayed in the sign up form but are still sent with a fixed value to the backend as root profile or user_metadata attributes.

I'm not a fan of keeping reference to `CustomField` type constants from the `HiddenField` class. Ideally these interface definition should be outside or in the parent abstract class. But doing that now would be a breaking change.

#### Usage:
Same builder method as before now accepts subclasses of `SignUpField` class.

##### Previously

```java
List<CustomField> fields = new ArrayList<>();
fields.add(new CustomField(R.drawable.com_auth0_lock_ic_mobile, CustomField.FieldType.TYPE_NAME, "full_name", R.string.hint_name, CustomField.Storage.PROFILE_ROOT));
builder.withSignUpFields(fields);
```

##### Now
Note the method will still work accepting the `List<CustomField>` argument, but if you want to include `HiddenField` and any other future field you'd need to change the list type to `List<SignUpField>`.

```java
List<SignUpField> fields = new ArrayList<>();
fields.add(new CustomField(R.drawable.com_auth0_lock_ic_mobile, CustomField.FieldType.TYPE_NAME, "full_name", R.string.hint_name, CustomField.Storage.PROFILE_ROOT));
fields.add(new HiddenField("reference", "1234", CustomField.Storage.PROFILE_ROOT));
builder.withSignUpFields(fields);
```
### References

- Supersedes https://github.com/auth0/Lock.Android/pull/549

### Testing

- [x] This change adds unit test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors

- [x] The correct base branch is being used
