### PR TITLE
Fixed material library 1.1.0 tab layout height issue

### DIFF
--- a/lib/src/main/res/layout/com_auth0_lock_tab.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_tab.xml
@@ -12,9 +12,4 @@
         android:gravity="center"
         android:textAppearance="@style/Lock.Theme.TextAppearance.Tab" />
 
-    <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/com_auth0_lock_widget_tab_strip_height"
-        android:layout_alignParentBottom="true"
-        android:background="@color/com_auth0_lock_tab_underline" />
 </RelativeLayout>

--- a/lib/src/main/res/layout/com_auth0_lock_tab_layout.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_tab_layout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -13,4 +13,11 @@
         app:tabIndicatorHeight="@dimen/com_auth0_lock_widget_tab_strip_height"
         app:tabPaddingEnd="0dp"
         app:tabPaddingStart="0dp"/>
-</LinearLayout>
+
+    <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_gravity="bottom"
+            android:layout_height="@dimen/com_auth0_lock_widget_tab_strip_height"
+            android:background="@color/com_auth0_lock_tab_underline" />
+
+</FrameLayout>


### PR DESCRIPTION
This pull request refers to #567 . Turned out it is the tab layout that has been stretched vertically so it pushes down the TextViews.

![Layout inspector](https://user-images.githubusercontent.com/6381605/80525426-ded93580-8999-11ea-8f6c-7c019d395b8f.png)

### Changes

- Layout files of tab layout (`com_auth0_lock_tab.xml`) and tabs (`com_auth0_lock_tab.xml`). The whole idea is to get rid of the strip in the tab's relative layout that has `android:layout_alignParentBottom="true"` which stretches the tab vertically.

#### Screenshots

Before:

![2020-04-28 21 40 19](https://user-images.githubusercontent.com/6381605/80525544-16e07880-899a-11ea-94ee-b4c1fe0b9449.jpg)

After

![2020-04-28 21 40 24](https://user-images.githubusercontent.com/6381605/80525535-11832e00-899a-11ea-94f3-88d9d9bec108.jpg)

### References

[Relative Layout docs](https://developer.android.com/reference/android/widget/RelativeLayout.html):
> Note that you cannot have a circular dependency between the size of the RelativeLayout and the position of its children. For example, you cannot have a RelativeLayout whose height is set to `WRAP_CONTENT` and a child set to `ALIGN_PARENT_BOTTOM`.

### Testing

All the automated tests have been passed on a local machine.

The lib needs to be integrated into an application project that uses androidX and  `com.google.android.material:material:1.1.0` dependency to show the real impact of this pull request. It was done locally, no automated tests were added.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors

- [x] The correct base branch is being used
