### PR TITLE
Add compatibility with Android 11: Bump SDK version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.android.tools.build:gradle:3.4.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     }
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.squareup.okhttp:okhttp:2.7.5'
     implementation 'com.squareup:otto:1.3.8'
-    api 'com.auth0.android:auth0:1.25.0'
+    api 'com.auth0.android:auth0:1.26.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation 'org.robolectric:robolectric:4.0.2'


### PR DESCRIPTION
### Changes
The latest version of the SDK is now compatible with Android 11 (officially released yesterday).

**Note:** If you run into gradle sync issues when trying to build the app it's because you are using an old Android Gradle Plugin version that is not yet aware of the "queries" tag on the manifest file. In order to fix that, you have to use the latest patch version of the version you are currently using. Do check the table in the blog post linked below.

### References
- See https://github.com/auth0/Auth0.Android/pull/335
- Blogpost https://android-developers.googleblog.com/2020/07/preparing-your-build-for-package-visibility-in-android-11.html

### Testing

- [ ] This change adds unit test coverage

- [ ] This change adds integration/UI test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors

- [x] The correct base branch is being used
