### PR TITLE
Center Custom Fields additional form vertically

### DIFF
--- a/lib/src/main/res/layout/com_auth0_lock_custom_fields_form_view.xml
+++ b/lib/src/main/res/layout/com_auth0_lock_custom_fields_form_view.xml
@@ -33,5 +33,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/com_auth0_lock_widget_vertical_margin_field"
+        android:layout_gravity="center_vertical"
         android:orientation="vertical" />
 </ScrollView>


### PR DESCRIPTION
### Changes
Center the custom fields form vertically in the screen

#### Previously
![image](https://user-images.githubusercontent.com/3900123/82502694-1a18e100-9ace-11ea-80c7-9042cc171e39.png)

#### Now
![image](https://user-images.githubusercontent.com/3900123/82502614-ec339c80-9acd-11ea-9fc1-c778895f72e1.png)


### References
Related to https://github.com/auth0/Lock.Android/issues/574


### Testing

- [ ] This change adds unit test coverage

- [ ] This change adds integration/UI test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors

- [x] The correct base branch is being used
