### PR TITLE
Bump GSON dependency to 2.8.9

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'com.google.android.material:material:1.4.0'
-    implementation 'com.google.code.gson:gson:2.8.7'
+    implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.squareup:otto:1.3.8'
     api 'com.auth0.android:auth0:2.5.0'
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
This change bumps [the GSON dependency to 2.8.9](https://github.com/google/gson/releases/tag/gson-parent-2.8.9) to resolve a potential vulnerability in earlier versions of the library reported: https://app.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327
