### PR TITLE
Remove WebView component support [SDK-2430]

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -28,15 +28,14 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.os.Build;
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StyleRes;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
-import android.util.Log;
 
 import com.auth0.android.Auth0;
-import com.auth0.android.authentication.ParameterBuilder;
 import com.auth0.android.lock.LockCallback.LockEvent;
 import com.auth0.android.lock.internal.configuration.Options;
 import com.auth0.android.lock.internal.configuration.Theme;
@@ -239,21 +238,6 @@ public class Lock {
             final Lock lock = new Lock(options, callback);
             lock.initialize(context);
             return lock;
-        }
-
-        /**
-         * Whether to use the Browser for Authentication with Identity Providers or the inner WebView.
-         *
-         * @param useBrowser or WebView. By default, the Authentication flow will use the Browser.
-         * @return the current Builder instance
-         * @deprecated This method has been deprecated since Google is no longer supporting WebViews to perform login.
-         */
-        @Deprecated
-        @NonNull
-        public Builder useBrowser(boolean useBrowser) {
-            //noinspection deprecation
-            options.setUseBrowser(useBrowser);
-            return this;
         }
 
         /**

--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -195,15 +195,6 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
             Log.e(TAG, "You're not allowed to start Lock with startActivityForResult.");
             return false;
         }
-        boolean launchedAsSingleTask = (getIntent().getFlags() & Intent.FLAG_ACTIVITY_NEW_TASK) != 0;
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT) {
-            //TODO: Document this case for users on <= KITKAT, as they will not receive this warning.
-            //noinspection deprecation
-            if (options.useBrowser() && !launchedAsSingleTask) {
-                Log.e(TAG, "Please, check that you have specified launchMode 'singleTask' in the AndroidManifest.");
-                return false;
-            }
-        }
         return true;
     }
 

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -267,21 +267,6 @@ public class PasswordlessLock {
         }
 
         /**
-         * Whether to use the Browser for Authentication with Identity Providers or the inner WebView.
-         *
-         * @param useBrowser or WebView. By default, the Authentication flow will use the Browser.
-         * @return the current Builder instance
-         * @deprecated This method has been deprecated since Google is no longer supporting WebViews to perform login.
-         */
-        @Deprecated
-        @NonNull
-        public Builder useBrowser(boolean useBrowser) {
-            //noinspection deprecation
-            options.setUseBrowser(useBrowser);
-            return this;
-        }
-
-        /**
          * Whether to use implicit grant or code grant when performing calls to /authorize. This only affects passive authentication.
          * Default is {@code false}
          *

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -194,16 +194,6 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
             Log.e(TAG, "You're not allowed to start Lock with startActivityForResult.");
             return false;
         }
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT) {
-            //TODO: Document this case for users on <= KITKAT, as they will not receive this warning.
-            boolean launchedAsSingleTask = (getIntent().getFlags() & Intent.FLAG_ACTIVITY_NEW_TASK) != 0;
-            //noinspection deprecation
-            if (options.useBrowser() && !launchedAsSingleTask) {
-                Log.e(TAG, "Please, check that you have specified launchMode 'singleTask' in the AndroidManifest.");
-                return false;
-            }
-        }
-
         return true;
     }
 

--- a/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
+++ b/lib/src/main/java/com/auth0/android/lock/internal/configuration/Options.java
@@ -65,7 +65,6 @@ public class Options implements Parcelable {
     private static final String SCOPE_OFFLINE_ACCESS = "offline_access";
 
     private Auth0 account;
-    private boolean useBrowser;
     private boolean usePKCE;
     private boolean closable;
     private int usernameStyle;
@@ -102,7 +101,6 @@ public class Options implements Parcelable {
         usernameStyle = UsernameStyle.DEFAULT;
         initialScreen = InitialScreen.LOG_IN;
         visibleSignUpFieldsthreshold = DEFAULT_VISIBLE_SIGN_UP_FIELDS_THRESHOLD;
-        useBrowser = true;
         allowLogIn = true;
         allowSignUp = true;
         allowForgotPassword = true;
@@ -123,7 +121,6 @@ public class Options implements Parcelable {
         Auth0Parcelable auth0Parcelable = (Auth0Parcelable) in.readValue(Auth0Parcelable.class.getClassLoader());
         //noinspection ConstantConditions
         account = auth0Parcelable.getAuth0();
-        useBrowser = in.readByte() != WITHOUT_DATA;
         usePKCE = in.readByte() != WITHOUT_DATA;
         closable = in.readByte() != WITHOUT_DATA;
         allowLogIn = in.readByte() != WITHOUT_DATA;
@@ -205,7 +202,6 @@ public class Options implements Parcelable {
     @Override
     public void writeToParcel(@NonNull Parcel dest, int flags) {
         dest.writeValue(new Auth0Parcelable(account));
-        dest.writeByte((byte) (useBrowser ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (usePKCE ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (closable ? HAS_DATA : WITHOUT_DATA));
         dest.writeByte((byte) (allowLogIn ? HAS_DATA : WITHOUT_DATA));
@@ -295,17 +291,6 @@ public class Options implements Parcelable {
 
     public void setAccount(@NonNull Auth0 account) {
         this.account = account;
-    }
-
-    @SuppressWarnings("DeprecatedIsStillUsed")
-    @Deprecated
-    public boolean useBrowser() {
-        return useBrowser;
-    }
-
-    @Deprecated
-    public void setUseBrowser(boolean useBrowser) {
-        this.useBrowser = useBrowser;
     }
 
     public void withTheme(@NonNull Theme theme) {

--- a/lib/src/test/java/com/auth0/android/lock/LockActivityTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/LockActivityTest.java
@@ -639,7 +639,6 @@ public class LockActivityTest {
         when(connection.getName()).thenReturn("my-connection");
         when(connection.isActiveFlowEnabled()).thenReturn(false);
         OAuthLoginEvent event = new OAuthLoginEvent(connection, "user@domain.com", null);
-        when(options.useBrowser()).thenReturn(true);
         activity.onOAuthAuthenticationRequest(event);
 
         verify(lockView, never()).showProgress(true);
@@ -671,7 +670,6 @@ public class LockActivityTest {
         OAuthConnection connection = mock(OAuthConnection.class);
         when(connection.getName()).thenReturn("my-connection");
         OAuthLoginEvent event = new OAuthLoginEvent(connection);
-        when(options.useBrowser()).thenReturn(true);
         activity.onOAuthAuthenticationRequest(event);
 
         verify(lockView, never()).showProgress(true);

--- a/lib/src/test/java/com/auth0/android/lock/PasswordlessLockActivityTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/PasswordlessLockActivityTest.java
@@ -283,7 +283,6 @@ public class PasswordlessLockActivityTest {
         OAuthConnection connection = mock(OAuthConnection.class);
         when(connection.getName()).thenReturn("my-connection");
         OAuthLoginEvent event = new OAuthLoginEvent(connection);
-        when(options.useBrowser()).thenReturn(true);
         activity.onOAuthAuthenticationRequest(event);
 
         verify(lockView, never()).showProgress(eq(true));

--- a/lib/src/test/java/com/auth0/android/lock/WebProviderTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/WebProviderTest.java
@@ -44,7 +44,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.isOneOf;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -104,7 +103,6 @@ public class WebProviderTest {
         Options options = new Options();
         options.setAccount(account);
 
-        options.setUseBrowser(true);
         options.withAudience("https://me.auth0.com/myapi");
 
         Callback<Credentials, AuthenticationException> callback = mock(Callback.class);
@@ -139,7 +137,6 @@ public class WebProviderTest {
         Options options = new Options();
         options.setAccount(account);
 
-        options.setUseBrowser(true);
         options.withAudience("https://me.auth0.com/myapi");
 
         Callback<Credentials, AuthenticationException> callback = mock(Callback.class);
@@ -174,7 +171,6 @@ public class WebProviderTest {
         options.setAuthenticationParameters(parameters);
         options.withScope("email profile photos");
         options.withConnectionScope("my-connection", "the connection scope");
-        options.setUseBrowser(true);
         options.withScheme("auth0");
         CustomTabsOptions customTabsOptions = CustomTabsOptions.newBuilder().build();
         options.withCustomTabsOptions(customTabsOptions);

--- a/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/internal/configuration/OptionsTest.java
@@ -162,19 +162,6 @@ public class OptionsTest {
     }
 
     @Test
-    public void shouldUseWebView() {
-        options.setUseBrowser(false);
-
-        Parcel parcel = Parcel.obtain();
-        options.writeToParcel(parcel, 0);
-        parcel.setDataPosition(0);
-
-        Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
-        assertThat(options.useBrowser(), is(false));
-        assertThat(options.useBrowser(), is(equalTo(parceledOptions.useBrowser())));
-    }
-
-    @Test
     public void shouldUseLabeledSubmitButton() {
         options.setUseLabeledSubmitButton(true);
 
@@ -715,7 +702,6 @@ public class OptionsTest {
 
         Options parceledOptions = Options.CREATOR.createFromParcel(parcel);
         assertThat(options, is(not(parceledOptions))); //assure correct Parcelable object testing
-        assertThat(options.useBrowser(), is(true));
         assertThat(options.usePKCE(), is(true));
         assertThat(options.allowLogIn(), is(true));
         assertThat(options.allowSignUp(), is(true));
@@ -742,7 +728,6 @@ public class OptionsTest {
 
     @Test
     public void shouldSetAllTrueFields() {
-        options.setUseBrowser(true);
         options.setUsePKCE(true);
         options.setUsernameStyle(UsernameStyle.EMAIL);
         options.setInitialScreen(InitialScreen.LOG_IN);
@@ -767,7 +752,6 @@ public class OptionsTest {
         assertThat(options.mustAcceptTerms(), is(equalTo(parceledOptions.mustAcceptTerms())));
         assertThat(options.showTerms(), is(equalTo(parceledOptions.showTerms())));
         assertThat(options.isClosable(), is(equalTo(parceledOptions.isClosable())));
-        assertThat(options.useBrowser(), is(equalTo(parceledOptions.useBrowser())));
         assertThat(options.usePKCE(), is(equalTo(parceledOptions.usePKCE())));
         assertThat(options.usernameStyle(), is(equalTo(parceledOptions.usernameStyle())));
         assertThat(options.initialScreen(), is(equalTo(parceledOptions.initialScreen())));
@@ -784,7 +768,6 @@ public class OptionsTest {
     @Test
     public void shouldSetAllFalseFields() {
         options.setClosable(false);
-        options.setUseBrowser(false);
         options.setUsePKCE(false);
         options.setUsernameStyle(UsernameStyle.USERNAME);
         options.setInitialScreen(InitialScreen.SIGN_UP);
@@ -808,7 +791,6 @@ public class OptionsTest {
         assertThat(options.mustAcceptTerms(), is(equalTo(parceledOptions.mustAcceptTerms())));
         assertThat(options.showTerms(), is(equalTo(parceledOptions.showTerms())));
         assertThat(options.isClosable(), is(equalTo(parceledOptions.isClosable())));
-        assertThat(options.useBrowser(), is(equalTo(parceledOptions.useBrowser())));
         assertThat(options.usePKCE(), is(equalTo(parceledOptions.usePKCE())));
         assertThat(options.usernameStyle(), is(equalTo(parceledOptions.usernameStyle())));
         assertThat(options.initialScreen(), is(equalTo(parceledOptions.initialScreen())));


### PR DESCRIPTION
### Changes
The core SDK no longer supports using WebView components to execute the webauth flow. This PR removes the options related to preferring it.

### References
See `SDK-2430`

### Testing
Passed locally
![image](https://user-images.githubusercontent.com/3900123/115458122-9e676d00-a225-11eb-9608-05e45dc5ac2c.png)


