### PR TITLE
Trim username and email input to avoid NPE

### DIFF
--- a/lib/src/main/java/com/auth0/android/lock/views/ChangePasswordFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ChangePasswordFormView.java
@@ -71,7 +71,7 @@ public class ChangePasswordFormView extends FormView implements TextView.OnEdito
 
     @NonNull
     private String getUsernameOrEmail() {
-        return emailInput.getText();
+        return emailInput.getText().trim();
     }
 
     @Override

--- a/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/LogInFormView.java
@@ -174,10 +174,10 @@ public class LogInFormView extends FormView implements TextView.OnEditorActionLi
         boolean usingDatabase = currentConnection == null && fallbackToDatabase;
         boolean usingOAuthEnterprise = currentConnection != null && !currentConnection.isActiveFlowEnabled();
         if (usingDatabase || usingOAuthEnterprise) {
-            return emailInput.getText();
+            return emailInput.getText().trim();
         } else {
             //Using RO: we get the Username from the "second screen".
-            return usernameInput.getText();
+            return usernameInput.getText().trim();
         }
     }
 

--- a/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/SignUpFormView.java
@@ -131,12 +131,12 @@ public class SignUpFormView extends FormView implements TextView.OnEditorActionL
 
     @Nullable
     private String getUsername() {
-        return usernameInput.getVisibility() == VISIBLE ? usernameInput.getText() : null;
+        return usernameInput.getVisibility() == VISIBLE ? usernameInput.getText().trim() : null;
     }
 
     @NonNull
     private String getEmail() {
-        return emailInput.getText();
+        return emailInput.getText().trim();
     }
 
     @NonNull


### PR DESCRIPTION
### Changes

When the form fires an event to authenticate the user, it passes the input in a DTO class (the "event"). The input was not being normalized before being passed, causing the regex checking logic to fail when whitespace was added at the beginning or end of the string.

This PR trims the email and username input before passing them to the event.

### References
See #627 

### Testing
These View classes are not unit tested. However, here's a manual test video:

https://user-images.githubusercontent.com/3900123/119700546-a3869000-be53-11eb-9d65-8101a71586df.mp4

