### PR TITLE
Remove support for changing the Social Button style  [SDK-2430]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ allprojects {
     group = 'com.auth0.android'
     
     repositories {
-        mavenLocal()
         mavenCentral()
         google()
     }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.squareup:otto:1.3.8'
-    api 'com.auth0.android:auth0:2.1.0-SNAPSHOT'
+    api 'com.auth0.android:auth0:2.2.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation 'org.robolectric:robolectric:4.4'

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -317,23 +317,6 @@ public class Lock {
         }
 
         /**
-         * Auth Button size to use when Social connections are available. If Social
-         * is the only connection type it will default to the BIG size. If Database or
-         * Enterprise are present and there's only one Social connection, the button will use the
-         * BIG size. In the rest of the cases, it will use SMALL size.
-         *
-         * @param style a valid AuthButtonSize.
-         * @return the current builder instance
-         * @deprecated Small button style is no longer offered since it is not compliant
-         * to some providers branding guidelines. e.g. google
-         */
-        @Deprecated
-        @NonNull
-        public Builder withAuthButtonSize(@AuthButtonSize int style) {
-            return this;
-        }
-
-        /**
          * Authentication Style to use with the given strategy or connection name. It will override any lock defaults.
          *
          * @param connectionName to use this style with

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -306,23 +306,6 @@ public class PasswordlessLock {
         }
 
         /**
-         * Auth Button size to use when Social connections are available. If Social
-         * is the only connection type it will default to the BIG size. If Database or
-         * Enterprise are present and there's only one Social connection, the button will use the
-         * BIG size. In the rest of the cases, it will use SMALL size.
-         *
-         * @param style a valid AuthButtonSize.
-         * @return the current builder instance
-         * @deprecated Small button style is no longer offered since it is not compliant
-         * to some providers branding guidelines. e.g. google
-         */
-        @Deprecated
-        @NonNull
-        public Builder withAuthButtonSize(@AuthButtonSize int style) {
-            return this;
-        }
-
-        /**
          * Authentication Style to use with the given strategy or connection name. It will override any lock defaults.
          *
          * @param connectionName to use this style with


### PR DESCRIPTION
### Changes
The `AuthButton` is the component in charge of drawing the social authentication buttons. Previously, we supported changing the style to a small-squared or a long button. Since small buttons are not compliant with some providers, the ability to change that was removed some months ago.

This PR removes the methods associated to that option.

### References

See SDK-2430

### Testing

Tested locally
![image](https://user-images.githubusercontent.com/3900123/115457671-1f723480-a225-11eb-9ea5-3deff3ee795e.png)
