### PR TITLE
Drop Jetifier plugin usage

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,5 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.enableJetifier=true
+android.enableJetifier=false
 android.useAndroidX=true


### PR DESCRIPTION
### Changes
The plugin was meant to bring compatibility during the AndroidX migration. I've run https://github.com/plnice/can-i-drop-jetifier and the result was that this can be disabled now, as no other dependency is in conflict with that. Attached below the report:

![image](https://user-images.githubusercontent.com/3900123/117045097-6e34c980-ad0f-11eb-961c-4c63fb935819.png)

### References

Relates to #609 

### Testing

I've manually tested this change.
