### PR TITLE
Add support for OOB multi-factor authentication

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# We'll let Git's auto-detection algorithm infer if a file is text. If it is,
+# enforce LF line endings regardless of OS or git configurations.
+* text=auto eol=lf
+
+# Isolate binary files in case the auto-detection algorithm fails and
+# marks them as text files (which could brick them).
+*.{png,jpg,jpeg,gif,webp,woff,woff2} binary

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,8 +46,8 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.13.2'
     implementation project(':lock')
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.3.0'
-    implementation "androidx.core:core-ktx:1.3.2"
+    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'com.google.android.material:material:1.4.0'
+    implementation "androidx.core:core-ktx:1.6.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.32'
+    ext.kotlin_version = '1.5.21'
     repositories {
         mavenCentral()
         maven {
@@ -10,7 +10,9 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        // AGP 4.2.2 breaks 'unitTestVariants' usage
+        // See: https://github.com/openid/AppAuth-Android/issues/707
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -65,20 +65,20 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.recyclerview:recyclerview:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'com.google.android.material:material:1.4.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.squareup:otto:1.3.8'
-    api 'com.auth0.android:auth0:2.2.0'
+    api 'com.auth0.android:auth0:2.4.0'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.hamcrest:hamcrest-library:1.3'
+    testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testImplementation 'org.robolectric:robolectric:4.4'
-    testImplementation 'org.mockito:mockito-core:3.6.28'
+    testImplementation 'org.mockito:mockito-core:3.7.7'
     testImplementation 'com.squareup.okhttp3:okhttp:4.9.0'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
     testImplementation 'com.squareup.okhttp3:okhttp-tls:4.9.0'
     testImplementation 'com.jayway.awaitility:awaitility:1.7.0'
-    testImplementation 'androidx.test.espresso:espresso-intents:3.3.0'
+    testImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
 }

--- a/lib/src/main/java/com/auth0/android/lock/LockActivity.java
+++ b/lib/src/main/java/com/auth0/android/lock/LockActivity.java
@@ -437,7 +437,7 @@ public class LockActivity extends AppCompatActivity implements ActivityCompat.On
             request = apiClient.login(event.getUsernameOrEmail(), event.getPassword(), connection);
         } else if (MFA_CHALLENGE_TYPE_OOB.equals(lastDatabaseLogin.getMultifactorChallengeType())) {
             // oob multi-factor authentication
-            request = apiClient.loginWithOOB(event.getMultifactorToken(), event.getMultifactorOOBCode(), null);
+            request = apiClient.loginWithOOB(event.getMultifactorToken(), event.getMultifactorOOBCode(), event.getMultifactorOTP());
         } else {
             // otp multi-factor authentication
             request = apiClient.loginWithOTP(event.getMultifactorToken(), event.getMultifactorOTP());

--- a/lib/src/main/java/com/auth0/android/lock/events/DatabaseLoginEvent.java
+++ b/lib/src/main/java/com/auth0/android/lock/events/DatabaseLoginEvent.java
@@ -31,8 +31,10 @@ import androidx.annotation.Nullable;
 public class DatabaseLoginEvent extends DatabaseEvent {
 
     private final String password;
-    private String verificationCode;
+    private String mfaOTP;
+    private String mfaOOBCode;
     private String mfaToken;
+    private String mfaChallengeType;
 
     public DatabaseLoginEvent(@NonNull String usernameOrEmail, @NonNull String password) {
         super(usernameOrEmail);
@@ -49,21 +51,39 @@ public class DatabaseLoginEvent extends DatabaseEvent {
         return password;
     }
 
-    public void setVerificationCode(@NonNull String code) {
-        this.verificationCode = code;
+    public void setMultifactorOTP(@NonNull String code) {
+        this.mfaOTP = code;
     }
 
     @Nullable
-    public String getVerificationCode() {
-        return verificationCode;
+    public String getMultifactorOTP() {
+        return mfaOTP;
     }
 
-    public void setMFAToken(@NonNull String mfaToken) {
+    public void setMultifactorOOBCode(@Nullable String code) {
+        this.mfaOOBCode = code;
+    }
+
+    @Nullable
+    public String getMultifactorOOBCode() {
+        return mfaOOBCode;
+    }
+
+    public void setMultifactorToken(@NonNull String mfaToken) {
         this.mfaToken = mfaToken;
     }
 
     @Nullable
-    public String getMFAToken() {
+    public String getMultifactorToken() {
         return mfaToken;
+    }
+
+    public void setMultifactorChallengeType(@NonNull String challengeType) {
+        this.mfaChallengeType = challengeType;
+    }
+
+    @Nullable
+    public String getMultifactorChallengeType() {
+        return mfaChallengeType;
     }
 }

--- a/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/ClassicLockView.java
@@ -29,10 +29,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
-import androidx.appcompat.app.AlertDialog;
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
 import android.util.Log;
@@ -43,6 +39,11 @@ import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
 
 import com.auth0.android.lock.InitialScreen;
 import com.auth0.android.lock.R;
@@ -334,7 +335,7 @@ public class ClassicLockView extends LinearLayout implements LockWidgetForm {
     }
 
     public void showMFACodeForm(@NonNull DatabaseLoginEvent event) {
-        MFACodeFormView form = new MFACodeFormView(this, event.getUsernameOrEmail(), event.getPassword(), event.getMFAToken());
+        MFACodeFormView form = new MFACodeFormView(this, event.getUsernameOrEmail(), event.getPassword(), event.getMultifactorToken(), event.getMultifactorChallengeType(), event.getMultifactorOOBCode());
         updateHeaderTitle(R.string.com_auth0_lock_title_mfa_input_code);
         addSubForm(form);
     }

--- a/lib/src/main/java/com/auth0/android/lock/views/MFACodeFormView.java
+++ b/lib/src/main/java/com/auth0/android/lock/views/MFACodeFormView.java
@@ -41,17 +41,21 @@ public class MFACodeFormView extends FormView implements TextView.OnEditorAction
     private final String usernameOrEmail;
     private final String password;
     private final String mfaToken;
+    private final String mfaChallengeType;
+    private final String mfaOOBCode;
 
     private final LockWidget lockWidget;
     private ValidatedInputView codeInput;
 
 
-    public MFACodeFormView(@NonNull LockWidget lockWidget, @Nullable String usernameOrEmail, @Nullable String password, @Nullable String mfaToken) {
+    public MFACodeFormView(@NonNull LockWidget lockWidget, @Nullable String usernameOrEmail, @Nullable String password, @Nullable String mfaToken, @Nullable String mfaChallengeType, @Nullable String mfaOOBCode) {
         super(lockWidget.getContext());
         this.lockWidget = lockWidget;
         this.usernameOrEmail = usernameOrEmail;
         this.password = password;
         this.mfaToken = mfaToken;
+        this.mfaChallengeType = mfaChallengeType;
+        this.mfaOOBCode = mfaOOBCode;
         init();
     }
 
@@ -66,8 +70,10 @@ public class MFACodeFormView extends FormView implements TextView.OnEditorAction
     @Override
     public Object getActionEvent() {
         DatabaseLoginEvent event = new DatabaseLoginEvent(usernameOrEmail, password);
-        event.setVerificationCode(getInputText());
-        event.setMFAToken(mfaToken);
+        event.setMultifactorOTP(getInputText());
+        event.setMultifactorToken(mfaToken);
+        event.setMultifactorChallengeType(mfaChallengeType);
+        event.setMultifactorOOBCode(mfaOOBCode);
         return event;
     }
 

--- a/lib/src/test/java/com/auth0/android/lock/LockActivityTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/LockActivityTest.java
@@ -27,7 +27,6 @@ import com.auth0.android.request.SignUpRequest;
 import com.auth0.android.result.Credentials;
 import com.auth0.android.result.DatabaseUser;
 
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,7 +34,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.hamcrest.MockitoHamcrest;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
@@ -43,15 +41,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.anything;
-import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -173,7 +167,7 @@ public class LockActivityTest {
     @Test
     public void shouldCallLegacyDatabaseLoginWithVerificationCode() {
         DatabaseLoginEvent event = new DatabaseLoginEvent("username", "password");
-        event.setVerificationCode("123456");
+        event.setMultifactorOTP("123456");
         activity.onDatabaseAuthenticationRequest(event);
 
 
@@ -204,8 +198,8 @@ public class LockActivityTest {
         LockActivity activity = new LockActivity(configuration, options, lockView, webProvider);
 
         DatabaseLoginEvent event = new DatabaseLoginEvent("username", "password");
-        event.setVerificationCode("123456");
-        event.setMFAToken("mfaToken");
+        event.setMultifactorOTP("123456");
+        event.setMultifactorToken("mfaToken");
         activity.onDatabaseAuthenticationRequest(event);
 
         verify(lockView).showProgress(true);

--- a/lib/src/test/java/com/auth0/android/lock/events/DatabaseLoginEventTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/events/DatabaseLoginEventTest.java
@@ -49,7 +49,7 @@ public class DatabaseLoginEventTest {
 
     @Test
     public void shouldSetOOBCode() {
-        event.setMultifactorOTP("oob");
+        event.setMultifactorOOBCode("oob");
         assertThat(event.getMultifactorOOBCode(), is("oob"));
     }
 

--- a/lib/src/test/java/com/auth0/android/lock/events/DatabaseLoginEventTest.java
+++ b/lib/src/test/java/com/auth0/android/lock/events/DatabaseLoginEventTest.java
@@ -7,8 +7,8 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 21)
@@ -32,24 +32,46 @@ public class DatabaseLoginEventTest {
     }
 
     @Test
-    public void shouldNotHaveVerificationCode() {
-        assertThat(event.getVerificationCode(), is(nullValue()));
+    public void shouldNotHaveOTP() {
+        assertThat(event.getMultifactorOTP(), is(nullValue()));
     }
 
     @Test
-    public void shouldSetVerificationCode() {
-        event.setVerificationCode("code");
-        assertThat(event.getVerificationCode(), is("code"));
+    public void shouldSetOTP() {
+        event.setMultifactorOTP("otp");
+        assertThat(event.getMultifactorOTP(), is("otp"));
+    }
+
+    @Test
+    public void shouldNotHaveOOBCode() {
+        assertThat(event.getMultifactorOOBCode(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldSetOOBCode() {
+        event.setMultifactorOTP("oob");
+        assertThat(event.getMultifactorOOBCode(), is("oob"));
     }
 
     @Test
     public void shouldNotHaveMFAToken() {
-        assertThat(event.getMFAToken(), is(nullValue()));
+        assertThat(event.getMultifactorToken(), is(nullValue()));
     }
 
     @Test
     public void shouldSetMFAToken() {
-        event.setMFAToken("mfatoken");
-        assertThat(event.getMFAToken(), is("mfatoken"));
+        event.setMultifactorToken("mfa-challenge");
+        assertThat(event.getMultifactorToken(), is("mfa-challenge"));
+    }
+
+    @Test
+    public void shouldNotHaveMFAChallengeType() {
+        assertThat(event.getMultifactorChallengeType(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldSetMFAChallengeType() {
+        event.setMultifactorChallengeType("mfa-challenge");
+        assertThat(event.getMultifactorChallengeType(), is("mfa-challenge"));
     }
 }


### PR DESCRIPTION
### Changes

Whenever an `mfa_required` error is received from the server, and before showing the "MFA prompt" screen, the SDK will attempt to send an MFA challenge request to the registered OOB factor. If the user doesn't have any, the request will fail but the user will still be able to complete the authentication using the OTP generated from their favorite app.

This PR also bumps the dependencies and commits the line-endings setting so every IDE will pick up.
 
### References

See `SDK-2658`.

Videos showing the usage

#### MFA with SMS (OOB)
https://user-images.githubusercontent.com/3900123/126327983-2d55c47b-b4ec-4aa0-ac0b-e42c8397e0de.mp4

#### MFA with OTP (fallback, always available)
https://user-images.githubusercontent.com/3900123/126328104-f9d842fb-b5a1-433d-9422-cb925984622e.mp4

### Testing

Some tests regarding legacy use cases, those related to `/oauth/ro` MFA, were removed. Functionality is unaffected.

- [x] This change adds unit test coverage

- [ ] This change adds integration/UI test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors

- [x] The correct base branch is being used
