### PR TITLE
Bump SDK version and OSS plugin version

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.auth0.gradle.oss-library.android" version "0.8.0"
+    id "com.auth0.gradle.oss-library.android" version "0.10.0"
 }
 
 logger.lifecycle("Using version ${version} for ${name}")
@@ -48,7 +48,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.squareup.okhttp:okhttp:2.7.5'
     implementation 'com.squareup:otto:1.3.8'
-    api 'com.auth0.android:auth0:1.20.0'
+    api 'com.auth0.android:auth0:1.20.1'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation 'org.robolectric:robolectric:4.0.2'


### PR DESCRIPTION
### Changes

- The latest SDK patch removes the check for `issued_at` claim of ID tokens. 
- The new OSS plugin fixes the `javaCompile` usage so there shouldn't be any warning displayed now.