### PR TITLE
Add custom tabs options to the available Lock settings [SDK-1974]

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.squareup.okhttp:okhttp:2.7.5'
     implementation 'com.squareup:otto:1.3.8'
-    api 'com.auth0.android:auth0:1.28.0'
+    api 'com.auth0.android:auth0:1.29.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation 'org.robolectric:robolectric:4.0.2'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.squareup.okhttp:okhttp:2.7.5'
     implementation 'com.squareup:otto:1.3.8'
-    api 'com.auth0.android:auth0:1.26.1'
+    api 'com.auth0.android:auth0:1.28.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation 'org.robolectric:robolectric:4.0.2'

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -44,6 +44,7 @@ import com.auth0.android.lock.provider.AuthResolver;
 import com.auth0.android.lock.utils.LockException;
 import com.auth0.android.lock.utils.SignUpField;
 import com.auth0.android.provider.AuthHandler;
+import com.auth0.android.provider.CustomTabsOptions;
 import com.auth0.android.util.Telemetry;
 
 import java.util.ArrayList;
@@ -556,6 +557,18 @@ public class Lock {
         @NonNull
         public Builder withAudience(@NonNull String audience) {
             options.withAudience(audience);
+            return this;
+        }
+
+        /**
+         * Specify style and other additional configuration for when the Web Auth flow is used with Custom Tabs.
+         *
+         * @param customTabsOptions to use in the Web Auth flow.
+         * @return the current builder instance
+         */
+        @NonNull
+        public Builder withCustomTabsOptions(@NonNull CustomTabsOptions customTabsOptions) {
+            options.withCustomTabsOptions(customTabsOptions);
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -43,6 +43,7 @@ import com.auth0.android.lock.internal.configuration.Theme;
 import com.auth0.android.lock.provider.AuthResolver;
 import com.auth0.android.lock.utils.LockException;
 import com.auth0.android.provider.AuthHandler;
+import com.auth0.android.provider.CustomTabsOptions;
 import com.auth0.android.util.Telemetry;
 
 import java.util.Arrays;
@@ -422,6 +423,18 @@ public class PasswordlessLock {
         @NonNull
         public Builder withScheme(@NonNull String scheme) {
             options.withScheme(scheme);
+            return this;
+        }
+
+        /**
+         * Specify style and other additional configuration for when the Web Auth flow is used with Custom Tabs.
+         *
+         * @param customTabsOptions to use in the Web Auth flow.
+         * @return the current builder instance
+         */
+        @NonNull
+        public Builder withCustomTabsOptions(@NonNull CustomTabsOptions customTabsOptions) {
+            options.withCustomTabsOptions(customTabsOptions);
             return this;
         }
 

--- a/lib/src/main/java/com/auth0/android/lock/WebProvider.java
+++ b/lib/src/main/java/com/auth0/android/lock/WebProvider.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 
 import com.auth0.android.lock.internal.configuration.Options;
 import com.auth0.android.provider.AuthCallback;
+import com.auth0.android.provider.CustomTabsOptions;
 import com.auth0.android.provider.WebAuthProvider;
 
 import java.util.HashMap;
@@ -68,6 +69,10 @@ class WebProvider {
         final String scheme = options.getScheme();
         if (scheme != null) {
             builder.withScheme(scheme);
+        }
+        final CustomTabsOptions customTabsOptions = options.getCustomTabsOptions();
+        if (customTabsOptions != null) {
+            builder.withCustomTabsOptions(customTabsOptions);
         }
         //noinspection deprecation
         builder.start(activity, callback, requestCode);

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -40,6 +40,7 @@ import com.auth0.android.lock.Auth0Parcelable;
 import com.auth0.android.lock.InitialScreen;
 import com.auth0.android.lock.UsernameStyle;
 import com.auth0.android.lock.utils.SignUpField;
+import com.auth0.android.provider.CustomTabsOptions;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -88,6 +89,7 @@ public class Options implements Parcelable {
     private int initialScreen;
     private int visibleSignUpFieldsthreshold;
     private Theme theme;
+    private CustomTabsOptions customTabsOptions;
     private String privacyURL;
     private String termsURL;
     private String supportURL;
@@ -139,6 +141,7 @@ public class Options implements Parcelable {
         initialScreen = in.readInt();
         visibleSignUpFieldsthreshold = in.readInt();
         theme = in.readParcelable(Theme.class.getClassLoader());
+        customTabsOptions = in.readParcelable(CustomTabsOptions.class.getClassLoader());
         privacyURL = in.readString();
         termsURL = in.readString();
         supportURL = in.readString();
@@ -220,6 +223,7 @@ public class Options implements Parcelable {
         dest.writeInt(initialScreen);
         dest.writeInt(visibleSignUpFieldsthreshold);
         dest.writeParcelable(theme, flags);
+        dest.writeParcelable(customTabsOptions, flags);
         dest.writeString(privacyURL);
         dest.writeString(termsURL);
         dest.writeString(supportURL);
@@ -579,5 +583,14 @@ public class Options implements Parcelable {
 
     public int visibleSignUpFieldsThreshold() {
         return visibleSignUpFieldsthreshold;
+    }
+
+    public void withCustomTabsOptions(@NonNull CustomTabsOptions customTabsOptions) {
+        this.customTabsOptions = customTabsOptions;
+    }
+
+    @Nullable
+    public CustomTabsOptions getCustomTabsOptions() {
+        return customTabsOptions;
     }
 }

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -11,6 +11,7 @@ import com.auth0.android.lock.UsernameStyle;
 import com.auth0.android.lock.utils.CustomField;
 import com.auth0.android.lock.utils.CustomField.FieldType;
 import com.auth0.android.lock.utils.SignUpField;
+import com.auth0.android.provider.CustomTabsOptions;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -605,6 +606,20 @@ public class OptionsTest {
         assertThat(parceledOptions.getScheme(), is("auth0"));
     }
 
+    @Test
+    public void shouldSetCustomTabsOptions() {
+        CustomTabsOptions ctOptions = CustomTabsOptions.newBuilder().build();
+        options.withCustomTabsOptions(ctOptions);
+
+        Parcel parcel = Parcel.obtain();
+        options.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
+        assertThat(options.getCustomTabsOptions(), is(equalTo(ctOptions)));
+        assertThat(parceledOptions.getCustomTabsOptions(), is(notNullValue()));
+    }
+
     @SuppressWarnings("ResourceType")
     @Test
     public void shouldAddAuthStyles() {
@@ -716,6 +731,7 @@ public class OptionsTest {
         assertThat(options.getScope(), is(nullValue()));
         assertThat(options.getAudience(), is(nullValue()));
         assertThat(options.getScheme(), is(nullValue()));
+        assertThat(options.getCustomTabsOptions(), is(nullValue()));
         assertThat(options.usernameStyle(), is(equalTo(UsernameStyle.DEFAULT)));
         assertThat(options.visibleSignUpFieldsThreshold(), is(equalTo(2)));
         assertThat(options.getTheme(), is(notNullValue()));


### PR DESCRIPTION
### Changes

Version 1.27.0 of the SDK added the ability to filter the browsers allowed to be used for web authentication. That configuration is set via the `CustomTabsOptions` object, which never got introduced to Lock before. This PR adds the ability to set one, and bumps the SDK to the latest major.

### References

https://github.com/auth0/Auth0.Android/pull/353

### Testing

- [x] This change adds unit test coverage

- [x] This change adds integration/UI test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors

- [x] The correct base branch is being used
