### PR TITLE
Security: Bump Kotlin Stdlib to 1.6.20 to address CVE-2022-24329

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     environment:
       JVM_OPTS: -Xmx3200m
     docker:
-      - image: circleci/android:api-28
+      - image: cimg/android:2022.03.1
 
     steps:
     - checkout

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.5.21'
+    ext.kotlin_version = '1.6.20'
     repositories {
         mavenCentral()
         maven {


### PR DESCRIPTION
This PR:
- Bumps the Kotlin version to 1.6.20 (up from 1.5.10) to address [CVE-2022-24329](https://nvd.nist.gov/vuln/detail/CVE-2022-24329)¹
- Updates the CircleCI docker image to a supported format, as CircleCI is [preparing to retire](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) the image type previously referenced.

Notes:
¹ We should consider holding off cutting a release with this change until OkHttp release's 4.10 which will also bump to Kotlin 1.6.20 to address this CVE, or we will still appear as vulnerable to security scanners by inheritance.

Related PRs:
- https://github.com/auth0/Auth0.Android/pull/552