### PR TITLE
Bugfix #581 | Fix social login buttons with white backgrounds

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/views/SocialButton.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/SocialButton.java
@@ -50,13 +50,13 @@ class SocialButton extends RelativeLayout {
     }
 
     private StateListDrawable getTouchFeedbackBackground(@ColorInt int pressedColor, @ViewUtils.Corners int corners) {
-        final ShapeDrawable normalBackground;
+        final Drawable normalBackground;
         final ShapeDrawable pressedBackground;
 
         boolean shouldDrawOutline = pressedColor == Color.WHITE;
         if (shouldDrawOutline) {
             int outlineColor = getResources().getColor(R.color.com_auth0_lock_social_light_background_focused);
-            normalBackground = ViewUtils.getRoundedOutlineBackground(getResources(), outlineColor);
+            normalBackground = ViewUtils.getOpaqueRoundedOutlineBackground(getResources(), pressedColor, outlineColor);
             pressedBackground = ViewUtils.getRoundedBackground(this, outlineColor, corners);
         } else {
             normalBackground = ViewUtils.getRoundedBackground(this, pressedColor, corners);

--- a/lib/src/main/java/com/auth0/android/lock/views/ViewUtils.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ViewUtils.java
@@ -28,6 +28,7 @@ import android.content.res.ColorStateList;
 import android.content.res.Resources;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.ShapeDrawable;
 import android.graphics.drawable.shapes.RoundRectShape;
 import android.os.Build;
@@ -113,10 +114,10 @@ abstract class ViewUtils {
     }
 
     /**
-     * Generates a rounded outline drawable with the given background color.
+     * Generates a rounded outline drawable with a transparent background.
      *
      * @param resources the context's current resources.
-     * @param color     the color to use as background.
+     * @param color     the color to use for the outline.
      * @return the rounded drawable.
      */
     static ShapeDrawable getRoundedOutlineBackground(Resources resources, @ColorInt int color) {
@@ -125,6 +126,28 @@ abstract class ViewUtils {
         RoundRectShape rr = new RoundRectShape(new float[]{r, r, r, r, r, r, r, r}, new RectF(t, t, t, t), new float[]{r, r, r, r, r, r, r, r});
         ShapeDrawable drawable = new ShapeDrawable(rr);
         drawable.getPaint().setColor(color);
+        return drawable;
+    }
+
+    /**
+     * Generates a rounded outline drawable with the given background color.
+     *
+     * @param resources       the context's current resources.
+     * @param backgroundColor the color to use for the background.
+     * @param outlineColor    the color to use for the outline
+     * @return the opaque rounded drawable.
+     */
+    static Drawable getOpaqueRoundedOutlineBackground(
+            Resources resources,
+            @ColorInt int backgroundColor,
+            @ColorInt int outlineColor
+    ) {
+        int cornerRadius = resources.getDimensionPixelSize(R.dimen.com_auth0_lock_widget_corner_radius);
+        int stroke = resources.getDimensionPixelSize(R.dimen.com_auth0_lock_input_field_stroke_width);
+        GradientDrawable drawable = new GradientDrawable();
+        drawable.setCornerRadius(cornerRadius);
+        drawable.setColor(backgroundColor);
+        drawable.setStroke(stroke, outlineColor);
         return drawable;
     }
 


### PR DESCRIPTION
### Changes

See #581 

### Testing

You can test this change in dark mode by adding this line in the app level `colors.xml` file:

```
    <color name="com_auth0_lock_form_background">#121212</color>
```

- ~~This change adds unit test coverage~~

- ~~This change adds integration/UI test coverage~~
I did not see unit or integration tests for the existing social button methods.

- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors

- [X] The correct base branch is being used

| Light Mode | Dark Mode |
|-|-|
|![google-light-mode](https://user-images.githubusercontent.com/11651971/86178878-0c4b7800-bade-11ea-85a6-0793b076367e.png)|![google-dark-mode](https://user-images.githubusercontent.com/11651971/86178893-13728600-bade-11ea-877d-16078e1c814c.png)|