### PR TITLE
Bump the minimum required android version [SDK-2427]

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Since June 2017 new Applications no longer have the **Password Grant Type*** ena
 
 ## Requirements
 
-Android API Level 15+ is required in order to use Lock's UI.
+Android API Level 21+ is required in order to use Lock's UI.
 
 ## Install
 
@@ -89,7 +89,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.auth0.samples"
-        minSdkVersion 15
+        minSdkVersion 21
         targetSdkVersion 28
         //...
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "com.auth0.android.lock.app"
-        minSdkVersion 15
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -18,7 +18,7 @@ allprojects {
     group = 'com.auth0.android'
     
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -26,7 +26,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName project.version

--- a/lib/src/test/java/com/auth0/android/lock/utils/ApplicationAPI.java
+++ b/lib/src/test/java/com/auth0/android/lock/utils/ApplicationAPI.java
@@ -36,6 +36,9 @@ public class ApplicationAPI {
     private MockWebServer server;
 
     public ApplicationAPI() throws IOException {
+        // FIXME: Remove this if migrating to Robolectric 4.4
+        // ref: https://github.com/robolectric/robolectric/issues/5115#issuecomment-593107140
+        System.setProperty("javax.net.ssl.trustStoreType", "JKS");
         this.server = new MockWebServer();
         this.server.start();
     }


### PR DESCRIPTION
### Changes
The minimum version will now match what the SDK requires -> API 21

### Testing

I had to fix a few tests that were broken passing a configuration variable. This is a temporary fix until we migrate to Robolectric 4.4.