### PR TITLE
Use latest SDK patch

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.squareup.okhttp:okhttp:2.7.5'
     implementation 'com.squareup:otto:1.3.8'
-    api 'com.auth0.android:auth0:1.24.0'
+    api 'com.auth0.android:auth0:1.24.1'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation 'org.robolectric:robolectric:4.0.2'


### PR DESCRIPTION
### Changes
The last release of Lock.Android included a bug on the `SecureCredentialsManager` class that made the `hasValidCredentials()` call return true and the `getCredentials()` call to fail. 

### References

This was fixed on https://github.com/auth0/Auth0.Android/pull/325, and released as `1.24.1`.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. This library has unit testing, tests should be added for new logic and functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage

- [ ] This change adds integration/UI test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors

- [ ] The correct base branch is being used
