### PR TITLE
Bump SDK to fix NPE with Kotlin nullable annotations

### DIFF
--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.java
@@ -306,7 +306,7 @@ public class DemoActivity extends AppCompatActivity {
         }
 
         @Override
-        public void onFailure(AuthenticationException exception) {
+        public void onFailure(@NonNull AuthenticationException exception) {
             showResult("Failed > " + exception.getDescription());
         }
 
@@ -323,7 +323,7 @@ public class DemoActivity extends AppCompatActivity {
         }
 
         @Override
-        public void onSuccess(Void payload) {
+        public void onSuccess(@Nullable Void payload) {
             showResult("Logged out!");
         }
     };

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.squareup.okhttp:okhttp:2.7.5'
     implementation 'com.squareup:otto:1.3.8'
-    api 'com.auth0.android:auth0:1.26.0'
+    api 'com.auth0.android:auth0:1.26.1'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation 'org.robolectric:robolectric:4.0.2'

--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -483,7 +483,8 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
     //Callbacks
     private final com.auth0.android.callback.AuthenticationCallback<List<Connection>> applicationCallback = new AuthenticationCallback<List<Connection>>() {
         @Override
-        public void onSuccess(@NonNull final List<Connection> connections) {
+        public void onSuccess(@Nullable final List<Connection> connections) {
+            //noinspection ConstantConditions
             configuration = new Configuration(connections, options);
             handler.post(new Runnable() {
                 @Override
@@ -541,7 +542,8 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
 
     private final AuthenticationCallback<Credentials> authCallback = new AuthenticationCallback<Credentials>() {
         @Override
-        public void onSuccess(@NonNull Credentials credentials) {
+        public void onSuccess(@Nullable Credentials credentials) {
+            //noinspection ConstantConditions
             deliverAuthenticationResult(credentials);
             lastDatabaseLogin = null;
             lastDatabaseSignUp = null;
@@ -582,10 +584,11 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
 
     private final AuthenticationCallback<DatabaseUser> createCallback = new AuthenticationCallback<DatabaseUser>() {
         @Override
-        public void onSuccess(@NonNull final DatabaseUser user) {
+        public void onSuccess(@Nullable final DatabaseUser user) {
             handler.post(new Runnable() {
                 @Override
                 public void run() {
+                    //noinspection ConstantConditions
                     deliverSignUpResult(user);
                 }
             });
@@ -611,7 +614,7 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
 
     private final AuthenticationCallback<Void> changePwdCallback = new AuthenticationCallback<Void>() {
         @Override
-        public void onSuccess(@NonNull Void payload) {
+        public void onSuccess(@Nullable Void payload) {
             handler.post(new Runnable() {
                 @Override
                 public void run() {

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -459,7 +459,8 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
     //Callbacks
     private final com.auth0.android.callback.AuthenticationCallback<List<Connection>> applicationCallback = new com.auth0.android.callback.AuthenticationCallback<List<Connection>>() {
         @Override
-        public void onSuccess(@NonNull final List<Connection> connections) {
+        public void onSuccess(@Nullable final List<Connection> connections) {
+            //noinspection ConstantConditions
             configuration = new Configuration(connections, options);
             identityHelper = new PasswordlessIdentityHelper(PasswordlessLockActivity.this, configuration.getPasswordlessMode());
             handler.post(new Runnable() {
@@ -487,7 +488,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
 
     private final com.auth0.android.callback.AuthenticationCallback<Void> passwordlessCodeCallback = new com.auth0.android.callback.AuthenticationCallback<Void>() {
         @Override
-        public void onSuccess(@NonNull Void payload) {
+        public void onSuccess(@Nullable Void payload) {
             handler.post(new Runnable() {
                 @Override
                 public void run() {
@@ -515,11 +516,12 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
 
     private final com.auth0.android.callback.AuthenticationCallback<Credentials> authCallback = new com.auth0.android.callback.AuthenticationCallback<Credentials>() {
         @Override
-        public void onSuccess(@NonNull Credentials credentials) {
+        public void onSuccess(@Nullable Credentials credentials) {
             if (configuration.usePasswordlessAutoSubmit()) {
                 Log.d(TAG, "Saving passwordless identity for a future log in request.");
                 identityHelper.saveIdentity(lastPasswordlessIdentity, lastPasswordlessCountry);
             }
+            //noinspection ConstantConditions
             deliverAuthenticationResult(credentials);
         }
 


### PR DESCRIPTION
### Changes

Fixes Kotlin compatibility issues with our `VoidCallback` interface by using `@Nullable` annotations on the authentication callback signature.

This NPE **only affected Kotlin** apps.

### References

See https://github.com/auth0/Auth0.Android/pull/344 for all the details.

### Testing

I've manually tested the following scenarios using Lock and PasswordlessLock on a pure Kotlin android application.

- Auth with username/password
- Auth with passwordless
- Auth with social connection
- WebAuth (inherited through SKD)

- [ ] This change adds unit test coverage

- [ ] This change adds integration/UI test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors

- [ ] The correct base branch is being used
