### PR TITLE
Raise Unauthorized and Access Denied errors through callback [SDK-2480]

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -68,3 +68,7 @@ Continue reading for the detail of classes and methods that were impacted.
 ### Changes to the underlying SDK
 
 The core SDK has been updated to the version 2+. Since this is exposed as an API scoped dependency, if you were using any of the classes or methods that changed in the new major release (e.g. the `WebAuthProvider` class), you might need to update your code. Follow the [Auth0.Android Migration Guide](https://github.com/auth0/Auth0.Android/blob/main/V2_MIGRATION_GUIDE.md) to assess the impact. 
+
+## Changes in behavior
+
+The `LockCallback` will get its `onError` method invoked when an [Auth0 Rule](https://auth0.com/docs/rules) returns an `Error` or `UnauthorizedError`. This was previously handled internally by Lock, causing it to display an orange toast with a generic failure message. From this release on, if you are using Auth0 Rules and throwing custom errors, you should obtain the _cause_ of the exception and read the code or description values to understand what went wrong.  

--- a/lib/src/main/java/com/auth0/android/lock/AuthenticationCallback.java
+++ b/lib/src/main/java/com/auth0/android/lock/AuthenticationCallback.java
@@ -29,6 +29,8 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import com.auth0.android.authentication.AuthenticationException;
+import com.auth0.android.lock.utils.LockException;
 import com.auth0.android.result.Credentials;
 
 import java.util.Date;
@@ -75,6 +77,11 @@ public abstract class AuthenticationCallback implements LockCallback {
      * @param data the intent received at the end of the login process.
      */
     private void parseAuthentication(Intent data) {
+        if (data.hasExtra(Constants.EXCEPTION_EXTRA)) {
+            AuthenticationException error = (AuthenticationException) data.getSerializableExtra(Constants.EXCEPTION_EXTRA);
+            onError(new LockException(error));
+            return;
+        }
         String idToken = data.getStringExtra(Constants.ID_TOKEN_EXTRA);
         String accessToken = data.getStringExtra(Constants.ACCESS_TOKEN_EXTRA);
         String tokenType = data.getStringExtra(Constants.TOKEN_TYPE_EXTRA);

--- a/lib/src/main/java/com/auth0/android/lock/Constants.java
+++ b/lib/src/main/java/com/auth0/android/lock/Constants.java
@@ -36,6 +36,7 @@ abstract class Constants {
     static final String CANCELED_ACTION = "com.auth0.android.lock.action.Canceled";
     static final String INVALID_CONFIGURATION_ACTION = "com.auth0.android.lock.action.InvalidConfiguration";
 
+    static final String EXCEPTION_EXTRA = "com.auth0.android.lock.extra.Exception";
     static final String ERROR_EXTRA = "com.auth0.android.lock.extra.Error";
     static final String ID_TOKEN_EXTRA = "com.auth0.android.lock.extra.IdToken";
     static final String ACCESS_TOKEN_EXTRA = "com.auth0.android.lock.extra.AccessToken";

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -36,6 +36,7 @@ import androidx.annotation.StyleRes;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.auth0.android.Auth0;
+import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.lock.LockCallback.LockEvent;
 import com.auth0.android.lock.internal.configuration.Options;
 import com.auth0.android.lock.internal.configuration.Theme;
@@ -150,8 +151,8 @@ public class Lock {
         switch (action) {
             case Constants.AUTHENTICATION_ACTION:
                 Log.v(TAG, "AUTHENTICATION action received in our BroadcastReceiver");
-                if (data.hasExtra(Constants.ERROR_EXTRA)) {
-                    callback.onError(new LockException(data.getStringExtra(Constants.ERROR_EXTRA)));
+                if (data.hasExtra(Constants.EXCEPTION_EXTRA)) {
+                    callback.onError(new LockException((AuthenticationException) data.getSerializableExtra(Constants.EXCEPTION_EXTRA)));
                 } else {
                     callback.onEvent(LockEvent.AUTHENTICATION, data);
                 }

--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -493,7 +493,7 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
         @Override
         public void onFailure(@NonNull final AuthenticationException exception) {
             Log.e(TAG, "Failed to authenticate the user: " + exception.getCode(), exception);
-            if (exception.isRuleError()) {
+            if (exception.isRuleError() || exception.isAccessDenied()) {
                 deliverAuthenticationError(exception);
                 return;
             }
@@ -519,7 +519,7 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
         @Override
         public void onFailure(@NonNull final AuthenticationException error) {
             Log.e(TAG, "Failed to authenticate the user: " + error.getCode(), error);
-            if (error.isRuleError()) {
+            if (error.isRuleError() || error.isAccessDenied()) {
                 deliverAuthenticationError(error);
                 return;
             }

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -36,6 +36,7 @@ import androidx.annotation.StyleRes;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.auth0.android.Auth0;
+import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.lock.LockCallback.LockEvent;
 import com.auth0.android.lock.internal.configuration.Options;
 import com.auth0.android.lock.internal.configuration.Theme;
@@ -149,8 +150,8 @@ public class PasswordlessLock {
         switch (action) {
             case Constants.AUTHENTICATION_ACTION:
                 Log.v(TAG, "AUTHENTICATION action received in our BroadcastReceiver");
-                if (data.getExtras().containsKey(Constants.ERROR_EXTRA)) {
-                    callback.onError(new LockException(data.getStringExtra(Constants.ERROR_EXTRA)));
+                if (data.hasExtra(Constants.EXCEPTION_EXTRA)) {
+                    callback.onError(new LockException((AuthenticationException) data.getSerializableExtra(Constants.EXCEPTION_EXTRA)));
                 } else {
                     callback.onEvent(LockEvent.AUTHENTICATION, data);
                 }

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLockActivity.java
@@ -502,7 +502,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
         @Override
         public void onFailure(@NonNull final AuthenticationException error) {
             Log.e(TAG, "Failed to authenticate the user: " + error.getMessage(), error);
-            if (error.isRuleError()) {
+            if (error.isRuleError() || error.isAccessDenied()) {
                 deliverAuthenticationError(error);
                 return;
             }
@@ -520,7 +520,7 @@ public class PasswordlessLockActivity extends AppCompatActivity implements Activ
         @Override
         public void onFailure(@NonNull final AuthenticationException exception) {
             Log.e(TAG, "Failed to authenticate the user: " + exception.getCode(), exception);
-            if (exception.isRuleError()) {
+            if (exception.isRuleError() || exception.isAccessDenied()) {
                 deliverAuthenticationError(exception);
                 return;
             }

--- a/lib/src/main/java/com/auth0/android/lock/utils/LockException.java
+++ b/lib/src/main/java/com/auth0/android/lock/utils/LockException.java
@@ -26,10 +26,17 @@ package com.auth0.android.lock.utils;
 
 import androidx.annotation.NonNull;
 
+import com.auth0.android.authentication.AuthenticationException;
+
 
 public class LockException extends Exception {
 
     public LockException(@NonNull String message) {
         super(message);
     }
+
+    public LockException(@NonNull AuthenticationException exception) {
+        super(exception);
+    }
+
 }

--- a/lib/src/test/java/com/auth0/android/lock/AuthenticationCallbackTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/AuthenticationCallbackTest.java
@@ -26,6 +26,7 @@ package com.auth0.android.lock;
 
 import android.content.Intent;
 
+import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.lock.LockCallback.LockEvent;
 import com.auth0.android.lock.utils.MockLockCallback;
 import com.auth0.android.result.Credentials;
@@ -39,6 +40,7 @@ import org.robolectric.annotation.Config;
 import java.util.Date;
 
 import static com.auth0.android.lock.utils.AuthenticationCallbackMatcher.hasAuthentication;
+import static com.auth0.android.lock.utils.AuthenticationCallbackMatcher.hasError;
 import static com.auth0.android.lock.utils.AuthenticationCallbackMatcher.hasNoError;
 import static com.auth0.android.lock.utils.AuthenticationCallbackMatcher.isCanceled;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -78,6 +80,16 @@ public class AuthenticationCallbackTest {
         assertThat(callback.getCredentials().getExpiresAt(), equalTo(credentials.getExpiresAt()));
         assertThat(callback.getCredentials().getScope(), equalTo(credentials.getScope()));
         assertThat(callback, hasNoError());
+    }
+
+    @Test
+    public void shouldReturnAuthenticationError() {
+        Intent data = new Intent();
+        AuthenticationException error = new AuthenticationException("err_code", "err description");
+        data.putExtra(Constants.EXCEPTION_EXTRA, error);
+        callback.onEvent(LockEvent.AUTHENTICATION, data);
+
+        assertThat(callback, hasError());
     }
 
     @Test


### PR DESCRIPTION
### Changes

These two error codes `unauthorized` and `access_denied` can be raised through [Auth0 Rules](https://auth0.com/docs/rules). 

To improve the use case of handling custom errors in the authentication pipeline, these will now be raised directly through the provided callback instead of displaying an orange toast / snackbar with a generic error message. That means developers will need to handle this use case from now on. 

**This represents a breaking change in behavior. The public API remains the same after this PR.**

Affected flows: Any authentication flow. (e.g. Passwordless, Database, Enterprise, WebAuth)

### References
See `SDK-2480`

### Testing

There are currently no tests for this part of the widget. This change was tested manually.
