### PR TITLE
Fix github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,39 +1,39 @@
 ---
-  name: Feature request
-  about: Suggest an idea or a feature for this project
-  title: ''
-  labels: feature request
-  assignees: ''
-  ---
-  
-  <!--
-  **Please do not report security vulnerabilities here**. The Responsible Disclosure Program (https://auth0.com/whitehat) details the procedure for disclosing security issues.
-  
-  Thank you in advance for helping us to improve this library! Your attention to detail here is greatly appreciated and will help us respond as quickly as possible. For general support or usage questions, use the Auth0 Community (https://community.auth0.com/) or Auth0 Support (https://support.auth0.com/). Finally, to avoid duplicates, please search existing Issues before submitting one here.
-  
-  By submitting an Issue to this repository, you agree to the terms within the Auth0 Code of Conduct (https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
-  -->
-  
-  ### Describe the problem you'd like to have solved
-  
-  <!--
-  > A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
-  -->
-  
-  ### Describe the ideal solution
-  
-  <!--
-  > A clear and concise description of what you want to happen.
-  -->
-  
-  ## Alternatives and current work-arounds
-  
-  <!--
-  > A clear and concise description of any alternatives you've considered or any work-arounds that are currently in place.
-  -->
-  
-  ### Additional information, if any
-  
-  <!--
-  > Add any other context or screenshots about the feature request here.
-  -->
+name: Feature request
+about: Suggest an idea or a feature for this project
+title: ''
+labels: feature request
+assignees: ''
+---
+
+<!--
+**Please do not report security vulnerabilities here**. The Responsible Disclosure Program (https://auth0.com/whitehat) details the procedure for disclosing security issues.
+
+Thank you in advance for helping us to improve this library! Your attention to detail here is greatly appreciated and will help us respond as quickly as possible. For general support or usage questions, use the Auth0 Community (https://community.auth0.com/) or Auth0 Support (https://support.auth0.com/). Finally, to avoid duplicates, please search existing Issues before submitting one here.
+
+By submitting an Issue to this repository, you agree to the terms within the Auth0 Code of Conduct (https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
+-->
+
+### Describe the problem you'd like to have solved
+
+<!--
+> A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+-->
+
+### Describe the ideal solution
+
+<!--
+> A clear and concise description of what you want to happen.
+-->
+
+## Alternatives and current work-arounds
+
+<!--
+> A clear and concise description of any alternatives you've considered or any work-arounds that are currently in place.
+-->
+
+### Additional information, if any
+
+<!--
+> Add any other context or screenshots about the feature request here.
+-->

--- a/.github/ISSUE_TEMPLATE/report_a_bug.md
+++ b/.github/ISSUE_TEMPLATE/report_a_bug.md
@@ -1,55 +1,55 @@
 ---
-  name: Report a bug
-  about: Have you found a bug or issue? Create a bug report for this SDK
-  title: ''
-  labels: bug report
-  assignees: ''
-  ---
-  
-  <!--
-  **Please do not report security vulnerabilities here**. The Responsible Disclosure Program (https://auth0.com/whitehat) details the procedure for disclosing security issues.
-  
-  Thank you in advance for helping us to improve this library! Please read through the template below and answer all relevant questions. Your additional work here is greatly appreciated and will help us respond as quickly as possible. For general support or usage questions, use the Auth0 Community (https://community.auth0.com/) or Auth0 Support (https://support.auth0.com/). Finally, to avoid duplicates, please search existing Issues before submitting one here.
-  
-  By submitting an Issue to this repository, you agree to the terms within the Auth0 Code of Conduct (https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
-  -->
-  
-  ### Describe the problem
-  
-  <!--
-  > Provide a clear and concise description of the issue
-  -->
-  
-  ### What was the expected behavior?
-  
-  <!--
-  > Tell us about the behavior you expected to see
-  -->
-  
-  ### Reproduction
-  <!--
-  > Detail the steps taken to reproduce this error, and whether this issue can be reproduced consistently or if it is intermittent.
-  > **Note**: If clear, reproducable steps or the smallest sample app demonstrating misbehavior cannot be provided, we may not be able to follow up on this bug report.
-  
-  > Where possible, please include:
-  >
-  > - The smallest possible sample app that reproduces the undesirable behavior
-  > - Log files (redact/remove sensitive information)
-  > - Application settings (redact/remove sensitive information)
-  > - Screenshots
-  -->
-  
-  - Step 1..
-  - Step 2..
-  - ...
-  
-  ### Environment
-  
-  <!--
-  > Please provide the following:
-  -->
-  
-  - **Version of this library used:**
-  - **Which framework are you using, if applicable:**
-  - **Other modules/plugins/libraries that might be involved:**
-  - **Any other relevant information you think would be useful:**
+name: Report a bug
+about: Have you found a bug or issue? Create a bug report for this SDK
+title: ''
+labels: bug report
+assignees: ''
+---
+
+<!--
+**Please do not report security vulnerabilities here**. The Responsible Disclosure Program (https://auth0.com/whitehat) details the procedure for disclosing security issues.
+
+Thank you in advance for helping us to improve this library! Please read through the template below and answer all relevant questions. Your additional work here is greatly appreciated and will help us respond as quickly as possible. For general support or usage questions, use the Auth0 Community (https://community.auth0.com/) or Auth0 Support (https://support.auth0.com/). Finally, to avoid duplicates, please search existing Issues before submitting one here.
+
+By submitting an Issue to this repository, you agree to the terms within the Auth0 Code of Conduct (https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
+-->
+
+### Describe the problem
+
+<!--
+> Provide a clear and concise description of the issue
+-->
+
+### What was the expected behavior?
+
+<!--
+> Tell us about the behavior you expected to see
+-->
+
+### Reproduction
+<!--
+> Detail the steps taken to reproduce this error, and whether this issue can be reproduced consistently or if it is intermittent.
+> **Note**: If clear, reproducable steps or the smallest sample app demonstrating misbehavior cannot be provided, we may not be able to follow up on this bug report.
+
+> Where possible, please include:
+>
+> - The smallest possible sample app that reproduces the undesirable behavior
+> - Log files (redact/remove sensitive information)
+> - Application settings (redact/remove sensitive information)
+> - Screenshots
+-->
+
+- Step 1..
+- Step 2..
+- ...
+
+### Environment
+
+<!--
+> Please provide the following:
+-->
+
+- **Version of this library used:**
+- **Which framework are you using, if applicable:**
+- **Other modules/plugins/libraries that might be involved:**
+- **Any other relevant information you think would be useful:**


### PR DESCRIPTION
### Changes

The markdown file is not formatted properly for the Github issue template to work. We have fixed it in this PR.

