### PR TITLE
Fix broadcast receiver usage

### DIFF
--- a/app/src/main/java/com/auth0/android/lock/app/DemoActivity.kt
+++ b/app/src/main/java/com/auth0/android/lock/app/DemoActivity.kt
@@ -162,6 +162,10 @@ class DemoActivity : AppCompatActivity() {
             }
         }
 
+        // For demo purposes because options change dynamically, we release the resources of Lock here.
+        // In a real app, you will have a single instance and release its resources in Activity#OnDestroy.
+        lock?.onDestroy(this)
+        // Create a new instance with the updated configuration
         lock = builder.build(this)
         startActivity(lock!!.newIntent(this))
     }
@@ -179,6 +183,10 @@ class DemoActivity : AppCompatActivity() {
             builder.useCode()
         }
 
+        // For demo purposes because options change dynamically, we release the resources of Lock here.
+        // In a real app, you will have a single instance and release its resources in Activity#OnDestroy.
+        passwordlessLock?.onDestroy(this)
+        // Create a new instance with the updated configuration
         passwordlessLock = builder.build(this)
         startActivity(passwordlessLock!!.newIntent(this))
     }

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -137,12 +137,14 @@ public class Lock {
     }
 
     private void initialize(@NonNull Context context) {
+        LocalBroadcastManager lbm = LocalBroadcastManager.getInstance(context);
+        lbm.unregisterReceiver(this.receiver);
         IntentFilter filter = new IntentFilter();
         filter.addAction(Constants.AUTHENTICATION_ACTION);
         filter.addAction(Constants.SIGN_UP_ACTION);
         filter.addAction(Constants.CANCELED_ACTION);
         filter.addAction(Constants.INVALID_CONFIGURATION_ACTION);
-        LocalBroadcastManager.getInstance(context).registerReceiver(this.receiver, filter);
+        lbm.registerReceiver(this.receiver, filter);
     }
 
     private void processEvent(@NonNull Context context, @NonNull Intent data) {

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -68,7 +68,7 @@ public class Lock {
 
         @Override
         public void onReceive(Context context, Intent data) {
-            processEvent(context, data);
+            processEvent(data);
         }
     };
 
@@ -147,8 +147,7 @@ public class Lock {
         lbm.registerReceiver(this.receiver, filter);
     }
 
-    private void processEvent(@NonNull Context context, @NonNull Intent data) {
-        LocalBroadcastManager.getInstance(context).unregisterReceiver(this.receiver);
+    private void processEvent(@NonNull Intent data) {
         String action = data.getAction();
         switch (action) {
             case Constants.AUTHENTICATION_ACTION:

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -137,11 +137,13 @@ public class PasswordlessLock {
     }
 
     private void initialize(Context context) {
+        LocalBroadcastManager lbm = LocalBroadcastManager.getInstance(context);
+        lbm.unregisterReceiver(this.receiver);
         IntentFilter filter = new IntentFilter();
         filter.addAction(Constants.AUTHENTICATION_ACTION);
         filter.addAction(Constants.CANCELED_ACTION);
         filter.addAction(Constants.INVALID_CONFIGURATION_ACTION);
-        LocalBroadcastManager.getInstance(context).registerReceiver(this.receiver, filter);
+        lbm.registerReceiver(this.receiver, filter);
     }
 
     private void processEvent(Context context, Intent data) {

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -64,7 +64,7 @@ public class PasswordlessLock {
 
         @Override
         public void onReceive(@NonNull Context context, @NonNull Intent data) {
-            processEvent(context, data);
+            processEvent(data);
         }
     };
 
@@ -146,8 +146,7 @@ public class PasswordlessLock {
         lbm.registerReceiver(this.receiver, filter);
     }
 
-    private void processEvent(Context context, Intent data) {
-        LocalBroadcastManager.getInstance(context).unregisterReceiver(this.receiver);
+    private void processEvent(Intent data) {
         String action = data.getAction();
         switch (action) {
             case Constants.AUTHENTICATION_ACTION:


### PR DESCRIPTION
### Changes
The broadcast receiver that handles events was being registered right after the lock widget `Builder` was built. This is because the lock instance is meant to be created once and reused. And while this instance is meant to be released in the (dev's) `activity#onDestroy()` method, this wasn't consistently documented across the readme.

Calling multiple times `builder#build(context)` like we used to do in our demo app before this PR, would cause multiple different broadcast receiver instances to be registered. Then the callback would be invoked multiple times after each event. 

The right way to clear up resources and broadcast receiver registrations is via the `lock#onDestroy(context)`.

### References

Fixes https://github.com/auth0/Lock.Android/issues/607

### Testing
This part of the code is not unit-tested.