### PR TITLE
Enable AppLinks in the declared intent filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,6 @@ If you haven't done yet, go to [Auth0](https://auth0.com) and create an Account,
 https://{YOUR_AUTH0_DOMAIN}/android/{YOUR_APP_PACKAGE_NAME}/callback
 ```
 
-If you plan to use Passwordless authentication with SMS or Email connections, the Callback URL you will register looks like this:
-
-```
-https://{YOUR_AUTH0_DOMAIN}/android/{YOUR_APP_PACKAGE_NAME}/sms
-// or
-https://{YOUR_AUTH0_DOMAIN}/android/{YOUR_APP_PACKAGE_NAME}/email
-``` 
-
 The *package name* value required in the Callback URL can be found in your app's `build.gradle` file in the `applicationId` property. Both the *domain* and *client id* values can be found at the top of your Auth0 Application's settings. You're going to use them to setup the SDK. It's good practice to add them to the `strings.xml` file as string resources that you can reference later from the code. This guide will follow that practice.
 
 ```xml

--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -9,8 +9,8 @@
         <activity
             android:name="com.auth0.android.provider.RedirectActivity"
             tools:node="replace">
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
+            <intent-filter android:autoVerify="true">
+            <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -37,8 +37,8 @@
             android:launchMode="singleTask"
             android:screenOrientation="portrait"
             android:theme="@style/Lock.Theme">
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
+            <intent-filter android:autoVerify="true">
+            <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -46,12 +46,12 @@
                 <data
                     android:host="${auth0Domain}"
                     android:pathPrefix="/android/${applicationId}/email"
-                    android:scheme="${auth0Scheme}" />
+                    android:scheme="https" />
 
                 <data
                     android:host="${auth0Domain}"
                     android:pathPrefix="/android/${applicationId}/sms"
-                    android:scheme="${auth0Scheme}" />
+                    android:scheme="https" />
             </intent-filter>
         </activity>
         <!--Auth0 PasswordlessLock End-->

--- a/lib/src/main/java/com/auth0/android/lock/Lock.java
+++ b/lib/src/main/java/com/auth0/android/lock/Lock.java
@@ -518,7 +518,9 @@ public class Lock {
         }
 
         /**
-         * Specify a custom Scheme for the redirect url used to send the Web Auth results. Default redirect url scheme is 'https'.
+         * Specify a custom Scheme for the redirect URL used when executing a Web Authentication flow
+         * via the Universal Login page.
+         * Default redirect url scheme is 'https'.
          *
          * @param scheme to use in the Web Auth redirect uri.
          * @return the current builder instance

--- a/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
+++ b/lib/src/main/java/com/auth0/android/lock/PasswordlessLock.java
@@ -362,7 +362,9 @@ public class PasswordlessLock {
         }
 
         /**
-         * Specify a custom Scheme for the redirect url used to send the Web Auth results. Default redirect url scheme is 'https'.
+         * Specify a custom Scheme for the redirect URL used when executing a Web Authentication flow
+         * via the Universal Login page. This has no effect on the Passwordless with Link mode.
+         * Default redirect url scheme is 'https'.
          *
          * @param scheme to use in the Web Auth redirect uri.
          * @return the current builder instance


### PR DESCRIPTION
### Changes

This aligns with what the SDK does. By setting the `autoVerify` attribute to true, and only when the scheme used is "https", upon install time, the Android OS will attempt to pull the _assetlinks_ hosted file from the Auth0 server in order to verify that the domain given in the intent-filters is owned by the developer of the android app. When this succeeds, the disambiguation dialog will not be shown, and the application will be opened directly. This only works for Android 23 and above. 

Having this attribute enabled for when the scheme is not "https" or when the android version is lower than 23, has no negative effect.

Sample logging in with Passwordless Link
![2021-04-30 at 11 32 35 - Salmon Pony](https://user-images.githubusercontent.com/3900123/116677838-f54d0f00-a9a8-11eb-884f-a17eb372bae7.gif)

Tested running the following command in the terminal
```
adb shell am start -a android.intent.action.VIEW -d "demo://lbalmaceda.auth0.com/android/com.auth0.android.lock.app/email\?code\=145604"
```

See https://github.com/auth0/Lock.Android/pull/620
